### PR TITLE
[codex] Avoid stale update manifests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "docs/**"
       - "zensical.toml"
-      - "package.json"
       - "hack/write-latest-manifest.mjs"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
@@ -37,9 +36,53 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
+      - name: Check release state
+        id: release-state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          latest_tag="$(gh release view --repo "$GH_REPO" --json tagName --jq '.tagName' 2>/dev/null || true)"
+
+          if [ -z "$latest_tag" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "No latest release exists; deploying docs without an update manifest."
+            exit 0
+          fi
+
+          if node - "$package_version" "$latest_tag" <<'NODE'
+          const [, , packageVersion, latestTag] = process.argv;
+
+          function parts(version) {
+            const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(version.trim());
+            if (!match) return undefined;
+            return [Number(match[1]), Number(match[2] ?? 0), Number(match[3] ?? 0)];
+          }
+
+          const next = parts(packageVersion);
+          const latest = parts(latestTag);
+          if (!next || !latest) process.exit(1);
+
+          for (let i = 0; i < next.length; i += 1) {
+            if (next[i] > latest[i]) process.exit(0);
+            if (next[i] < latest[i]) process.exit(1);
+          }
+          process.exit(1);
+          NODE
+          then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping Pages deploy: package.json is $package_version but the latest release is $latest_tag."
+          else
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "Deploying docs with update manifest from $latest_tag."
+          fi
       - run: pip install zensical
+        if: steps.release-state.outputs.deploy == 'true'
       - run: zensical build --clean --strict
+        if: steps.release-state.outputs.deploy == 'true'
       - name: Write update manifest
+        if: steps.release-state.outputs.deploy == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -51,7 +94,9 @@ jobs:
             rm -f site/latest.json
           fi
       - uses: actions/upload-pages-artifact@v5
+        if: steps.release-state.outputs.deploy == 'true'
         with:
           path: site
       - uses: actions/deploy-pages@v5
+        if: steps.release-state.outputs.deploy == 'true'
         id: deployment


### PR DESCRIPTION
## Summary

- Prevent the Docs workflow from deploying Pages when `package.json` is ahead of the latest published GitHub release.
- Stop root `package.json` changes from triggering a Docs deployment on release-prep commits.
- Keep Docs deployments active once the GitHub latest release has caught up, so `latest.json` is written from current release metadata.

## Root Cause

The release-prep merge for `0.2.2` triggered the Docs workflow before the `v0.2.2` GitHub release existed. That deployed `latest.json` for `0.2.1`. The later release workflow generated `latest.json` for `0.2.2`, but the Pages deployment used the same commit SHA, leaving the public update manifest stale.

## Validation

- `git diff --check`
- Parsed `.github/workflows/docs.yml` with PyYAML
- Tested the version comparison guard locally for equal and ahead versions

After merge, the Docs workflow should run from this workflow-file change and redeploy `latest.json` from the current latest release, `v0.2.2`.