### PR TITLE
Close dock tabs with Cmd/Ctrl+W

### DIFF
--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -14,6 +14,10 @@ declare global {
       setTitleBarOverlay(options: { color: string; symbolColor: string }): void;
       getAppInfo(): Promise<AppInfo | undefined>;
       checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
+      /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */
+      onCloseTab(callback: () => void): () => void;
+      /** Close the main window (fallback when no dock tab is open). */
+      closeWindow(): void;
     };
   }
 }

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import { Outlet } from 'react-router';
 import { TopBar } from './TopBar.js';
@@ -16,6 +16,19 @@ export function AppShell() {
   const back = useDetailStore((s) => s.back);
   const closeDetail = useDetailStore((s) => s.close);
   const dockRef = useRef<HTMLDivElement>(null);
+
+  // Cmd/Ctrl+W closes the focused dock tab (logs/terminal) instead of the whole
+  // window; when nothing is docked it falls back to closing the window.
+  useEffect(() => {
+    const desktop = window.kubusDesktop;
+    if (!desktop?.onCloseTab) return;
+    return desktop.onCloseTab(() => {
+      const dock = useDockStore.getState();
+      if (dock.open && dock.activeId) dock.closeTab(dock.activeId);
+      else desktop.closeWindow();
+    });
+  }, []);
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
       <TopBar />

--- a/docs/guide/logs.md
+++ b/docs/guide/logs.md
@@ -23,6 +23,7 @@ separate `kubectl logs -f` windows.
 - **From the palette** — ++ctrl+k++, find the resource, ++tab++ → **Logs**.
 
 Each stream opens as its own **tab** in the dock, so you can watch several at once.
+Close the focused tab with ++ctrl+w++ / ++cmd+w++ (desktop app).
 
 ## Time range
 

--- a/docs/guide/shell.md
+++ b/docs/guide/shell.md
@@ -23,7 +23,7 @@ Open a shell into any container:
 
 Kubus runs the Kubernetes `exec` API over a WebSocket. By default it tries **`bash`** and
 falls back to **`sh`**, so it works on minimal images too. The terminal resizes with the
-pane, and the session ends cleanly when you close the tab.
+pane, and the session ends cleanly when you close the tab (++ctrl+w++ / ++cmd+w++ on the desktop app).
 
 You can change the default shell (or set a custom path) in
 [Settings → Logs & terminal](settings.md#logs-terminal).

--- a/docs/guide/the-window.md
+++ b/docs/guide/the-window.md
@@ -51,7 +51,8 @@ shell gets its own tab, so you can keep several open at once. You can:
 
 - **resize** the dock by dragging its top edge,
 - **maximise** it to fill the window,
-- **toggle** it with the command *Toggle terminal dock* (++ctrl+k++ → `>`).
+- **toggle** it with the command *Toggle terminal dock* (++ctrl+k++ → `>`),
+- **close** the focused tab with ++ctrl+w++ / ++cmd+w++ (desktop app; with the dock empty this closes the window).
 
 [More on logs](logs.md) · [More on shells](shell.md)
 

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -20,6 +20,20 @@ is the hub — almost everything is reachable through it.
 | ++ctrl+f++ / ++cmd+f++ | Focus the table search |
 | `s` / `:` | Focus the table search |
 
+## Bottom dock (logs & terminals)
+
+| Shortcut | Action |
+| --- | --- |
+| ++ctrl+w++ / ++cmd+w++ | Close the focused log or terminal tab |
+
+When the dock is empty, ++ctrl+w++ / ++cmd+w++ closes the Kubus window as usual.
+
+!!! note "Desktop app only"
+
+    Closing a tab with ++ctrl+w++ / ++cmd+w++ is handled by the Kubus desktop app.
+    In a browser tab that shortcut is reserved by the browser and closes the tab
+    instead; use the tab's **×** button there.
+
 ## Inside the command palette
 
 | Key | Action |

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -282,8 +282,24 @@ function createWindow(url: string): void {
     void shell.openExternal(external);
     return { action: 'deny' };
   });
+  // Cmd/Ctrl+W is the OS "close window" accelerator. Hand it to the renderer so
+  // it can close the focused dock tab (logs/terminal) first, and only close the
+  // whole window when nothing is docked. preventDefault() stops the native menu
+  // accelerator from firing (and keeps the key out of the page).
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown' || input.key.toLowerCase() !== 'w' || input.alt || input.shift) return;
+    const closeChord = isMac ? input.meta && !input.control : input.control && !input.meta;
+    if (!closeChord) return;
+    event.preventDefault();
+    mainWindow?.webContents.send('kubus:close-tab');
+  });
   void mainWindow.loadURL(url);
 }
+
+ipcMain.on('kubus:close-window', (event) => {
+  if (!isMainWindowSender(event)) return;
+  mainWindow?.close();
+});
 
 ipcMain.on('kubus:set-titlebar-overlay', (event, options: unknown) => {
   if (isMac || !isMainWindowSender(event)) return;

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -23,4 +23,15 @@ contextBridge.exposeInMainWorld('kubusDesktop', {
   checkForUpdate(options?: { force?: boolean }) {
     return ipcRenderer.invoke('kubus:check-for-update', options);
   },
+  // Fires when the user presses the OS close-window chord (Cmd/Ctrl+W). Returns
+  // an unsubscribe. The renderer closes the focused dock tab, or calls
+  // closeWindow() when there is nothing docked to close.
+  onCloseTab(callback: () => void): () => void {
+    const listener = (): void => callback();
+    ipcRenderer.on('kubus:close-tab', listener);
+    return () => ipcRenderer.removeListener('kubus:close-tab', listener);
+  },
+  closeWindow(): void {
+    ipcRenderer.send('kubus:close-window');
+  },
 });


### PR DESCRIPTION
main.ts (before-input-event): intercepts the OS close chord — Cmd+W on macOS, Ctrl+W elsewhere — calls preventDefault() to suppress the native window-close, and forwards a kubus:close-tab message to the renderer. Also adds a kubus:close-window IPC handler for the fallback.

preload.ts: exposes two bridge methods — onCloseTab() (subscription, returns an unsubscribe) and closeWindow().

Renderer (AppShell.tsx): on the chord, closes the active dock tab; if nothing is docked, calls closeWindow() — reproducing the exact previous "close the window" behavior.