### PR TITLE
Add Monaco/OpenAPI schema route and client schema hooks

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@xyflow/react": "^12.11.1",
     "js-yaml": "^5.2.0",
     "monaco-editor": "^0.55.1",
+    "monaco-yaml": "^5.5.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.1.0",

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -415,6 +415,20 @@ export function useResource(sel: { ctx: string; group: string; version: string; 
   });
 }
 
+/** JSON Schema for a kind, derived from the cluster's OpenAPI (covers CRDs). Best-effort: consumers degrade gracefully without it. */
+export function useResourceSchema(sel: { ctx: string; group: string; version: string; kind: string } | undefined) {
+  return useQuery({
+    queryKey: ['resource-schema', sel],
+    queryFn: () => {
+      const params = new URLSearchParams({ group: sel!.group, version: sel!.version, kind: sel!.kind });
+      return apiFetch<Record<string, unknown>>(`/api/contexts/${encodeURIComponent(sel!.ctx)}/schema?${params}`);
+    },
+    enabled: !!sel,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}
+
 /** One-shot (non-watched) list of a resource kind, with optional selectors. */
 export function useResourceList(sel: { ctx: string; group: string; version: string; plural: string; namespace?: string; labelSelector?: string; fieldSelector?: string } | undefined) {
   return useQuery({

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -8,7 +8,7 @@ import { dump as dumpYaml } from 'js-yaml';
 import type { KubeObject } from '@kubus/shared';
 import { useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
 import { withoutManagedFields } from '../kube-display.js';
-import { YamlEditor } from './YamlEditor.js';
+import { YamlEditor, useYamlSchema } from './YamlEditor.js';
 import { GenericDetail } from './detail/GenericDetail.js';
 import { DeploymentDetail } from './detail/DeploymentDetail.js';
 import { PodDetail } from './detail/PodDetail.js';
@@ -74,6 +74,9 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   const { data: events } = useResourceEvents(tab === 'events' && sel ? { ctx: sel.ctx, name: sel.name, kind: sel.kind, namespace: sel.namespace } : undefined);
   const apply = useApplyResource();
   const dryRun = useDryRunResource();
+  // Warm the schema (fetch + yaml-worker registration) while the drawer is on
+  // Overview, so hover/validation are ready the moment the YAML tab opens.
+  useYamlSchema(sel ? { ctx: sel.ctx, group: sel.group, version: sel.version, kind: sel.kind } : undefined);
 
   // Only serialize on the YAML tab — dumping a large object mid-open would
   // stall the drawer's slide-in animation.
@@ -217,6 +220,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
                 applyLabel="Replace"
                 onApply={handleApply}
                 onDryRun={sel ? (text) => dryRun.mutateAsync({ ctx: sel.ctx, yamlBody: text }) : undefined}
+                schema={sel ? { ctx: sel.ctx, group: sel.group, version: sel.version, kind: sel.kind } : undefined}
                 toolbar={
                   isSecret ? (
                     <FormControlLabel

--- a/client/src/components/YamlEditor.tsx
+++ b/client/src/components/YamlEditor.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Box, Button, Stack } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Editor from '@monaco-editor/react';
 import { useTheme } from '@mui/material/styles';
 import type { ResourceDryRunResponse } from '@kubus/shared';
+import { useResourceSchema } from '../api/queries.js';
+import { newYamlModelPath, registerYamlSchema, type YamlSchemaRef } from '../monaco-setup.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 
 interface Props {
@@ -14,9 +16,29 @@ interface Props {
   applyLabel?: string;
   /** Extra toolbar content (e.g. reveal-secrets toggle). */
   toolbar?: React.ReactNode;
+  /** Kind being edited; enables schema-based hover docs, completion and validation. */
+  schema?: YamlSchemaRef;
 }
 
-export function YamlEditor({ value, readOnly, onApply, onDryRun, applyLabel = 'Apply', toolbar }: Props) {
+/**
+ * Fetch a kind's JSON schema and register it with monaco-yaml. Callers that
+ * know the kind ahead of time (e.g. the detail drawer) can invoke this before
+ * the editor mounts so the yaml worker is warm when the YAML tab opens.
+ */
+export function useYamlSchema(schema: YamlSchemaRef | undefined): YamlSchemaRef | undefined {
+  const { ctx, group, version, kind } = schema ?? {};
+  const schemaRef = useMemo<YamlSchemaRef | undefined>(
+    () => (ctx !== undefined && group !== undefined && version && kind ? { ctx, group, version, kind } : undefined),
+    [ctx, group, version, kind],
+  );
+  const { data: schemaDoc } = useResourceSchema(schemaRef);
+  useEffect(() => {
+    if (schemaRef && schemaDoc) registerYamlSchema(schemaRef, schemaDoc);
+  }, [schemaRef, schemaDoc]);
+  return schemaRef;
+}
+
+export function YamlEditor({ value, readOnly, onApply, onDryRun, applyLabel = 'Apply', toolbar, schema }: Props) {
   const theme = useTheme();
   const monoFontSize = useUiPrefsStore((s) => s.monoFontSize);
   const [text, setText] = useState(value);
@@ -27,6 +49,10 @@ export function YamlEditor({ value, readOnly, onApply, onDryRun, applyLabel = 'A
   const [dryRun, setDryRun] = useState<ResourceDryRunResponse>();
   const [copied, setCopied] = useState(false);
   const copyResetRef = useRef<number | undefined>(undefined);
+  const schemaRef = useYamlSchema(schema);
+  // Per-mount model path under the schema's glob prefix, so the registered
+  // schema matches this editor without reconfiguring the yaml worker.
+  const modelPath = useMemo(() => newYamlModelPath(schemaRef), [schemaRef]);
 
   useEffect(() => {
     setText(value);
@@ -134,6 +160,7 @@ export function YamlEditor({ value, readOnly, onApply, onDryRun, applyLabel = 'A
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <Editor
           language="yaml"
+          path={modelPath}
           value={text}
           onChange={(v) => {
             setText(v ?? '');
@@ -149,6 +176,10 @@ export function YamlEditor({ value, readOnly, onApply, onDryRun, applyLabel = 'A
             scrollBeyondLastLine: false,
             wordWrap: 'on',
             tabSize: 2,
+            // Render hover/suggest widgets in a viewport-fixed layer so they
+            // aren't clipped by the editor container (drawer sits at the
+            // screen edge, so clipped widgets end up off-screen).
+            fixedOverflowWidgets: true,
           }}
         />
       </Box>

--- a/client/src/monaco-setup.ts
+++ b/client/src/monaco-setup.ts
@@ -1,10 +1,100 @@
-// Bundle Monaco locally (no CDN) and wire its worker for Vite.
+// Bundle Monaco locally (no CDN) and wire its workers for Vite.
 import * as monaco from 'monaco-editor';
 import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import YamlWorker from 'monaco-yaml/yaml.worker?worker';
 import { loader } from '@monaco-editor/react';
+import { configureMonacoYaml, type SchemasSettings } from 'monaco-yaml';
+
+const workerFor = (label: string): Worker => (label === 'yaml' ? new YamlWorker() : new EditorWorker());
 
 self.MonacoEnvironment = {
-  getWorker: () => new EditorWorker(),
+  getWorker: (_moduleId, label) => workerFor(label),
 };
 
 loader.config({ monaco });
+
+/**
+ * monaco-yaml (via monaco-worker-manager) still calls the pre-0.53
+ * createWebWorker({ moduleId, label, createData }) API; monaco >= 0.53 expects
+ * the caller to create the worker and prime it with two messages (an init
+ * trigger, then createData) before handing it over — see monaco-editor's own
+ * esm/vs/common/workers.js, which its bundled language services use. Give
+ * configureMonacoYaml a monaco facade whose createWebWorker bridges the two,
+ * otherwise the yaml worker handshake fails and monaco silently falls back to
+ * a main-thread editor worker that lacks the yaml methods.
+ */
+const monacoForYaml = {
+  ...monaco,
+  editor: {
+    ...monaco.editor,
+    createWebWorker: <T extends object>(opts: { label?: string; createData?: unknown; host?: Record<string, Function>; keepIdleModels?: boolean }): monaco.editor.MonacoWebWorker<T> => {
+      const worker = workerFor(opts.label ?? '');
+      worker.postMessage('ignore'); // wakes the worker's initialize hook
+      worker.postMessage(opts.createData); // consumed by monaco's compat shim as createData
+      return monaco.editor.createWebWorker<T>({ worker, host: opts.host, keepIdleModels: opts.keepIdleModels });
+    },
+  },
+} as unknown as typeof monaco;
+
+// isKubernetes: manifests dumped by the API server contain explicit nulls
+// (e.g. creationTimestamp: null in pod templates) that plain JSON Schema
+// validation would flag; kubernetes mode accepts null wherever a type is set.
+const yamlDefaults = {
+  hover: true,
+  completion: true,
+  validate: true,
+  isKubernetes: true,
+  enableSchemaRequest: false,
+};
+
+const monacoYaml = configureMonacoYaml(monacoForYaml, yamlDefaults);
+
+export interface YamlSchemaRef {
+  ctx: string;
+  group: string;
+  version: string;
+  kind: string;
+}
+
+/** Glob- and URI-safe slug; the hash keeps exotic context names (EKS ARNs…) collision-free. */
+function slug(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return `${s.replace(/[^\w.-]/g, '_')}-${(h >>> 0).toString(36)}`;
+}
+
+/** Cluster + GVK → cache key; also the path prefix its editor models live under. */
+const schemaKey = (ref: YamlSchemaRef): string => `${slug(ref.ctx)}/${ref.group || 'core'}/${ref.version}/${ref.kind}`;
+
+/**
+ * Registered schemas live for the whole session and match models via glob, so
+ * editor mounts/unmounts don't touch the yaml language configuration. That
+ * matters because every update() makes monaco-worker-manager restart the yaml
+ * worker, which then has to recompile every registered schema — the worker
+ * only restarts when a not-yet-seen kind (or changed schema content) arrives.
+ */
+const gvkSchemas = new Map<string, { json: string; entry: SchemasSettings }>();
+
+export function registerYamlSchema(ref: YamlSchemaRef, schema: object): void {
+  const key = schemaKey(ref);
+  const json = JSON.stringify(schema);
+  if (gvkSchemas.get(key)?.json === json) return;
+  gvkSchemas.set(key, {
+    json,
+    entry: {
+      fileMatch: [`**/kubus-gvk/${key}/*.yaml`],
+      schema,
+      // The last segment (kind) shows as the hover's "Source:" link.
+      uri: `kubus://schema/${key}`,
+    },
+  });
+  void monacoYaml.update({ ...yamlDefaults, schemas: [...gvkSchemas.values()].map((v) => v.entry) });
+}
+
+let nextModelId = 0;
+
+/** Unique per-mount model path, placed under the schema's glob when a kind is known. */
+export function newYamlModelPath(ref?: YamlSchemaRef): string {
+  nextModelId += 1;
+  return ref ? `kubus-gvk/${schemaKey(ref)}/${nextModelId}.yaml` : `kubus-${nextModelId}.yaml`;
+}

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -338,6 +338,7 @@ export function ResourceListPage() {
           <YamlEditor
             value={createTemplate(kind, group, version)}
             applyLabel="Create"
+            schema={selected[0] ? { ctx: selected[0], group, version, kind } : undefined}
             onApply={async (text) => {
               await create.mutateAsync({ ctx: selected[0]!, yamlBody: text });
               setCreateOpen(false);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  monaco-yaml>path-browserify: npm:pathe@^2.0.3
+
 importers:
 
   .:
@@ -59,6 +62,9 @@ importers:
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
+      monaco-yaml:
+        specifier: ^5.5.1
+        version: 5.5.1(monaco-editor@0.55.1)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -80,13 +86,13 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.1.2
-        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   electron:
     devDependencies:
@@ -1167,6 +1173,9 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -2088,6 +2097,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
@@ -2283,6 +2295,25 @@ packages:
   monaco-editor@0.55.1:
     resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
+  monaco-languageserver-types@0.4.1:
+    resolution: {integrity: sha512-uLiYM6K6jPqAa1ni9lRBoj8ZJAErOcegBrfEpurIUUO8cBhlhrGYjWbjhl4OPcxUNoj1JvqSETjwCTyhGgwymQ==}
+
+  monaco-marker-data-provider@1.2.5:
+    resolution: {integrity: sha512-5ZdcYukhPwgYMCvlZ9H5uWs5jc23BQ8fFF5AhSIdrz5mvYLsqGZ58ZLxTv8rCX6+AxdJ8+vxg1HVSk+F2bLosg==}
+
+  monaco-types@0.1.2:
+    resolution: {integrity: sha512-8LwfrlWXsedHwAL41xhXyqzPibS8IqPuIXr9NdORhonS495c2/wky+sI1PRLvMCuiI0nqC2NH1six9hdiRY4Xg==}
+
+  monaco-worker-manager@2.0.1:
+    resolution: {integrity: sha512-kdPL0yvg5qjhKPNVjJoym331PY/5JC11aPJXtCZNwWRvBr6jhkIamvYAyiY5P1AWFmNOy0aRDRoMdZfa71h8kg==}
+    peerDependencies:
+      monaco-editor: '>=0.30.0'
+
+  monaco-yaml@5.5.1:
+    resolution: {integrity: sha512-vLR1EoV7Au0tkuA9T6ZJr2q7CooRP69AvlqzWh9Gui6amuijdTsfCAQHtCFobRMwkhbuly6J1Q16NziTTiWtWQ==}
+    peerDependencies:
+      monaco-editor: '>=0.36'
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2406,6 +2437,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -2464,6 +2498,11 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2490,6 +2529,9 @@ packages:
 
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  proxy-disposable@1.0.0:
+    resolution: {integrity: sha512-Y673BKpFqk8XkYuoK9DGZ1RIzldz5SkzxTKc/+DkpaMdrDEbEalWlO/uMRMdJsXvdbTybJI26XDwN0KJpZDN4w==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2958,6 +3000,22 @@ packages:
       yaml:
         optional: true
 
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.18.2:
+    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3027,6 +3085,11 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -4068,10 +4131,12 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
 
-  '@vitejs/plugin-react@6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
+  '@vitejs/plugin-react@6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
+      vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vscode/l10n@0.0.18': {}
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -5090,6 +5155,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@3.3.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
@@ -5243,6 +5310,39 @@ snapshots:
       dompurify: 3.2.7
       marked: 14.0.0
 
+  monaco-languageserver-types@0.4.1:
+    dependencies:
+      monaco-types: 0.1.2
+      vscode-languageserver-protocol: 3.18.2
+      vscode-uri: 3.1.0
+
+  monaco-marker-data-provider@1.2.5:
+    dependencies:
+      monaco-types: 0.1.2
+
+  monaco-types@0.1.2: {}
+
+  monaco-worker-manager@2.0.1(monaco-editor@0.55.1):
+    dependencies:
+      monaco-editor: 0.55.1
+
+  monaco-yaml@5.5.1(monaco-editor@0.55.1):
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      jsonc-parser: 3.3.1
+      monaco-editor: 0.55.1
+      monaco-languageserver-types: 0.4.1
+      monaco-marker-data-provider: 1.2.5
+      monaco-types: 0.1.2
+      monaco-worker-manager: 2.0.1(monaco-editor@0.55.1)
+      path-browserify: pathe@2.0.3
+      prettier: 3.9.4
+      proxy-disposable: 1.0.0
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+      yaml: 2.9.0
+
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
@@ -5355,6 +5455,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
   pe-library@0.4.1: {}
 
   picocolors@1.1.1: {}
@@ -5445,6 +5547,8 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  prettier@3.9.4: {}
+
   proc-log@6.1.0: {}
 
   process-nextick-args@2.0.1: {}
@@ -5471,6 +5575,8 @@ snapshots:
       graceful-fs: 4.2.11
       retry: 0.12.0
       signal-exit: 3.0.7
+
+  proxy-disposable@1.0.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -5927,7 +6033,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4):
+  vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5940,6 +6046,20 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.4
+      yaml: 2.9.0
+
+  vscode-jsonrpc@9.0.1: {}
+
+  vscode-languageserver-protocol@3.18.2:
+    dependencies:
+      vscode-jsonrpc: 9.0.1
+      vscode-languageserver-types: 3.18.0
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
+  vscode-uri@3.1.0: {}
 
   web-streams-polyfill@3.3.3: {}
 
@@ -5994,6 +6114,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@1.10.3: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,12 @@ packages:
   - server
   - client
   - electron
+# monaco-yaml's worker imports path-browserify, which is CJS-only; the Vite dev
+# server serves worker-graph deps as native ESM without CJS interop, so the
+# yaml worker dies with "module is not defined" (prod builds are unaffected).
+# pathe is an ESM drop-in for node:path covering every function the worker uses.
+overrides:
+  "monaco-yaml>path-browserify": "npm:pathe@^2.0.3"
 allowBuilds:
   esbuild: true
   electron: true

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,7 @@ import { registerSshRoutes } from './routes/ssh.js';
 import { registerResourceRoutes } from './routes/resources.js';
 import { registerActionRoutes } from './routes/actions.js';
 import { registerDetailRoutes } from './routes/detail.js';
+import { registerSchemaRoutes } from './routes/schema.js';
 import { registerMetricsRoutes } from './routes/metrics.js';
 import { registerHelmRoutes } from './routes/helm.js';
 import { registerPortForwardRoutes } from './routes/portforward.js';
@@ -96,6 +97,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerResourceRoutes(app, ctx);
   registerActionRoutes(app, ctx);
   registerDetailRoutes(app, ctx);
+  registerSchemaRoutes(app, ctx);
   registerMetricsRoutes(app, ctx);
   registerHelmRoutes(app, ctx);
   registerPortForwardRoutes(app, ctx);

--- a/server/src/kube/openapi-schema.ts
+++ b/server/src/kube/openapi-schema.ts
@@ -1,0 +1,136 @@
+import type { ClusterHandle } from './cluster-manager.js';
+import { HttpProblem } from '../util/errors.js';
+
+interface OpenApiV3Discovery {
+  paths?: Record<string, { serverRelativeURL?: string }>;
+}
+
+type SchemaNode = Record<string, unknown>;
+
+interface OpenApiV3Doc {
+  components?: { schemas?: Record<string, SchemaNode> };
+}
+
+const REF_PREFIX = '#/components/schemas/';
+
+/**
+ * Per-process cache of fetched group/version OpenAPI documents. The
+ * serverRelativeURL embeds a content hash, so a key hit means the schema is
+ * still current; CRD updates or apiserver upgrades change the URL. The
+ * discovery document itself has no hash and is always fetched fresh.
+ */
+const docCache = new Map<string, Promise<OpenApiV3Doc>>();
+const DOC_CACHE_MAX = 16;
+
+function fetchGroupDoc(handle: ClusterHandle, relativeUrl: string): Promise<OpenApiV3Doc> {
+  const key = `${handle.contextName}|${relativeUrl}`;
+  let doc = docCache.get(key);
+  if (!doc) {
+    doc = handle.raw.json<OpenApiV3Doc>(relativeUrl);
+    doc.catch(() => docCache.delete(key));
+    if (docCache.size >= DOC_CACHE_MAX) {
+      const oldest = docCache.keys().next().value;
+      if (oldest !== undefined) docCache.delete(oldest);
+    }
+    docCache.set(key, doc);
+  }
+  return doc;
+}
+
+function collectRefs(node: unknown, out: Set<string>): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectRefs(item, out);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string' && value.startsWith(REF_PREFIX)) out.add(value.slice(REF_PREFIX.length));
+    else collectRefs(value, out);
+  }
+}
+
+/**
+ * Kubernetes OpenAPI schemas leave objects open (no additionalProperties), so
+ * plain JSON Schema validation would never flag misspelled fields. Close every
+ * object that declares properties — mirroring the server's strict field
+ * validation — except where the schema explicitly allows unknown fields.
+ * Only recurses through schema positions (never through property-name maps),
+ * so CRD fields literally named "properties" can't be mistaken for schemas.
+ */
+function closeObjectSchemas(schema: unknown): void {
+  if (Array.isArray(schema)) {
+    for (const item of schema) closeObjectSchemas(item);
+    return;
+  }
+  if (!schema || typeof schema !== 'object') return;
+  const node = schema as SchemaNode;
+  const props = node.properties;
+  if (
+    props &&
+    typeof props === 'object' &&
+    (node.type === 'object' || node.type === undefined) &&
+    node.additionalProperties === undefined &&
+    node['x-kubernetes-preserve-unknown-fields'] !== true &&
+    !Array.isArray(node.allOf) // never constrain composed schemas
+  ) {
+    node.additionalProperties = false;
+  }
+  if (props && typeof props === 'object') {
+    for (const value of Object.values(props)) closeObjectSchemas(value);
+  }
+  closeObjectSchemas(node.items);
+  if (node.additionalProperties && typeof node.additionalProperties === 'object') closeObjectSchemas(node.additionalProperties);
+  for (const combiner of ['allOf', 'anyOf', 'oneOf'] as const) {
+    if (Array.isArray(node[combiner])) closeObjectSchemas(node[combiner]);
+  }
+  closeObjectSchemas(node.not);
+}
+
+function matchesGvk(def: SchemaNode, group: string, version: string, kind: string): boolean {
+  const gvks = def['x-kubernetes-group-version-kind'];
+  if (!Array.isArray(gvks)) return false;
+  return gvks.some((entry) => {
+    const g = entry as { group?: string; version?: string; kind?: string };
+    return (g.group ?? '') === group && g.version === version && g.kind === kind;
+  });
+}
+
+/**
+ * Build a self-contained JSON Schema for one group/version/kind from the
+ * cluster's OpenAPI v3 (which includes CRDs). The result roots at the kind's
+ * definition and carries only the transitively referenced definitions, with
+ * refs rewritten from OpenAPI components to JSON Schema definitions.
+ */
+export async function gvkJsonSchema(handle: ClusterHandle, group: string, version: string, kind: string): Promise<SchemaNode> {
+  const discovery = await handle.raw.json<OpenApiV3Discovery>('/openapi/v3');
+  const pathKey = group ? `apis/${group}/${version}` : `api/${version}`;
+  const relativeUrl = discovery.paths?.[pathKey]?.serverRelativeURL;
+  if (!relativeUrl) throw new HttpProblem(404, `no OpenAPI document for ${pathKey}`);
+
+  const doc = await fetchGroupDoc(handle, relativeUrl);
+  const allDefs = doc.components?.schemas ?? {};
+  const rootName = Object.keys(allDefs).find((name) => matchesGvk(allDefs[name]!, group, version, kind));
+  if (!rootName) throw new HttpProblem(404, `no schema for ${group || 'core'}/${version} ${kind}`);
+
+  // Transitive closure of $refs from the root definition.
+  const reachable = new Set<string>([rootName]);
+  const queue = [rootName];
+  while (queue.length) {
+    const refs = new Set<string>();
+    collectRefs(allDefs[queue.pop()!], refs);
+    for (const ref of refs) {
+      if (!reachable.has(ref) && allDefs[ref]) {
+        reachable.add(ref);
+        queue.push(ref);
+      }
+    }
+  }
+
+  const pruned: Record<string, SchemaNode> = {};
+  for (const name of reachable) pruned[name] = allDefs[name]!;
+  // Deep-copy via ref rewrite so closeObjectSchemas never mutates the cached doc.
+  const definitions = JSON.parse(JSON.stringify(pruned).replaceAll(REF_PREFIX, '#/definitions/')) as Record<string, SchemaNode>;
+  for (const def of Object.values(definitions)) closeObjectSchemas(def);
+
+  return { $ref: `#/definitions/${rootName}`, definitions };
+}

--- a/server/src/routes/schema.ts
+++ b/server/src/routes/schema.ts
@@ -1,0 +1,22 @@
+import type { FastifyInstance } from 'fastify';
+import type { AppContext } from '../app.js';
+import { gvkJsonSchema } from '../kube/openapi-schema.js';
+import { HttpProblem, sendError } from '../util/errors.js';
+
+export function registerSchemaRoutes(app: FastifyInstance, ctx: AppContext): void {
+  /** JSON Schema for a group/version/kind, derived from the cluster's OpenAPI v3 (includes CRDs). */
+  app.get<{ Params: { ctx: string }; Querystring: { group?: string; version?: string; kind?: string } }>(
+    '/api/contexts/:ctx/schema',
+    async (req, reply) => {
+      try {
+        const { group = '', version, kind } = req.query;
+        if (!version || !kind) throw new HttpProblem(422, 'version and kind are required');
+        const handle = ctx.clusters.get(req.params.ctx);
+        return await gvkJsonSchema(handle, group, version, kind);
+      } catch (err) {
+        sendError(reply, err);
+        return reply;
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Load and expose Kubernetes/OpenAPI schema on the server via a new /schema endpoint.
- Add client wiring for schema queries and Monaco editor schema support.
- Update lockfile/workspace config for schema tooling changes.