### PR TITLE
Record and render user-resized column widths

### DIFF
--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -38,6 +38,8 @@ interface Props {
   checkboxSelection?: boolean;
   /** Column fields hidden by default (user can re-enable via the column menu). */
   hiddenFields?: string[];
+  /** Stable id used to persist user-resized column widths for this table. */
+  tableId?: string;
 }
 
 export function ResourceTable({
@@ -57,6 +59,7 @@ export function ResourceTable({
   checkboxSelection,
   onSelectionChange,
   hiddenFields,
+  tableId,
 }: Props) {
   const [localFilter, setLocalFilter] = useState('');
   const activeFilter = filter ?? localFilter;
@@ -65,14 +68,37 @@ export function ResourceTable({
   const hiddenKey = (hiddenFields ?? []).join(',');
   const [visibility, setVisibility] = useState<GridColumnVisibilityModel>({});
   const tableDensity = useUiPrefsStore((s) => s.tableDensity);
+  // Retrieve this table's saved column widths (if any)
+  const storedWidths = useUiPrefsStore((s) => (tableId ? s.columnWidths[tableId] : undefined));
+  // Retrieve the action used to persist a column width
+  const setColumnWidth = useUiPrefsStore((s) => s.setColumnWidth);
   useEffect(() => {
     setVisibility(Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []));
   }, [hiddenKey]);
 
-  const gridColumns = useMemo(
-    () => columns.map((column) => (column.renderCell && !column.display ? { ...column, display: 'flex' as const } : column)),
-    [columns],
-  );
+  // Check the watchlist and rebuild the columns upon detected changes
+  const gridColumns = useMemo(() => {
+    const result: GridColDef<ClusterRow>[] = [];
+    for (const column of columns) {
+      let next = column;
+      let stored;
+      if (storedWidths) {
+        stored = storedWidths[column.field];
+      }
+      // If a saved width exists, make a copy of the column with that width applied
+      if (stored !== undefined) {
+        next = { ...next, width: stored, flex: undefined };
+      }
+      // If this column draws custom cells, make sure they lay out correctly
+      if (next.renderCell && !next.display) {
+        next = { ...next, display: 'flex' as const };
+      }
+      result.push(next);
+    }
+
+    // Hand back the whole adjusted list.
+    return result;
+  }, [columns, storedWidths]); // watch list
 
   const filtered = useMemo(() => {
     if (!activeFilter) return rows;
@@ -207,6 +233,7 @@ export function ResourceTable({
         }
         columnVisibilityModel={visibility}
         onColumnVisibilityModelChange={setVisibility}
+        onColumnWidthChange={tableId ? (params) => setColumnWidth(tableId, params.colDef.field, params.width) : undefined}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
         sx={{
           border: 0,

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -198,6 +198,7 @@ export function ResourceListPage() {
         )}
       </Box>
       <ResourceTable
+        tableId={kindPath}
         rows={list.rows}
         columns={columns}
         loading={Object.values(list.status).some((s) => s.state === 'loading')}

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -20,7 +20,10 @@ interface UiPrefsState {
   defaultShell: string;
   /** Treat contexts without an explicit protected flag as protected. */
   protectByDefault: boolean;
+  /** User-resized column widths, keyed by table id then column field. */
+  columnWidths: Record<string, Record<string, number>>;
   set: (patch: Partial<Omit<UiPrefsState, 'set'>>) => void;
+  setColumnWidth: (tableId: string, field: string, width: number) => void;
 }
 
 export const useUiPrefsStore = create<UiPrefsState>()(
@@ -32,7 +35,12 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       defaultTailLines: 500,
       defaultShell: 'auto',
       protectByDefault: false,
+      columnWidths: {},
       set: (patch) => set(patch),
+      setColumnWidth: (tableId, field, width) =>
+        set((state) => ({
+          columnWidths: { ...state.columnWidths, [tableId]: { ...state.columnWidths[tableId], [field]: width } },
+        })),
     }),
     { name: 'kubus-prefs', storage: createJSONStorage(() => kubusStateStorage) },
   ),


### PR DESCRIPTION
Add support for persisting user-resized column widths in the `ResourceTable` component using 'tableId' built from an already defined 'kindPath'

Fixes #31 