### PR TITLE
Fix dropped auth headers on raw requests, explain credential failures

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/settings/AddClusterDialog.tsx
+++ b/client/src/components/settings/AddClusterDialog.tsx
@@ -256,6 +256,11 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
             {result.backupPath && ` Backup: ${result.backupPath}`}
           </Alert>
         )}
+        {(result?.warnings ?? []).map((w) => (
+          <Alert key={w} severity="warning">
+            {w}
+          </Alert>
+        ))}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={busy}>

--- a/client/src/components/settings/EditClusterDialog.tsx
+++ b/client/src/components/settings/EditClusterDialog.tsx
@@ -207,6 +207,11 @@ export function EditClusterDialog({ context: c, onClose }: { context: ContextInf
             <MenuItem value="client-cert">Replace with client certificate</MenuItem>
           </Select>
         </FormControl>
+        {form.auth === 'keep' && c.authWarning && (
+          <Alert severity="warning" sx={{ py: 0 }}>
+            {c.authWarning}
+          </Alert>
+        )}
         {form.auth === 'token' && <TextField label="Token" size="small" value={form.token} onChange={(e) => set('token', e.target.value)} />}
         {form.auth === 'client-cert' && (
           <>

--- a/client/src/components/settings/SettingsDialog.tsx
+++ b/client/src/components/settings/SettingsDialog.tsx
@@ -65,9 +65,19 @@ function looksLikeNetworkError(msg?: string): boolean {
   );
 }
 
+/** Failures where the server was reached but the credentials are the problem. */
+function looksLikeAuthError(msg?: string): boolean {
+  if (!msg) return false;
+  return /\b401\b|\b403\b|Unauthorized|Forbidden|credential plugin|auth-provider/i.test(msg);
+}
+
 function ClusterRow({ c, isProtected, onToggleProtected }: { c: ContextInfo; isProtected: boolean; onToggleProtected: () => void }) {
   const [editOpen, setEditOpen] = useState(false);
-  const networkHint = c.health === 'error' && looksLikeNetworkError(c.healthMessage);
+  // One hint at a time, most actionable first: a proactive credential warning
+  // (plugin missing, legacy stanza), then the probe's auth failure, then the
+  // "maybe it needs a tunnel" nudge.
+  const authHint = c.authWarning ?? (c.health === 'error' && looksLikeAuthError(c.healthMessage) ? c.healthMessage : undefined);
+  const networkHint = !authHint && c.health === 'error' && looksLikeNetworkError(c.healthMessage);
 
   return (
     <Box sx={{ borderBottom: 1, borderColor: 'divider', py: 0.25 }}>
@@ -105,6 +115,11 @@ function ClusterRow({ c, isProtected, onToggleProtected }: { c: ContextInfo; isP
           slotProps={{ secondary: { sx: { fontSize: 12 } } }}
         />
       </ListItem>
+      {authHint && (
+        <Alert severity="warning" sx={{ py: 0, mb: 0.5 }}>
+          {authHint}
+        </Alert>
+      )}
       {networkHint && (
         <Alert severity="warning" sx={{ py: 0, mb: 0.5 }}>
           Can&apos;t reach the API server. Only reachable through a bastion or proxy?{' '}

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -23,7 +23,9 @@ everything degrades gracefully without them.
 ### Does it work with my managed cluster (EKS / GKE / AKS / k3s / …)?
 
 If `kubectl` can talk to it, so can Kubus — it uses the same kubeconfig and credential
-plugins.
+plugins. Getting a 401 or 403 from a cloud cluster? That's almost always the credential
+plugin or the cloud login, not Kubus — see
+[Cloud-managed clusters](../guide/clusters.md#cloud-managed-clusters-gke-eks-aks).
 
 ### Will it show my CustomResourceDefinitions?
 

--- a/docs/guide/clusters.md
+++ b/docs/guide/clusters.md
@@ -70,6 +70,49 @@ Open **Settings → Clusters** to manage the entries in your kubeconfig:
 Every change is written straight to your kubeconfig file (with a `.kubus.bak` backup), so
 `kubectl` and other tools see the same settings.
 
+## Cloud-managed clusters (GKE, EKS, AKS)
+
+Managed clusters work out of the box — with one thing to understand: the kubeconfig that
+`gcloud container clusters get-credentials`, `aws eks update-kubeconfig` or
+`az aks get-credentials` writes contains **no credentials at all**. It only names a
+*credential plugin* (`gke-gcloud-auth-plugin`, `aws`, `kubelogin`) that is run to mint a
+short-lived token for every connection — by `kubectl` and by Kubus alike.
+
+That means two things must be true **on the machine where the Kubus server runs**:
+
+1. **The plugin is installed and on `PATH`.**
+
+    | Provider | Plugin | Install |
+    | --- | --- | --- |
+    | GKE | `gke-gcloud-auth-plugin` | `gcloud components install gke-gcloud-auth-plugin` |
+    | EKS | `aws` | AWS CLI v2 |
+    | AKS | `kubelogin` | `az aks install-cli` |
+
+2. **The cloud CLI behind it is logged in** (`gcloud auth login`, `aws sso login`,
+   `az login`) as an identity that may access the cluster.
+
+If either is missing, Kubus tells you — the cluster's row in **Settings → Clusters**, the
+**Edit** dialog and **Test connection** all show what's wrong and how to fix it.
+
+A few pitfalls worth knowing:
+
+- **Restart Kubus after installing a plugin.** A running app keeps the `PATH` it started
+  with, so a freshly installed plugin isn't visible until relaunch.
+- **Kubus running elsewhere?** In a container, on a server, or under WSL, copying the
+  kubeconfig is not enough — the plugin and a logged-in CLI must exist in *that*
+  environment too. Alternatively, switch the entry to a self-contained credential (a
+  Kubernetes ServiceAccount token).
+- **Don't paste short-lived tokens.** A token from `gcloud auth print-access-token` (or
+  `kubectl create token`) dies within about an hour and you're back to 401s. Prefer the
+  plugin-based kubeconfig, or a ServiceAccount token you control.
+- **401 vs 403**: a **401** means the credentials were rejected (expired token, logged-out
+  CLI); a **403** means you authenticated fine but the identity lacks permission — Kubus
+  shows *which* identity the cluster resolved, so you can fix RBAC or cloud IAM for it.
+- **Old kubeconfig entries** with an `auth-provider: gcp`/`azure` block predate the
+  plugins (kubectl dropped them in v1.26) and rely on a cached token that expires after
+  an hour. Kubus flags these — re-run the provider's `get-credentials` command with a
+  current CLI to regenerate them.
+
 ## Reaching clusters behind a proxy or bastion
 
 If a cluster's API server isn't directly reachable from your machine — only through a

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/kube/auth-diagnostics.ts
+++ b/server/src/kube/auth-diagnostics.ts
@@ -1,0 +1,259 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { User } from '@kubernetes/client-node';
+import type { ClusterAuthType } from '@kubus/shared';
+import type { RawClient } from './raw-client.js';
+
+/**
+ * Turns raw connection/auth failures into messages that say what to do next,
+ * mirroring how the SSH tunnel manager explains a missing `ssh` binary. The
+ * common case: cloud kubeconfigs (GKE/EKS/AKS) hold no credentials at all —
+ * just an exec-plugin reference — so everything here revolves around making
+ * plugin failures and 401/403 responses self-explanatory.
+ */
+
+interface ExecEntry {
+  command?: string;
+}
+
+interface AuthProviderEntry {
+  name?: string;
+  config?: { exec?: ExecEntry };
+}
+
+export function authTypeOf(user: User | null | undefined): ClusterAuthType {
+  if (!user) return 'none';
+  if (user.exec) return 'exec';
+  if (user.authProvider) return 'auth-provider';
+  if (user.certData || user.certFile) return 'client-cert';
+  if (user.token) return 'token';
+  if (user.username) return 'basic';
+  return 'none';
+}
+
+export function execCommandOf(user: User | null | undefined): string | null {
+  const exec = (user?.exec ?? (user?.authProvider as AuthProviderEntry | undefined)?.config?.exec) as ExecEntry | undefined;
+  return exec?.command ?? null;
+}
+
+function authProviderNameOf(user: User | null | undefined): string | null {
+  return (user?.authProvider as AuthProviderEntry | undefined)?.name ?? null;
+}
+
+/** "gke-gcloud-auth-plugin" from "/usr/lib/.../gke-gcloud-auth-plugin.exe". */
+function pluginBaseName(command: string): string {
+  return (command.split(/[\\/]/).pop() ?? command).replace(/\.exe$/i, '');
+}
+
+const PLUGIN_INSTALL_HINTS: Record<string, string> = {
+  'gke-gcloud-auth-plugin': 'Install it with "gcloud components install gke-gcloud-auth-plugin" (or the google-cloud-cli-gke-gcloud-auth-plugin OS package)',
+  aws: 'Install the AWS CLI v2',
+  'aws-iam-authenticator': 'Install aws-iam-authenticator (https://github.com/kubernetes-sigs/aws-iam-authenticator)',
+  kubelogin: 'Install it with "az aks install-cli"',
+  doctl: 'Install the DigitalOcean CLI (doctl)',
+  oci: 'Install the Oracle Cloud CLI (oci)',
+};
+
+const PLUGIN_RELOGIN_HINTS: Record<string, string> = {
+  'gke-gcloud-auth-plugin': 'Run "gcloud auth login" and check the active account with "gcloud auth list"',
+  aws: 'Refresh your AWS credentials (e.g. "aws sso login")',
+  'aws-iam-authenticator': 'Refresh your AWS credentials',
+  kubelogin: 'Run "az login"',
+};
+
+export function pluginMissingMessage(command: string): string {
+  const base = pluginBaseName(command);
+  const hint = PLUGIN_INSTALL_HINTS[base] ?? `Install "${base}"`;
+  return (
+    `Credential plugin "${command}" was not found on PATH — this kubeconfig entry holds no credentials itself; the plugin mints a token for every connection. ` +
+    `${hint} on the machine where the Kubus server runs, then restart Kubus so it picks up the new PATH.`
+  );
+}
+
+export function legacyAuthProviderWarning(provider: string): string | undefined {
+  if (provider === 'gcp') {
+    return (
+      'This kubeconfig entry uses the legacy "gcp" auth-provider, which kubectl removed in v1.26 — it relies on a cached access token that expires after about an hour. ' +
+      'Regenerate the entry with "gcloud container clusters get-credentials" using a current gcloud (it writes a gke-gcloud-auth-plugin exec entry instead).'
+    );
+  }
+  if (provider === 'azure') {
+    return (
+      'This kubeconfig entry uses the legacy "azure" auth-provider, which kubectl removed in v1.26. ' +
+      'Regenerate the entry with "az aks get-credentials" using a current Azure CLI (it writes a kubelogin exec entry instead).'
+    );
+  }
+  return undefined;
+}
+
+function canExecute(p: string): boolean {
+  try {
+    // Windows has no meaningful X bit; existence is the best signal there.
+    fs.accessSync(p, process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK);
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function findOnPath(command: string): boolean {
+  if (path.isAbsolute(command) || command.includes('/') || (process.platform === 'win32' && command.includes('\\'))) {
+    return canExecute(command);
+  }
+  const dirs = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  let names = [command];
+  if (process.platform === 'win32') {
+    const exts = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean);
+    if (!exts.some((e) => command.toLowerCase().endsWith(e.toLowerCase()))) {
+      names = [command, ...exts.map((e) => command + e)];
+    }
+  }
+  return dirs.some((dir) => names.some((name) => canExecute(path.join(dir, name))));
+}
+
+/**
+ * PATH lookups are cheap but listContexts runs often; a short TTL also means
+ * "install the plugin" is noticed without restarting the server.
+ */
+const pathLookupCache = new Map<string, { found: boolean; at: number }>();
+const PATH_LOOKUP_TTL_MS = 15_000;
+
+export function isCommandOnPath(command: string): boolean {
+  const cached = pathLookupCache.get(command);
+  if (cached && Date.now() - cached.at < PATH_LOOKUP_TTL_MS) return cached.found;
+  const found = findOnPath(command);
+  pathLookupCache.set(command, { found, at: Date.now() });
+  return found;
+}
+
+/**
+ * Proactive warning for a kubeconfig user entry: exec plugin missing from
+ * PATH, or a legacy auth-provider that modern tooling no longer refreshes.
+ */
+export function authWarningForUser(user: User | null | undefined): string | undefined {
+  const provider = authProviderNameOf(user);
+  if (provider) {
+    const legacy = legacyAuthProviderWarning(provider);
+    if (legacy) return legacy;
+  }
+  const command = execCommandOf(user);
+  if (command && !isCommandOnPath(command)) return pluginMissingMessage(command);
+  return undefined;
+}
+
+/** The clean API server message of an ApiException, without the "HTTP-Code: …" wrapper. */
+function apiDetailOf(err: unknown): string {
+  const body = (err as { body?: unknown }).body;
+  if (body && typeof body === 'object' && 'message' in body) return String((body as { message: unknown }).message);
+  if (err instanceof Error) {
+    return /\nMessage: ([^\n]*)/.exec(err.message)?.[1] ?? err.message;
+  }
+  return '';
+}
+
+/** Numeric HTTP status of an ApiException-shaped error, if any. */
+export function statusCodeOf(err: unknown): number | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'number') return code;
+  const statusCode = (err as { statusCode?: unknown }).statusCode;
+  if (typeof statusCode === 'number') return statusCode;
+  return undefined;
+}
+
+/** "user "x" (groups: a, b)" via SelfSubjectReview, or null if unavailable. */
+export async function whoAmI(raw: RawClient, timeoutMs = 4_000): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref();
+  try {
+    const res = await raw.json<{ status?: { userInfo?: { username?: string; groups?: string[] } } }>('/apis/authentication.k8s.io/v1/selfsubjectreviews', {
+      method: 'POST',
+      body: JSON.stringify({ apiVersion: 'authentication.k8s.io/v1', kind: 'SelfSubjectReview' }),
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+    });
+    const info = res.status?.userInfo;
+    if (!info?.username) return null;
+    const groups = (info.groups ?? []).filter((g) => g !== 'system:authenticated');
+    if (!groups.length) return `user "${info.username}"`;
+    const shown = groups.slice(0, 4).join(', ');
+    return `user "${info.username}" (groups: ${shown}${groups.length > 4 ? ', …' : ''})`;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function describe401(user: User | null | undefined, authType: ClusterAuthType): string {
+  const base = 'The cluster rejected the credentials (401 Unauthorized).';
+  const command = execCommandOf(user);
+  if (command) {
+    const relogin = PLUGIN_RELOGIN_HINTS[pluginBaseName(command)] ?? 'Re-authenticate with the cloud CLI that backs the plugin';
+    return `${base} The token minted by credential plugin "${pluginBaseName(command)}" was not accepted — the cloud session behind it may have expired. ${relogin}, on the machine where the Kubus server runs.`;
+  }
+  const legacy = legacyAuthProviderWarning(authProviderNameOf(user) ?? '');
+  if (legacy) return `${base} ${legacy}`;
+  switch (authType) {
+    case 'token':
+      return `${base} The kubeconfig's bearer token was rejected — static tokens from cloud CLIs (e.g. "gcloud auth print-access-token" or "kubectl create token") expire quickly. Paste a fresh one, or switch the entry to the provider's exec plugin or a long-lived ServiceAccount token.`;
+    case 'client-cert':
+      return `${base} The client TLS credentials were rejected — the cert may have expired or its CA is no longer trusted by the cluster.`;
+    case 'none':
+      return `${base} This kubeconfig entry has no credentials at all, so the request was anonymous. Cloud clusters (GKE/EKS/AKS) authenticate via an exec plugin — regenerate the entry with the provider's CLI.`;
+    default:
+      return base;
+  }
+}
+
+/** True when the error most plausibly came from spawning the exec plugin, not from the network. */
+function looksLikeExecFailure(err: Error): boolean {
+  if (statusCodeOf(err) !== undefined) return false;
+  if (err.name === 'AbortError') return false;
+  // node-fetch and TLS/socket errors carry a string `code` (ECONNREFUSED,
+  // DEPTH_ZERO_SELF_SIGNED_CERT, …) or a `type`; exec_auth rejects with bare
+  // Errors (plugin stderr) or SyntaxError (non-JSON plugin output).
+  if ('type' in err || typeof (err as { code?: unknown }).code === 'string') return false;
+  return err.name === 'Error' || err.name === 'SyntaxError';
+}
+
+const MAX_DETAIL_CHARS = 400;
+
+function clip(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length > MAX_DETAIL_CHARS ? `${trimmed.slice(0, MAX_DETAIL_CHARS)}…` : trimmed;
+}
+
+/**
+ * The health/test-connection error text shown to the user. Never empty:
+ * exec plugins that die silently and errors without a message get a
+ * descriptive fallback instead of a blank alert.
+ */
+export async function describeProbeFailure(err: unknown, user: User | null | undefined, raw?: RawClient): Promise<string> {
+  const status = statusCodeOf(err);
+  if (status === 401) return describe401(user, authTypeOf(user));
+  if (status === 403) {
+    const detail = clip(apiDetailOf(err));
+    let message = `Authenticated, but not authorized (403 Forbidden)${detail ? `: ${detail}` : '.'}`;
+    const identity = raw ? await whoAmI(raw) : null;
+    if (identity) message += ` The cluster resolved the credentials to ${identity} — grant that identity the needed RBAC (and cloud IAM) permissions.`;
+    else message += ' Check the RBAC (and cloud IAM) permissions of the identity Kubus authenticates as.';
+    return message;
+  }
+  if (err instanceof Error) {
+    const command = execCommandOf(user);
+    if (command) {
+      const syscall = (err as NodeJS.ErrnoException).syscall;
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT' && (!syscall || syscall.startsWith('spawn'))) {
+        return pluginMissingMessage(command);
+      }
+      if (looksLikeExecFailure(err)) {
+        const detail = clip(err.message);
+        return detail ? `Credential plugin "${pluginBaseName(command)}" failed: ${detail}` : `Credential plugin "${pluginBaseName(command)}" failed without printing an error message.`;
+      }
+    }
+    return clip(err.message) || `connection failed (${err.name || 'no error message'})`;
+  }
+  return clip(String(err)) || 'connection failed (no error message)';
+}

--- a/server/src/kube/auth-diagnostics.ts
+++ b/server/src/kube/auth-diagnostics.ts
@@ -235,8 +235,20 @@ export async function describeProbeFailure(err: unknown, user: User | null | und
   if (status === 401) return describe401(user, authTypeOf(user));
   if (status === 403) {
     const detail = clip(apiDetailOf(err));
-    let message = `Authenticated, but not authorized (403 Forbidden)${detail ? `: ${detail}` : '.'}`;
+    // A 403 doesn't guarantee real credentials: entries without any, on an
+    // apiserver that allows anonymous requests, are denied as
+    // system:anonymous — the fix is the kubeconfig, not RBAC for anonymous.
+    if (authTypeOf(user) === 'none') {
+      return (
+        `The cluster denied the request (403 Forbidden)${detail ? `: ${detail}` : '.'} ` +
+        `This kubeconfig entry has no credentials, so the request was anonymous. Cloud clusters (GKE/EKS/AKS) authenticate via an exec plugin — regenerate the entry with the provider's CLI.`
+      );
+    }
     const identity = raw ? await whoAmI(raw) : null;
+    if (identity?.includes('"system:anonymous"')) {
+      return `The cluster denied the request (403 Forbidden)${detail ? `: ${detail}` : '.'} The request was treated as anonymous (system:anonymous) — the credentials were not applied at all; check this kubeconfig entry.`;
+    }
+    let message = `Authenticated, but not authorized (403 Forbidden)${detail ? `: ${detail}` : '.'}`;
     if (identity) message += ` The cluster resolved the credentials to ${identity} — grant that identity the needed RBAC (and cloud IAM) permissions.`;
     else message += ' Check the RBAC (and cloud IAM) permissions of the identity Kubus authenticates as.';
     return message;

--- a/server/src/kube/cluster-manager.ts
+++ b/server/src/kube/cluster-manager.ts
@@ -13,7 +13,6 @@ import {
   Log,
   Metrics,
   PortForward,
-  VersionApi,
   type ApiConstructor,
   type ApiType,
 } from '@kubernetes/client-node';
@@ -25,26 +24,16 @@ import { MetricsPoller } from './metrics-poller.js';
 import { ResourceSearchIndex } from './search-index.js';
 import { applyEnvProxy, applyProxyRuntimeCompatibility, overrideClusterProxyUrl } from './connection.js';
 import { patchClusterEntry, patchUserEntry, writeKubeconfig, type ClusterEditPatch } from './kubeconfig-file.js';
+import { authTypeOf, authWarningForUser, describeProbeFailure } from './auth-diagnostics.js';
 import { HttpProblem } from '../util/errors.js';
 import type { SshTunnelManager } from '../ssh/tunnel-manager.js';
 import { isValidSshDestination } from '../ssh/tunnel-manager.js';
-import type { ClusterAuthType } from '@kubus/shared';
 
 const BACKGROUND_HEALTH_INTERVAL_MS = 60_000;
 const BACKGROUND_HEALTH_TIMEOUT_MS = 8_000;
 const BACKGROUND_HEALTH_CONCURRENCY = 4;
 
 type CachedContextHealth = Pick<ContextInfo, 'health' | 'healthMessage' | 'kubernetesVersion'>;
-
-function authTypeOf(user: ReturnType<KubeConfig['getUser']>): ClusterAuthType {
-  if (!user) return 'none';
-  if (user.exec) return 'exec';
-  if (user.authProvider) return 'auth-provider';
-  if (user.certData || user.certFile) return 'client-cert';
-  if (user.token) return 'token';
-  if (user.username) return 'basic';
-  return 'none';
-}
 
 /** Everything the server holds for one connected kubeconfig context. */
 export class ClusterHandle {
@@ -122,13 +111,13 @@ export class ClusterHandle {
 
   async probe(): Promise<void> {
     try {
-      const info = await this.client(VersionApi).getCode();
+      const info = await this.raw.json<{ gitVersion?: string }>('/version');
       this.kubernetesVersion = info.gitVersion;
       this.health = 'connected';
       this.healthMessage = undefined;
     } catch (err) {
       this.health = 'error';
-      this.healthMessage = err instanceof Error ? err.message : String(err);
+      this.healthMessage = await describeProbeFailure(err, this.kc.getCurrentUser(), this.raw);
     }
   }
 
@@ -342,6 +331,7 @@ export class ClusterManager extends EventEmitter {
         skipTlsVerify: cluster?.skipTLSVerify || undefined,
         caPresent: !!(cluster?.caData || cluster?.caFile) || undefined,
         authType: authTypeOf(user),
+        authWarning: authWarningForUser(user),
       };
     });
   }
@@ -401,11 +391,13 @@ export class ClusterManager extends EventEmitter {
   }
 
   private async probeContext(contextName: string, timeoutMs: number): Promise<TestConnectionResponse> {
+    const userName = this.kc.getContexts().find((c) => c.name === contextName)?.user;
+    const user = userName ? this.kc.getUser(userName) : null;
     let raw: RawClient;
     try {
       raw = await this.probeClient(contextName);
     } catch (err) {
-      return { health: 'error', healthMessage: err instanceof Error ? err.message : String(err) };
+      return { health: 'error', healthMessage: await describeProbeFailure(err, user) };
     }
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -414,7 +406,7 @@ export class ClusterManager extends EventEmitter {
       const info = await raw.json<{ gitVersion?: string }>('/version', { signal: controller.signal });
       return { health: 'connected', kubernetesVersion: info.gitVersion };
     } catch (err) {
-      const message = err instanceof Error && err.name === 'AbortError' ? `timed out after ${timeoutMs / 1000}s` : err instanceof Error ? err.message : String(err);
+      const message = err instanceof Error && err.name === 'AbortError' ? `timed out after ${timeoutMs / 1000}s` : await describeProbeFailure(err, user, raw);
       return { health: 'error', healthMessage: message };
     } finally {
       clearTimeout(timeout);

--- a/server/src/kube/raw-client.ts
+++ b/server/src/kube/raw-client.ts
@@ -67,8 +67,19 @@ export class RawClient {
     requestInit.method = init?.method ?? 'GET';
     if (init?.body !== undefined) requestInit.body = init.body;
     if (init?.signal) requestInit.signal = init.signal;
-    const headers = requestInit.headers as Record<string, string> | undefined;
-    requestInit.headers = { ...(headers ?? {}), ...(init?.headers ?? {}) };
+    // applyToFetchOptions returns a Headers instance; spreading one yields {}
+    // and silently drops Authorization — token/exec clusters then probe as
+    // anonymous and fail with 401/403. Copy entries explicitly instead.
+    const baseHeaders: Record<string, string> = {};
+    const applied = requestInit.headers as unknown;
+    if (applied && typeof (applied as Headers).forEach === 'function') {
+      (applied as Headers).forEach((value, key) => {
+        baseHeaders[key] = value;
+      });
+    } else if (applied) {
+      Object.assign(baseHeaders, applied as Record<string, string>);
+    }
+    requestInit.headers = { ...baseHeaders, ...(init?.headers ?? {}) };
     return fetch(this.serverUrl() + path, requestInit);
   }
 

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -8,6 +8,24 @@ import type { KubeconfigImportResponse, KubeconfigSettings } from '@kubus/shared
 import type { AppContext } from '../app.js';
 import { HttpProblem, sendError } from '../util/errors.js';
 import { mergeKubeconfig, writeKubeconfig } from '../kube/kubeconfig-file.js';
+import { authWarningForUser } from '../kube/auth-diagnostics.js';
+
+/** Credential problems (missing exec plugin, legacy auth-provider) in the users an import brings in. */
+function importAuthWarnings(incomingYaml: string, addedUsers: string[]): string[] {
+  if (!addedUsers.length) return [];
+  const kc = new KubeConfig();
+  try {
+    kc.loadFromString(incomingYaml);
+  } catch {
+    return [];
+  }
+  const warnings: string[] = [];
+  for (const name of addedUsers) {
+    const warning = authWarningForUser(kc.getUsers().find((u) => u.name === name));
+    if (warning) warnings.push(`user "${name}": ${warning}`);
+  }
+  return warnings;
+}
 
 const setKubeconfigSchema = z.object({ path: z.string().min(1).nullable() });
 const importSchema = z.object({ yaml: z.string().min(1), overwrite: z.boolean().optional() });
@@ -73,6 +91,7 @@ export function registerSettingsRoutes(app: FastifyInstance, ctx: AppContext): v
         skipped: result.skipped,
         backupPath,
         contexts: ctx.clusters.listContexts(),
+        warnings: importAuthWarnings(parsed.data.yaml, result.added.users),
       };
       return response;
     } catch (err) {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -50,6 +50,8 @@ export interface ContextInfo {
   caPresent?: boolean;
   /** How the context's user authenticates (informational, for the editor). */
   authType?: ClusterAuthType;
+  /** Actionable problem with the user's credentials (exec plugin missing from PATH, legacy auth-provider). */
+  authWarning?: string;
 }
 
 export type ClusterAuthType = 'token' | 'client-cert' | 'exec' | 'auth-provider' | 'basic' | 'none';
@@ -152,6 +154,8 @@ export interface KubeconfigImportResponse {
   backupPath: string | null;
   /** Fresh context list after the reload. */
   contexts: ContextInfo[];
+  /** Per-user credential problems in the imported entries (e.g. exec plugin not installed here). */
+  warnings?: string[];
 }
 
 export interface ResourceKindInfo {


### PR DESCRIPTION
## Root cause: 401/403 on GKE/EKS/AKS clusters

`RawClient.request` spread the `Headers` instance returned by `applyToFetchOptions` into a plain object — spreading a `Headers` yields `{}`, so the `Authorization` header was silently dropped from **every raw API request** (health probes, discovery, resource lists, watches).

Cert-based clusters (kind, on-prem) never noticed because client certificates authenticate at the TLS layer. Token/exec clusters — GKE, EKS, AKS — sent anonymous requests and failed with 401/403 even though `kubectl` with the same kubeconfig worked fine. Fixed by copying the Headers entries explicitly.

## Diagnostics: make credential failures self-explanatory

Following the pattern of the SSH tunnel manager's missing-`ssh` message (new `server/src/kube/auth-diagnostics.ts`):

- **Exec-plugin failures** map to actionable health messages: plugin missing from PATH (per-provider install hint + restart reminder), plugin stderr surfaced with context, and a plugin that dies silently no longer produces an empty error.
- **401** explains what was rejected per auth type: expired cloud session (with the matching re-login command), expired pasted token, anonymous entry.
- **403** runs a `SelfSubjectReview` and names the identity the cluster resolved, so RBAC/IAM can be fixed for the right principal.
- **Proactive warnings** (`ContextInfo.authWarning`): missing exec plugins and legacy `gcp`/`azure` auth-provider stanzas (removed from kubectl in v1.26) are flagged on the cluster row in Settings and in the Edit dialog.
- **Import preflight**: pasting a kubeconfig whose credential plugin isn't installed warns immediately in the Add cluster dialog.
- **Docs**: new "Cloud-managed clusters (GKE, EKS, AKS)" section in the guide, linked from the FAQ.

## Verification

- Live server against kind with doctored contexts: missing plugin, garbage token (401), legacy `gcp` stanza, silently failing plugin, stderr-printing plugin, and an exec plugin minting a real ServiceAccount token — each produced the intended message; the real-token exec context connects and browses resources.
- Verified against a real GKE Autopilot cluster: test connection, discovery (155 kinds), namespaces, and the pods page all work through the exec-plugin flow.
- UI warnings confirmed via headless browser in Settings → Clusters and the Edit dialog.
- `pnpm typecheck` passes across all packages.

Bumps version to 0.2.4.