### PR TITLE
Fix resource detail drawer layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all deb win dmg clean
+
+all:
+	pnpm build && pnpm --filter @kubus/electron dist
+
+deb:
+	pnpm build && pnpm --filter @kubus/electron exec electron-builder --linux deb --x64
+
+win:
+	pnpm build && pnpm --filter @kubus/electron exec electron-builder --win --x64
+
+dmg:
+	pnpm build && pnpm --filter @kubus/electron exec electron-builder --mac dmg
+
+clean:
+	rm -rf electron/release

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { CssBaseline, ThemeProvider } from '@mui/material';
-import { buildTheme, titleBarColors } from './theme.js';
+import { buildTheme } from './theme.js';
+import { setTitleBarMode } from './titlebar-overlay.js';
 import { useClustersStore } from './state/clusters.js';
 import { AppRouter } from './router.js';
 import { UpdateNotification } from './components/UpdateNotification.js';
+import { TitleBarAwareBackdrop } from './components/TitleBarAwareBackdrop.js';
 
 export default function App() {
   const themeMode = useClustersStore((s) => s.themeMode);
@@ -12,10 +14,10 @@ export default function App() {
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
   );
   const effectiveMode = themeMode === 'os' ? osTheme : themeMode;
-  const theme = useMemo(() => buildTheme(effectiveMode), [effectiveMode]);
-  useEffect(() => {
+  const theme = useMemo(() => buildTheme(effectiveMode, { modalBackdrop: TitleBarAwareBackdrop }), [effectiveMode]);
+  useLayoutEffect(() => {
     // Keep the desktop app's native window controls in sync with the theme.
-    window.kubusDesktop?.setTitleBarOverlay(titleBarColors(effectiveMode));
+    setTitleBarMode(effectiveMode);
   }, [effectiveMode]);
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -82,7 +82,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   const hasRolloutHistory = sel?.kind === 'Deployment' || sel?.kind === 'StatefulSet';
   const showMap = !isCrd;
   const drawerTopOffset = 52;
-  const drawerViewportSx = {
+  const drawerPaperSx = {
     top: `${drawerTopOffset}px`,
     height: `calc(100% - ${drawerTopOffset}px)`,
   };
@@ -109,9 +109,8 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
       open={!!sel}
       onClose={onClose}
       slotProps={{
-        root: { sx: drawerViewportSx },
-        backdrop: { sx: { top: `${drawerTopOffset}px` } },
-        paper: { sx: { ...drawerViewportSx, width: drawerWidth, maxWidth: '100vw' } },
+        backdrop: { invisible: true },
+        paper: { sx: { ...drawerPaperSx, width: drawerWidth, maxWidth: '100vw' } },
       }}
     >
       {sel && (

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -75,7 +75,12 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   const apply = useApplyResource();
   const dryRun = useDryRunResource();
 
-  const yamlText = useMemo(() => (obj ? dumpYaml(withoutManagedFields(obj), { noRefs: true, lineWidth: 140 }) : ''), [obj]);
+  // Only serialize on the YAML tab — dumping a large object mid-open would
+  // stall the drawer's slide-in animation.
+  const yamlText = useMemo(
+    () => (obj && tab === 'yaml' ? dumpYaml(withoutManagedFields(obj), { noRefs: true, lineWidth: 140 }) : ''),
+    [obj, tab],
+  );
   const schemaSource = isCrd ? obj : backingCrd;
   const versions = useMemo(() => crdVersions(schemaSource), [schemaSource]);
   const hasMetrics = sel?.kind === 'Pod' || sel?.kind === 'Node';

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Box, Drawer, FormControlLabel, IconButton, Link, Stack, Switch, Tab, Tabs, Typography } from '@mui/material';
+import { Box, Drawer, FormControlLabel, IconButton, Link, Stack, Switch, Tab, Tabs, Tooltip, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import FullscreenIcon from '@mui/icons-material/Fullscreen';
+import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import { dump as dumpYaml } from 'js-yaml';
 import type { KubeObject } from '@kubus/shared';
 import { useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
@@ -41,6 +43,7 @@ interface Props {
 export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   const [tab, setTab] = useState('overview');
   const [reveal, setReveal] = useState(false);
+  const [fullScreen, setFullScreen] = useState(false);
   const pushDetail = useDetailStore((s) => s.push);
   const isSecret = sel?.kind === 'Secret';
   const isCrd = sel?.kind === 'CustomResourceDefinition';
@@ -61,6 +64,11 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
     setTab('overview');
     setReveal(false);
   }, [selKey]);
+
+  useEffect(() => {
+    if (!sel) setFullScreen(false);
+  }, [sel]);
+
   const { data: obj, refetch } = useResource(sel ? { ...sel, reveal: isSecret && reveal } : undefined);
   const { data: backingCrd } = useResource(backingCrdSelection);
   const { data: events } = useResourceEvents(tab === 'events' && sel ? { ctx: sel.ctx, name: sel.name, kind: sel.kind, namespace: sel.namespace } : undefined);
@@ -73,7 +81,12 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   const hasMetrics = sel?.kind === 'Pod' || sel?.kind === 'Node';
   const hasRolloutHistory = sel?.kind === 'Deployment' || sel?.kind === 'StatefulSet';
   const showMap = !isCrd;
-  const drawerWidth = tab === 'map' ? 'min(1060px, 92vw)' : tab.startsWith('crd:') ? 'min(920px, 90vw)' : 'min(720px, 80vw)';
+  const drawerTopOffset = 52;
+  const drawerViewportSx = {
+    top: `${drawerTopOffset}px`,
+    height: `calc(100% - ${drawerTopOffset}px)`,
+  };
+  const drawerWidth = fullScreen ? '100vw' : tab === 'map' ? 'min(1060px, 92vw)' : tab.startsWith('crd:') ? 'min(920px, 90vw)' : 'min(720px, 80vw)';
   const mapNamespaces = sel?.namespace ? [sel.namespace] : [];
 
   const handleApply = async (text: string) => {
@@ -91,7 +104,16 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   };
 
   return (
-    <Drawer anchor="right" open={!!sel} onClose={onClose} slotProps={{ paper: { sx: { width: drawerWidth } } }}>
+    <Drawer
+      anchor="right"
+      open={!!sel}
+      onClose={onClose}
+      slotProps={{
+        root: { sx: drawerViewportSx },
+        backdrop: { sx: { top: `${drawerTopOffset}px` } },
+        paper: { sx: { ...drawerViewportSx, width: drawerWidth, maxWidth: '100vw' } },
+      }}
+    >
       {sel && (
         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
           <Stack direction="row" sx={{ px: 2, py: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center' }}>
@@ -137,6 +159,11 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
             </Box>
             <Box sx={{ flex: 1 }} />
             {obj && <RowActions target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
+            <Tooltip title={fullScreen ? 'Restore drawer' : 'Full screen'}>
+              <IconButton onClick={() => setFullScreen((v) => !v)} aria-label={fullScreen ? 'Restore drawer' : 'Full screen'}>
+                {fullScreen ? <FullscreenExitIcon /> : <FullscreenIcon />}
+              </IconButton>
+            </Tooltip>
             <IconButton onClick={onClose}>
               <CloseIcon />
             </IconButton>

--- a/client/src/components/TitleBarAwareBackdrop.tsx
+++ b/client/src/components/TitleBarAwareBackdrop.tsx
@@ -1,0 +1,36 @@
+import { forwardRef, useLayoutEffect, useRef } from 'react';
+import Backdrop, { type BackdropProps } from '@mui/material/Backdrop';
+import { createTitleBarDimmer, type TitleBarDimmer } from '../titlebar-overlay.js';
+
+/** Modal backdrop that also dims the desktop app's native window-controls
+ *  overlay, tracking the backdrop's rendered opacity every frame so both
+ *  fade in lockstep — including the exit fade and interrupted transitions. */
+export const TitleBarAwareBackdrop = forwardRef<HTMLDivElement, BackdropProps>(function TitleBarAwareBackdrop(props, ref) {
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const dimmerRef = useRef<TitleBarDimmer | null>(null);
+
+  useLayoutEffect(() => {
+    const node = nodeRef.current;
+    if (props.invisible || !node || !window.kubusDesktop) return;
+    const dimmer = (dimmerRef.current ??= createTitleBarDimmer());
+    const target = props.open ? 1 : 0;
+    let frame = 0;
+    const track = () => {
+      const opacity = Number(getComputedStyle(node).opacity) || 0;
+      dimmer.set(opacity);
+      if (node.isConnected && Math.abs(opacity - target) > 0.001) frame = requestAnimationFrame(track);
+    };
+    track();
+    return () => cancelAnimationFrame(frame);
+  }, [props.open, props.invisible]);
+
+  useLayoutEffect(() => () => dimmerRef.current?.release(), []);
+
+  const setRefs = (node: HTMLDivElement | null) => {
+    nodeRef.current = node;
+    if (typeof ref === 'function') ref(node);
+    else if (ref) ref.current = node;
+  };
+
+  return <Backdrop ref={setRefs} {...props} sx={[{ zIndex: -1 }, ...(Array.isArray(props.sx) ? props.sx : props.sx ? [props.sx] : [])]} />;
+});

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -4,6 +4,8 @@ declare global {
   /** Bridge exposed by the Electron preload (absent in regular browsers). */
   interface Window {
     kubusDesktop?: {
+      /** Electron's process.platform ('linux', 'win32', 'darwin', …). */
+      platform: string;
       stateStorage: {
         getItem(name: string): string | null;
         setItem(name: string, value: string): void;

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -267,6 +267,10 @@ export function ResourceListPage() {
         onFilterChange={(value) => setQueryParam('q', value)}
         onLabelSelectorChange={(value) => setQueryParam('label', value)}
         onRowClick={(row) => {
+          // Open the drawer directly — going through ?sel alone would delay it
+          // by a full render + post-paint effect; the URL write below is kept
+          // for deep-linking and the mirror effect re-opens an equal selection.
+          openDetail({ ctx: row.ctx, group, version, plural, kind, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace, custom: isCustomKind });
           const next = new URLSearchParams(searchParams);
           next.delete('field');
           next.set('sel', `${row.ctx}|${row.obj.metadata.namespace ?? ''}|${row.obj.metadata.name}`);

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -1,5 +1,8 @@
+import type { ElementType } from 'react';
 import { alpha, createTheme, type Theme } from '@mui/material/styles';
 import type {} from '@mui/x-data-grid/themeAugmentation';
+
+const modalBackdropAlpha = 0.5;
 
 const darkColors = {
         primary: '#6e8bfb',
@@ -43,12 +46,27 @@ const lightColors = {
 
 /** Colors the desktop app paints the native window-controls overlay with —
  *  must match the rendered TopBar (AppBar uses `sidebar` as background). */
-export function titleBarColors(mode: 'light' | 'dark'): { color: string; symbolColor: string } {
+export function titleBarColors(mode: 'light' | 'dark', options: { dim?: number } = {}): { color: string; symbolColor: string } {
   const c = mode === 'dark' ? darkColors : lightColors;
-  return { color: c.sidebar, symbolColor: c.textPrimary };
+  const dim = options.dim ?? 0;
+  return {
+    color: compositeModalBackdrop(c.sidebar, dim),
+    symbolColor: compositeModalBackdrop(c.textPrimary, dim),
+  };
 }
 
-export function buildTheme(mode: 'light' | 'dark'): Theme {
+/** Composite the modal backdrop (black at modalBackdropAlpha × backdropOpacity)
+ *  over an opaque hex color, so the native overlay can match the web backdrop
+ *  at any point during its fade. */
+function compositeModalBackdrop(hex: string, backdropOpacity: number): string {
+  if (backdropOpacity <= 0) return hex;
+  const factor = 1 - modalBackdropAlpha * Math.min(1, backdropOpacity);
+  const value = hex.replace('#', '');
+  const channels = [0, 2, 4].map((offset) => parseInt(value.slice(offset, offset + 2), 16));
+  return `#${channels.map((channel) => Math.round(channel * factor).toString(16).padStart(2, '0')).join('')}`;
+}
+
+export function buildTheme(mode: 'light' | 'dark', options: { modalBackdrop?: ElementType } = {}): Theme {
   const dark = mode === 'dark';
   const c = dark ? darkColors : lightColors;
 
@@ -76,6 +94,20 @@ export function buildTheme(mode: 'light' | 'dark'): Theme {
       button: { fontWeight: 550 },
     },
     components: {
+      ...(options.modalBackdrop
+        ? {
+            MuiDrawer: {
+              defaultProps: {
+                slots: { backdrop: options.modalBackdrop },
+              },
+            },
+            MuiModal: {
+              defaultProps: {
+                slots: { backdrop: options.modalBackdrop },
+              },
+            },
+          }
+        : {}),
       MuiCssBaseline: {
         styleOverrides: {
           '*': {
@@ -152,6 +184,7 @@ export function buildTheme(mode: 'light' | 'dark'): Theme {
         },
       },
       MuiDialog: {
+        defaultProps: options.modalBackdrop ? { slots: { backdrop: options.modalBackdrop } } : undefined,
         styleOverrides: {
           paper: {
             borderRadius: 12,

--- a/client/src/titlebar-overlay.ts
+++ b/client/src/titlebar-overlay.ts
@@ -1,0 +1,49 @@
+import { titleBarColors } from './theme.js';
+
+type TitleBarMode = 'light' | 'dark';
+
+export type TitleBarDimmer = {
+  /** Report the backdrop's current opacity (0..1). */
+  set(opacity: number): void;
+  release(): void;
+};
+
+let currentMode: TitleBarMode = 'light';
+const backdropOpacities = new Map<object, number>();
+let lastApplied: string | undefined;
+
+// On Linux the native overlay background is transparent: the web AppBar and
+// modal backdrop show through and dim in the same compositor frame as the
+// rest of the page, so only the glyph color has to track the backdrop fade.
+// Other platforms paint an opaque box, so both colors track the fade there.
+const transparentBackground = window.kubusDesktop?.platform === 'linux';
+
+function applyTitleBarOverlay() {
+  const dim = backdropOpacities.size ? Math.max(...backdropOpacities.values()) : 0;
+  const colors = titleBarColors(currentMode, { dim });
+  if (transparentBackground) colors.color = '#00000000';
+  const key = `${colors.color}|${colors.symbolColor}`;
+  if (key === lastApplied) return;
+  lastApplied = key;
+  window.kubusDesktop?.setTitleBarOverlay(colors);
+}
+
+export function setTitleBarMode(mode: TitleBarMode) {
+  currentMode = mode;
+  applyTitleBarOverlay();
+}
+
+/** One dimmer per visible modal backdrop; the deepest dim wins when stacked. */
+export function createTitleBarDimmer(): TitleBarDimmer {
+  const key = {};
+  return {
+    set(opacity: number) {
+      backdropOpacities.set(key, Math.min(1, Math.max(0, opacity)));
+      applyTitleBarOverlay();
+    },
+    release() {
+      backdropOpacities.delete(key);
+      applyTitleBarOverlay();
+    },
+  };
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -26,6 +26,7 @@ app.setName('Kubus');
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isMac = process.platform === 'darwin';
+const isLinux = process.platform === 'linux';
 
 // Must match the client TopBar height: its toolbar doubles as the titlebar.
 const TITLEBAR_HEIGHT = 52;
@@ -141,9 +142,14 @@ function overlayColors(): { color: string; symbolColor: string } {
   // Match the client's default theme (prefers-color-scheme) until the app
   // reports its actual theme over the bridge; values = titleBarColors() in
   // client/src/theme.ts (the TopBar's AppBar background).
-  return nativeTheme.shouldUseDarkColors
-    ? { color: '#151518', symbolColor: '#e6e6ea' }
-    : { color: '#f4f4f5', symbolColor: '#1c1c21' };
+  // On Linux the overlay background is fully transparent: the web AppBar (and
+  // any modal backdrop) shows through, so that region dims in the same
+  // compositor frame as the rest of the page — only the glyphs are native.
+  const dark = nativeTheme.shouldUseDarkColors;
+  return {
+    color: isLinux ? '#00000000' : dark ? '#151518' : '#f4f4f5',
+    symbolColor: dark ? '#e6e6ea' : '#1c1c21',
+  };
 }
 
 function versionParts(version: string): [number, number, number] | undefined {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 // Desktop bridge for stable client state plus native window integrations.
 contextBridge.exposeInMainWorld('kubusDesktop', {
+  platform: process.platform,
   stateStorage: {
     getItem(name: string): string | null {
       return ipcRenderer.sendSync('kubus:state:get-item', name) as string | null;


### PR DESCRIPTION
## Summary
- Keep the resource detail drawer and backdrop below the top navbar.
- Add a fullscreen/restore control to the drawer header.
- Reset fullscreen state when the drawer closes.
- Dont dimm when the drawer is open
- Linux electron aesthetics
