### PR TITLE
Use 'kubectl replace' logic rather than 'apply'

### DIFF
--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -183,6 +183,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
             {tab === 'yaml' && (
               <YamlEditor
                 value={yamlText}
+                applyLabel="Replace"
                 onApply={handleApply}
                 onDryRun={sel ? (text) => dryRun.mutateAsync({ ctx: sel.ctx, yamlBody: text }) : undefined}
                 toolbar={

--- a/server/src/routes/resources.ts
+++ b/server/src/routes/resources.ts
@@ -186,17 +186,23 @@ export function registerResourceRoutes(app: FastifyInstance, ctx: AppContext): v
       if (kind.namespaced && !manifest.metadata?.namespace) {
         findings.push({ severity: 'warning', field: 'metadata.namespace', message: 'No namespace set; dry-run used default namespace.' });
       }
-      const query = new URLSearchParams({ dryRun: 'All', fieldManager: 'kubus', fieldValidation: 'Strict' });
-      const path = resourcePath(kind.group, kind.version, kind.plural, {
-        namespace,
-        name,
-        query,
-      });
+      const existsPath = resourcePath(kind.group, kind.version, kind.plural, { namespace, name });
+      const exists = await handle.raw
+        .json<KubeObject>(existsPath)
+        .then(() => true)
+        .catch((err: unknown) => {
+          if (err instanceof ApiException && err.code === 404) return false;
+          throw err;
+        });
+      const query = new URLSearchParams({ dryRun: 'All', fieldValidation: 'Strict' });
+      const path = exists
+        ? resourcePath(kind.group, kind.version, kind.plural, { namespace, name, query })
+        : resourcePath(kind.group, kind.version, kind.plural, { namespace, query });
       const body = typeof req.body === 'string' ? req.body : dumpYaml(manifest, { noRefs: true });
       try {
         await handle.raw.json<KubeObject>(path, {
-          method: 'PATCH',
-          headers: { 'content-type': 'application/apply-patch+yaml' },
+          method: exists ? 'PUT' : 'POST',
+          headers: { 'content-type': 'application/yaml' },
           body,
         });
         const response: ResourceDryRunResponse = {


### PR DESCRIPTION
Fixes: #33

Full replace (PUT) for an object that already exists, create (POST) for a new one. Server-Side Apply (apply-patch) must not be used here: it's declarative and merges by field ownership, and on merge-keyed lists like Service.spec.ports (keyed by port+protocol) an edited key becomes a new list entry while the original - owned by another field manager - stays in place.

I did not implemented Server-Side Apply because it can't drop list entries owned by other field managers, so replacing the whole object with a PUT is simpler.

<img width="720" height="287" alt="image" src="https://github.com/user-attachments/assets/bad1b643-4308-43d2-9e86-fd36e4b00c6f" />
