### PR TITLE
ci: remove unused Pages configuration step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,6 @@ jobs:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/configure-pages@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
Remove the leftover configure-pages step from the release workflow now that Pages publishing is branch-based. This prevents future release runs from reconfiguring Pages back toward workflow deployments.