### PR TITLE
ci: Build and do a smoketest on all supported OS'es

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,20 @@ on:
     branches: [main]
   pull_request:
 
+# A new push to a PR (or main) supersedes in-flight runs for the same ref;
+# cancel the stale ones to free runners.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      # Report every OS result; don't cancel the matrix on the first failure.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -23,6 +34,10 @@ jobs:
           path: |
             ~/.cache/electron
             ~/.cache/electron-builder
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ~\AppData\Local\electron\Cache
+            ~\AppData\Local\electron-builder\Cache
           key: electron-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
       - run: pnpm install --frozen-lockfile
       # build first: @kubus/shared (and /server for electron) resolve types
@@ -30,6 +45,11 @@ jobs:
       - run: pnpm build
       - run: pnpm typecheck
       # Unpacked desktop build so a broken electron-builder config fails PRs.
-      - run: pnpm --filter @kubus/electron exec electron-builder --dir --linux
+      # No platform flag: each runner packages for its own OS.
+      - run: pnpm --filter @kubus/electron exec electron-builder --dir
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+      # Boot the app's server on each OS to catch runtime startup regressions
+      # (won't listen, missing static assets, crash-on-boot) that packaging
+      # alone misses. Headless, so it needs no display on any runner.
+      - run: pnpm smoke

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -38,6 +38,8 @@ interface Props {
   checkboxSelection?: boolean;
   /** Column fields hidden by default (user can re-enable via the column menu). */
   hiddenFields?: string[];
+  /** Stable id used to persist user-resized column widths for this table. */
+  tableId?: string;
 }
 
 export function ResourceTable({
@@ -57,6 +59,7 @@ export function ResourceTable({
   checkboxSelection,
   onSelectionChange,
   hiddenFields,
+  tableId,
 }: Props) {
   const [localFilter, setLocalFilter] = useState('');
   const activeFilter = filter ?? localFilter;
@@ -65,14 +68,37 @@ export function ResourceTable({
   const hiddenKey = (hiddenFields ?? []).join(',');
   const [visibility, setVisibility] = useState<GridColumnVisibilityModel>({});
   const tableDensity = useUiPrefsStore((s) => s.tableDensity);
+  // Retrieve this table's saved column widths (if any)
+  const storedWidths = useUiPrefsStore((s) => (tableId ? s.columnWidths[tableId] : undefined));
+  // Retrieve the action used to persist a column width
+  const setColumnWidth = useUiPrefsStore((s) => s.setColumnWidth);
   useEffect(() => {
     setVisibility(Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []));
   }, [hiddenKey]);
 
-  const gridColumns = useMemo(
-    () => columns.map((column) => (column.renderCell && !column.display ? { ...column, display: 'flex' as const } : column)),
-    [columns],
-  );
+  // Check the watchlist and rebuild the columns upon detected changes
+  const gridColumns = useMemo(() => {
+    const result: GridColDef<ClusterRow>[] = [];
+    for (const column of columns) {
+      let next = column;
+      let stored;
+      if (storedWidths) {
+        stored = storedWidths[column.field];
+      }
+      // If a saved width exists, make a copy of the column with that width applied
+      if (stored !== undefined) {
+        next = { ...next, width: stored, flex: undefined };
+      }
+      // If this column draws custom cells, make sure they lay out correctly
+      if (next.renderCell && !next.display) {
+        next = { ...next, display: 'flex' as const };
+      }
+      result.push(next);
+    }
+
+    // Hand back the whole adjusted list.
+    return result;
+  }, [columns, storedWidths]); // watch list
 
   const filtered = useMemo(() => {
     if (!activeFilter) return rows;
@@ -207,6 +233,7 @@ export function ResourceTable({
         }
         columnVisibilityModel={visibility}
         onColumnVisibilityModelChange={setVisibility}
+        onColumnWidthChange={tableId ? (params) => setColumnWidth(tableId, params.colDef.field, params.width) : undefined}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
         sx={{
           border: 0,

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -198,6 +198,7 @@ export function ResourceListPage() {
         )}
       </Box>
       <ResourceTable
+        tableId={kindPath}
         rows={list.rows}
         columns={columns}
         loading={Object.values(list.status).some((s) => s.state === 'loading')}

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -20,7 +20,10 @@ interface UiPrefsState {
   defaultShell: string;
   /** Treat contexts without an explicit protected flag as protected. */
   protectByDefault: boolean;
+  /** User-resized column widths, keyed by table id then column field. */
+  columnWidths: Record<string, Record<string, number>>;
   set: (patch: Partial<Omit<UiPrefsState, 'set'>>) => void;
+  setColumnWidth: (tableId: string, field: string, width: number) => void;
 }
 
 export const useUiPrefsStore = create<UiPrefsState>()(
@@ -32,7 +35,12 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       defaultTailLines: 500,
       defaultShell: 'auto',
       protectByDefault: false,
+      columnWidths: {},
       set: (patch) => set(patch),
+      setColumnWidth: (tableId, field, width) =>
+        set((state) => ({
+          columnWidths: { ...state.columnWidths, [tableId]: { ...state.columnWidths[tableId], [field]: width } },
+        })),
     }),
     { name: 'kubus-prefs', storage: createJSONStorage(() => kubusStateStorage) },
   ),

--- a/hack/smoke-server.mjs
+++ b/hack/smoke-server.mjs
@@ -1,0 +1,58 @@
+// Headless runtime smoke test: boot the standalone Kubus server — the same
+// backend startServer() the desktop app launches — and confirm it comes up and
+// serves the client over HTTP, then shut it down.
+//
+// Runs in plain Node on every OS with no display, so it catches startup
+// regressions (server won't listen, static assets missing, a crash-on-boot)
+// that `electron-builder --dir` alone can't — without the flakiness of driving
+// a real Electron window in CI.
+//
+// Requires `pnpm build` first (needs server/dist and client/dist).
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const entry = path.join(repoRoot, 'server', 'dist', 'index.js');
+
+const port = process.env.SMOKE_PORT ?? '3999';
+const url = `http://127.0.0.1:${port}/`;
+const READY_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 500;
+
+const child = spawn(process.execPath, [entry], {
+  cwd: repoRoot,
+  // KUBUS_NO_OPEN: don't try to open a browser on a headless runner.
+  env: { ...process.env, PORT: port, KUBUS_NO_OPEN: '1', NODE_ENV: 'production' },
+  stdio: ['ignore', 'inherit', 'inherit'],
+});
+
+let settled = false;
+function finish(code, msg) {
+  if (settled) return;
+  settled = true;
+  (code === 0 ? console.log : console.error)(msg);
+  if (!child.killed) child.kill();
+  process.exit(code);
+}
+
+// The server should stay up; any exit before we've probed it is a failure.
+child.on('exit', (code) => finish(1, `smoke: FAIL — server exited early (code ${code})`));
+child.on('error', (err) => finish(1, `smoke: FAIL — could not launch server: ${err.message}`));
+
+const deadline = Date.now() + READY_TIMEOUT_MS;
+while (Date.now() < deadline && !settled) {
+  try {
+    const res = await fetch(url);
+    // Any HTTP response means the server is listening and routing. The client
+    // shell is served unauthenticated at `/`; only /api routes require a token.
+    if (res.ok) finish(0, `smoke: ok — ${url} responded ${res.status}`);
+    else finish(1, `smoke: FAIL — ${url} responded ${res.status}`);
+  } catch {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+}
+
+finish(1, `smoke: FAIL — server not ready within ${READY_TIMEOUT_MS}ms`);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "electron": "pnpm build && pnpm --filter @kubus/electron start",
     "dist": "pnpm build && pnpm --filter @kubus/electron dist",
     "typecheck": "pnpm -r typecheck",
+    "smoke": "node hack/smoke-server.mjs",
     "lint": "pnpm -r lint",
     "serve-docs": "uvx --native-tls zensical serve --open",
     "build-docs": "uvx --native-tls zensical build --clean"


### PR DESCRIPTION
CI job now builds on Windows, Ubuntu and MacOS runners in parallel and runs a hack/smoke-server.mjs script that starts the server, keeps poking it with HTTP requests until one succeeds, then shuts it down and prints a report.