### PR TITLE
Improve topology, resource discovery, and navigation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.2",
+    "elkjs": "^0.11.1",
     "js-yaml": "^5.2.1",
     "monaco-editor": "^0.55.1",
     "monaco-yaml": "^5.5.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/actions/resource-actions.ts
+++ b/client/src/actions/resource-actions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import type { KubeObject, ResourceRef } from '@kubus/shared';
+import { gvkForResource, type KubeObject, type ResourceRef } from '@kubus/shared';
 import {
   resolveLogTargetPods,
   useCordon,
@@ -37,7 +37,8 @@ const CORDON: PaletteAction = { id: 'cordon-toggle', title: 'Cordon / Uncordon',
 const OPEN: PaletteAction = { id: 'open', title: 'Open details', kind: 'detail' };
 const MORE: PaletteAction = { id: 'open-more', title: 'More actions… (delete, scale, forward)', kind: 'detail' };
 
-export function actionsForRef(kind: string): PaletteAction[] {
+export function actionsForRef(ref: ResourceRef): PaletteAction[] {
+  const kind = gvkForResource(ref.group, ref.version, ref.plural)?.kind === ref.kind ? ref.kind : undefined;
   switch (kind) {
     case 'Pod':
       return [OPEN, LOGS, SHELL, MORE];

--- a/client/src/components/AgeCell.tsx
+++ b/client/src/components/AgeCell.tsx
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import type { TypographyProps } from '@mui/material/Typography';
 
 const tickListeners = new Set<() => void>();
 let tickTimer: number | undefined;
@@ -41,12 +42,12 @@ export function formatAge(timestamp: string | undefined): string {
 }
 
 /** Live-ticking relative age. */
-export function AgeCell({ timestamp }: { timestamp?: string }) {
+export function AgeCell({ timestamp, variant = 'body2' }: { timestamp?: string; variant?: TypographyProps['variant'] }) {
   useSyncExternalStore(subscribeTick, getTick);
   if (!timestamp) return null;
   return (
     <Tooltip title={new Date(timestamp).toLocaleString()}>
-      <Typography variant="body2" component="span">
+      <Typography variant={variant} component="span">
         {formatAge(timestamp)}
       </Typography>
     </Tooltip>

--- a/client/src/components/ApiResourceDrawer.tsx
+++ b/client/src/components/ApiResourceDrawer.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Tab from '@mui/material/Tab';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableRow from '@mui/material/TableRow';
+import Tabs from '@mui/material/Tabs';
+import Typography from '@mui/material/Typography';
+import CloseIcon from '@mui/icons-material/Close';
+import SchemaOutlinedIcon from '@mui/icons-material/SchemaOutlined';
+import { gvkLabel, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
+import { useResourceSchema } from '../api/queries.js';
+import { OpenApiSchemaDetail } from './detail/CrdDetail.js';
+
+interface Props {
+  open: boolean;
+  ctx?: string;
+  resource: ResourceKindInfo;
+  onClose: () => void;
+  onOpenCrd?: () => void;
+}
+
+export function ApiResourceDrawer({ open, ctx, resource, onClose, onOpenCrd }: Props) {
+  const [tab, setTab] = useState('overview');
+  const resourceKey = `${resource.group}/${resource.version}/${resource.plural}`;
+  useEffect(() => setTab('overview'), [resourceKey]);
+
+  const schemaRef = open && ctx ? { ctx, group: resource.group, version: resource.version, kind: resource.kind } : undefined;
+  const schema = useResourceSchema(schemaRef);
+  const apiVersion = resource.group ? `${resource.group}/${resource.version}` : resource.version;
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      slotProps={{
+        backdrop: { invisible: true },
+        paper: { sx: { top: '52px', height: 'calc(100% - 52px)', width: 'min(760px, 86vw)', maxWidth: '100vw' } },
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Stack direction="row" sx={{ px: 2, py: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center' }}>
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+              {ctx ? `${ctx} · ` : ''}API Resource
+            </Typography>
+            <Typography variant="subtitle1" noWrap sx={{ fontWeight: 650, lineHeight: 1.3 }}>
+              {pluralLabel(resource.kind)}
+            </Typography>
+          </Box>
+          <Box sx={{ flex: 1 }} />
+          <IconButton onClick={onClose} aria-label="Close API resource">
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+
+        <Tabs value={tab} onChange={(_event, value) => setTab(value as string)} sx={{ borderBottom: 1, borderColor: 'divider', minHeight: 36 }}>
+          <Tab value="overview" label="Overview" sx={{ minHeight: 36 }} />
+          <Tab value="schema" label="Schema" sx={{ minHeight: 36 }} />
+        </Tabs>
+
+        <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
+          {tab === 'overview' && (
+            <Stack spacing={2} sx={{ p: 2 }}>
+              <Box>
+                <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                  Definition
+                </Typography>
+                <Table size="small">
+                  <TableBody>
+                    <InfoRow label="GVK" value={gvkLabel(resource)} />
+                    <InfoRow label="API version" value={apiVersion} />
+                    <InfoRow label="Group" value={resource.group || 'core'} />
+                    <InfoRow label="Version" value={resource.version} />
+                    <InfoRow label="Kind" value={resource.kind} />
+                    <InfoRow label="Plural" value={resource.plural} />
+                    <InfoRow label="Scope" value={resource.namespaced ? 'Namespaced' : 'Cluster'} />
+                    <InfoRow label="Short names" value={resource.shortNames?.join(', ')} />
+                    <InfoRow label="Categories" value={resource.categories?.join(', ')} />
+                  </TableBody>
+                </Table>
+              </Box>
+
+              {resource.verbs.length > 0 && (
+                <Box>
+                  <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
+                    Supported operations
+                  </Typography>
+                  <Stack direction="row" sx={{ gap: 0.5, flexWrap: 'wrap' }}>
+                    {resource.verbs.map((verb) => <Chip key={verb} label={verb} size="small" variant="outlined" />)}
+                  </Stack>
+                </Box>
+              )}
+
+              {onOpenCrd && (
+                <>
+                  <Divider />
+                  <Box>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                      This API resource is backed by a CustomResourceDefinition.
+                    </Typography>
+                    <Button variant="outlined" startIcon={<SchemaOutlinedIcon />} onClick={onOpenCrd}>
+                      Open backing CRD
+                    </Button>
+                  </Box>
+                </>
+              )}
+            </Stack>
+          )}
+
+          {tab === 'schema' && (
+            <>
+              {!ctx && <Alert severity="info" sx={{ m: 2 }}>Select a cluster to load its OpenAPI schema.</Alert>}
+              {ctx && schema.isFetching && (
+                <Box sx={{ display: 'grid', placeItems: 'center', p: 4 }}>
+                  <CircularProgress size={28} />
+                </Box>
+              )}
+              {ctx && schema.error && (
+                <Alert severity="info" sx={{ m: 2 }}>
+                  {schema.error instanceof Error ? schema.error.message : 'The OpenAPI schema is unavailable.'}
+                </Alert>
+              )}
+              {schema.data && <OpenApiSchemaDetail document={schema.data} />}
+            </>
+          )}
+        </Box>
+      </Box>
+    </Drawer>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string | undefined }) {
+  if (!value) return null;
+  return (
+    <TableRow>
+      <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{label}</TableCell>
+      <TableCell sx={{ border: 0, wordBreak: 'break-all' }}>{value}</TableCell>
+    </TableRow>
+  );
+}

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -15,7 +15,7 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import { dump as dumpYaml } from 'js-yaml';
-import type { KubeObject } from '@kubus/shared';
+import { gvkForResource, type KubeObject } from '@kubus/shared';
 import { useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
 import { withoutManagedFields } from '../kube-display.js';
 import { YamlEditor, useYamlSchema } from './YamlEditor.js';
@@ -55,8 +55,11 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   const [reveal, setReveal] = useState(false);
   const [fullScreen, setFullScreen] = useState(false);
   const pushDetail = useDetailStore((s) => s.push);
-  const isSecret = sel?.kind === 'Secret';
-  const isCrd = sel?.kind === 'CustomResourceDefinition';
+  const registeredKind = sel && gvkForResource(sel.group, sel.version, sel.plural)?.kind;
+  const isCrdResource = sel?.group === 'apiextensions.k8s.io' && sel.version === 'v1' && sel.plural === 'customresourcedefinitions';
+  const behaviorKind = sel && (registeredKind === sel.kind || isCrdResource) ? sel.kind : undefined;
+  const isSecret = behaviorKind === 'Secret';
+  const isCrd = isCrdResource && sel?.kind === 'CustomResourceDefinition';
   const backingCrdSelection = sel?.custom && !isCrd && sel.group
     ? {
         ctx: sel.ctx,
@@ -69,7 +72,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
     : undefined;
 
   // Reset per-resource view state when the selection changes.
-  const selKey = sel ? `${sel.ctx}|${sel.kind}|${sel.namespace ?? ''}|${sel.name}` : '';
+  const selKey = sel ? `${sel.ctx}|${sel.group}|${sel.version}|${sel.plural}|${sel.namespace ?? ''}|${sel.name}` : '';
   useEffect(() => {
     setTab('overview');
     setReveal(false);
@@ -97,8 +100,8 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   );
   const schemaSource = isCrd ? obj : backingCrd;
   const versions = useMemo(() => crdVersions(schemaSource), [schemaSource]);
-  const hasMetrics = sel?.kind === 'Pod' || sel?.kind === 'Node';
-  const hasRolloutHistory = sel?.kind === 'Deployment' || sel?.kind === 'StatefulSet';
+  const hasMetrics = behaviorKind === 'Pod' || behaviorKind === 'Node';
+  const hasRolloutHistory = behaviorKind === 'Deployment' || behaviorKind === 'StatefulSet';
   const showMap = !isCrd;
   const drawerTopOffset = 52;
   const drawerPaperSx = {
@@ -204,7 +207,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
             {hasRolloutHistory && <Tab value="history" label="History" sx={{ minHeight: 36 }} />}
           </Tabs>
           <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
-            {tab === 'overview' && obj && <OverviewForKind kind={sel.kind} obj={obj} ctx={sel.ctx} />}
+            {tab === 'overview' && obj && <OverviewForKind kind={behaviorKind} obj={obj} ctx={sel.ctx} />}
             {tab.startsWith('crd:') && schemaSource && <CrdSchemaDetail obj={schemaSource} versionName={tab.slice('crd:'.length)} />}
             {showMap && tab === 'map' && (
               <Box sx={{ height: '100%', p: 1.25 }}>
@@ -244,7 +247,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
             )}
             {tab === 'events' && <EventsList events={events?.items ?? []} />}
             {tab === 'metrics' && hasMetrics && (
-              <MetricsChart ctx={sel.ctx} kind={sel.kind === 'Pod' ? 'pod' : 'node'} name={sel.name} namespace={sel.namespace} />
+              <MetricsChart ctx={sel.ctx} kind={behaviorKind === 'Pod' ? 'pod' : 'node'} name={sel.name} namespace={sel.namespace} />
             )}
             {tab === 'history' && hasRolloutHistory && obj && (
               <RolloutHistory ctx={sel.ctx} kind={sel.kind as 'Deployment' | 'StatefulSet'} obj={obj} />
@@ -256,7 +259,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
   );
 }
 
-function OverviewForKind({ kind, obj, ctx }: { kind: string; obj: KubeObject; ctx: string }) {
+function OverviewForKind({ kind, obj, ctx }: { kind: string | undefined; obj: KubeObject; ctx: string }) {
   switch (kind) {
     case 'Deployment':
       return <DeploymentDetail obj={obj} ctx={ctx} />;

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -108,7 +108,11 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
     top: `${drawerTopOffset}px`,
     height: `calc(100% - ${drawerTopOffset}px)`,
   };
-  const drawerWidth = fullScreen ? '100vw' : tab === 'map' ? 'min(1060px, 92vw)' : tab.startsWith('crd:') ? 'min(920px, 90vw)' : 'min(720px, 80vw)';
+  const drawerWidth = fullScreen
+    ? '100vw'
+    : tab === 'map'
+      ? 'min(1060px, 92vw)'
+      : 'min(720px, 80vw)';
   const mapNamespaces = sel?.namespace ? [sel.namespace] : [];
 
   const handleApply = async (text: string) => {

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -162,7 +162,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack }: Props) {
                 {obj && (
                   <>
                     {' · '}
-                    <AgeCell timestamp={obj.metadata.creationTimestamp} /> old
+                    <AgeCell timestamp={obj.metadata.creationTimestamp} variant="caption" /> old
                   </>
                 )}
               </Typography>

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -34,7 +34,7 @@ import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import BlockIcon from '@mui/icons-material/Block';
 import DownhillSkiingIcon from '@mui/icons-material/DownhillSkiing';
-import type { KubeObject, LogTargetKind } from '@kubus/shared';
+import { gvkForResource, type KubeObject, type LogTargetKind } from '@kubus/shared';
 import {
   resolveLogTargetPods,
   useCordon,
@@ -115,6 +115,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const addTab = useDockStore((s) => s.addTab);
 
   const { kind, obj, ctx } = target;
+  const actionKind = gvkForResource(target.group, target.version, target.plural)?.kind === kind ? kind : undefined;
   const name = obj.metadata.name;
   const namespace = obj.metadata.namespace;
   const isProtected = useIsProtected(ctx);
@@ -123,30 +124,30 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const ok = (text: string) => setToast({ severity: 'success', text });
   const fail = (err: unknown) => setToast({ severity: 'error', text: err instanceof Error ? err.message : String(err) });
 
-  const scalable = kind === 'Deployment' || kind === 'StatefulSet' || kind === 'ReplicaSet';
-  const restartable = kind === 'Deployment' || kind === 'StatefulSet' || kind === 'DaemonSet';
-  const isReplicaSet = kind === 'ReplicaSet';
-  const isPod = kind === 'Pod';
-  const isNode = kind === 'Node';
-  const isCronJob = kind === 'CronJob';
-  const isJob = kind === 'Job';
-  const canForward = isPod || kind === 'Service';
-  const canViewLogs = isLogTargetKind(kind);
+  const scalable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'ReplicaSet';
+  const restartable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'DaemonSet';
+  const isReplicaSet = actionKind === 'ReplicaSet';
+  const isPod = actionKind === 'Pod';
+  const isNode = actionKind === 'Node';
+  const isCronJob = actionKind === 'CronJob';
+  const isJob = actionKind === 'Job';
+  const canForward = isPod || actionKind === 'Service';
+  const canViewLogs = isLogTargetKind(actionKind ?? '');
   const unschedulable = isNode && !!(obj.spec as { unschedulable?: boolean })?.unschedulable;
   const cjSuspended = isCronJob && !!(obj.spec as { suspend?: boolean })?.suspend;
-  const isDeployment = kind === 'Deployment';
+  const isDeployment = actionKind === 'Deployment';
   const rolloutPaused = isDeployment && !!(obj.spec as { paused?: boolean })?.paused;
 
   const openLogs = async () => {
-    if (!isLogTargetKind(kind)) return;
+    if (!actionKind || !isLogTargetKind(actionKind)) return;
     if (!namespace) {
       fail(new Error(`${kind} has no namespace`));
       return;
     }
     setLogsBusy(true);
     try {
-      const { pods } = await resolveLogTargetPods({ ctx, group: target.group, version: target.version, plural: target.plural, kind, namespace, name });
-      if (!pods.length) throw new Error(`No pods found for ${kind} ${namespace}/${name}`);
+      const { pods } = await resolveLogTargetPods({ ctx, group: target.group, version: target.version, plural: target.plural, kind: actionKind, namespace, name });
+      if (!pods.length) throw new Error(`No pods found for ${actionKind} ${namespace}/${name}`);
       const byNamespace = new Map<string, string[]>();
       for (const pod of pods) {
         const names = byNamespace.get(pod.namespace);
@@ -157,7 +158,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
         addTab({
           kind: 'logs',
           id: dockTabId(),
-          title: pods.length === 1 ? `logs: ${podNames[0] ?? name}` : `logs: ${kind}/${name}`,
+          title: pods.length === 1 ? `logs: ${podNames[0] ?? name}` : `logs: ${actionKind}/${name}`,
           ctx,
           namespace: ns,
           pods: podNames,

--- a/client/src/components/StatusChip.tsx
+++ b/client/src/components/StatusChip.tsx
@@ -1,14 +1,15 @@
 import Box from '@mui/material/Box';
 import CircleIcon from '@mui/icons-material/Circle';
 
-const GOOD = new Set(['Running', 'Succeeded', 'Active', 'Bound', 'Ready', 'Available', 'Completed', 'deployed', 'True']);
-const BAD = new Set(['Failed', 'CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'Error', 'Evicted', 'Lost', 'NotReady', 'failed', 'OOMKilled']);
-const WARN = new Set(['Pending', 'Terminating', 'ContainerCreating', 'PodInitializing', 'Released', 'Unknown', 'SchedulingDisabled', 'pending-install', 'pending-upgrade', 'superseded', 'uninstalling']);
+const GOOD = new Set(['running', 'succeeded', 'active', 'bound', 'ready', 'available', 'completed', 'deployed', 'true', 'healthy', 'synced']);
+const BAD = new Set(['failed', 'crashloopbackoff', 'imagepullbackoff', 'errimagepull', 'error', 'evicted', 'lost', 'notready', 'oomkilled', 'false', 'unhealthy', 'degraded', 'stopped']);
+const WARN = new Set(['pending', 'terminating', 'containercreating', 'podinitializing', 'released', 'unknown', 'schedulingdisabled', 'pending-install', 'pending-upgrade', 'superseded', 'uninstalling']);
 
 export function statusColor(status: string): 'success' | 'error' | 'warning' | 'default' {
-  if (GOOD.has(status)) return 'success';
-  if (BAD.has(status)) return 'error';
-  if (WARN.has(status)) return 'warning';
+  const normalized = status.trim().toLowerCase();
+  if (GOOD.has(normalized)) return 'success';
+  if (BAD.has(normalized)) return 'error';
+  if (WARN.has(normalized)) return 'warning';
   return 'default';
 }
 

--- a/client/src/components/TopologyGraphImpl.tsx
+++ b/client/src/components/TopologyGraphImpl.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import '@xyflow/react/dist/style.css';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -6,26 +6,39 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import {
+  applyNodeChanges,
   Background,
+  BaseEdge,
   Controls,
+  EdgeLabelRenderer,
   Handle,
   MarkerType,
   Position,
   ReactFlow,
   type Edge,
+  type EdgeProps,
   type Node,
+  type NodeChange,
   type NodeProps,
+  type ReactFlowInstance,
 } from '@xyflow/react';
-import type { GraphEdge, GraphNode, GraphNodeStatus, RelationshipGraph } from '@kubus/shared';
+import type { GraphEdge, GraphNode, GraphNodeStatus } from '@kubus/shared';
 import { useTopologyGraphs } from '../api/queries.js';
 import { useDetailStore } from '../state/detail.js';
+import { layoutTopology, routeEdges, topologyNodeBox, type RoutePoint, type TopologyLayout } from './topology-layout.js';
 import type { TopologyGraphProps } from './TopologyGraph.js';
 
 interface TopologyNodeData extends Record<string, unknown> {
   graphNode: GraphNode;
 }
 
-const LAYERS: GraphNode['layer'][] = ['entry', 'route', 'service', 'workload', 'replicaset', 'pod', 'storage', 'node', 'operator', 'other'];
+interface TopologyEdgeData extends Record<string, unknown> {
+  routePoints: RoutePoint[];
+  labelPoint?: RoutePoint;
+}
+
+type TopologyFlowNode = Node<TopologyNodeData>;
+type TopologyFlowEdge = Edge<TopologyEdgeData>;
 
 const STATUS_COLOR: Record<GraphNodeStatus, string> = {
   success: '#2e7d32',
@@ -96,72 +109,190 @@ function TopologyNode({ data, selected }: NodeProps) {
   );
 }
 
-const nodeTypes = { topology: TopologyNode };
-
-function degreeMap(edges: GraphEdge[]): Map<string, number> {
-  const degree = new Map<string, number>();
-  for (const edge of edges) {
-    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1);
-    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1);
-  }
-  return degree;
+// The layout pre-routes every edge around the node boxes; this just draws the
+// polyline with rounded corners plus a background-colored halo so crossings
+// stay readable. Endpoints are snapped to the live handle positions so edges
+// stay attached while a node is dragged (routes are recomputed on drag stop).
+function TopologyEdge({ id, sourceX, sourceY, targetX, targetY, data, markerEnd, style, label, labelStyle, interactionWidth }: EdgeProps<TopologyFlowEdge>) {
+  const theme = useTheme();
+  const routePoints =
+    data?.routePoints && data.routePoints.length > 1
+      ? alignRouteEndpoints(data.routePoints, { x: sourceX, y: sourceY }, { x: targetX, y: targetY })
+      : [
+          { x: sourceX, y: sourceY },
+          { x: targetX, y: targetY },
+        ];
+  const path = roundedRoutePath(routePoints);
+  const mid = data?.labelPoint ?? pointAtFraction(routePoints, 0.5);
+  const strokeWidth = typeof style?.strokeWidth === 'number' ? style.strokeWidth : 1.7;
+  const opacity = typeof style?.opacity === 'number' ? style.opacity : 1;
+  return (
+    <>
+      <path
+        d={path}
+        fill="none"
+        stroke={theme.palette.background.default}
+        strokeWidth={strokeWidth + 4}
+        strokeLinejoin="round"
+        opacity={opacity}
+      />
+      <BaseEdge id={id} path={path} markerEnd={markerEnd} style={style} interactionWidth={interactionWidth ?? 24} />
+      {label && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${mid.x}px, ${mid.y}px)`,
+              background: theme.palette.background.paper,
+              color: typeof labelStyle?.fill === 'string' ? labelStyle.fill : undefined,
+              opacity,
+              fontSize: 11,
+              fontWeight: 700,
+              lineHeight: 1.2,
+              padding: '1px 4px',
+              borderRadius: 3,
+              pointerEvents: 'none',
+            }}
+          >
+            {label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
 }
 
-function flowLayout(graphs: RelationshipGraph[] | undefined, hideDisconnected: boolean) {
-  const flowNodes: Array<Node<TopologyNodeData>> = [];
-  const flowEdges: Edge[] = [];
-  const warnings: string[] = [];
-  const problemNodes: GraphNode[] = [];
-  let yOffset = 0;
+function alignRouteEndpoints(routePoints: RoutePoint[], source: RoutePoint, target: RoutePoint): RoutePoint[] {
+  const aligned = routePoints.map((point) => ({ ...point }));
+  const lastIndex = aligned.length - 1;
+  aligned[0] = { x: source.x, y: source.y };
+  aligned[lastIndex] = { x: target.x, y: target.y };
+  if (aligned.length > 2) {
+    aligned[1] = { ...aligned[1]!, y: source.y };
+    aligned[lastIndex - 1] = { ...aligned[lastIndex - 1]!, y: target.y };
+  }
+  return aligned;
+}
 
-  for (const graph of graphs ?? []) {
-    warnings.push(...graph.warnings.map((w) => `${graph.ctx}: ${w}`));
-    const degree = degreeMap(graph.edges);
-    const keep = new Set<string>();
-    const byLayer = new Map<GraphNode['layer'], GraphNode[]>();
-    for (const node of graph.nodes) {
-      const isProblem = node.status === 'warning' || node.status === 'error';
-      if (hideDisconnected && (degree.get(node.id) ?? 0) === 0 && !isProblem) continue;
-      keep.add(node.id);
-      if (isProblem) problemNodes.push(node);
-      const layerNodes = byLayer.get(node.layer);
-      if (layerNodes) layerNodes.push(node);
-      else byLayer.set(node.layer, [node]);
+function roundedRoutePath(points: RoutePoint[], radius = 14): string {
+  if (!points.length) return '';
+  const [start] = points;
+  const commands = [`M ${start!.x} ${start!.y}`];
+
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1]!;
+    const current = points[index]!;
+    const next = points[index + 1];
+
+    if (!next) {
+      commands.push(`L ${current.x} ${current.y}`);
+      continue;
     }
-    const layerHeight = Math.max(1, ...[...byLayer.values()].map((items) => items.length)) * 104;
+    const incomingDistance = Math.hypot(current.x - previous.x, current.y - previous.y);
+    const outgoingDistance = Math.hypot(next.x - current.x, next.y - current.y);
+    if (incomingDistance === 0 || outgoingDistance === 0) {
+      commands.push(`L ${current.x} ${current.y}`);
+      continue;
+    }
+    const cornerRadius = Math.min(radius, incomingDistance / 2, outgoingDistance / 2);
+    const beforeCorner = {
+      x: current.x - ((current.x - previous.x) / incomingDistance) * cornerRadius,
+      y: current.y - ((current.y - previous.y) / incomingDistance) * cornerRadius,
+    };
+    const afterCorner = {
+      x: current.x + ((next.x - current.x) / outgoingDistance) * cornerRadius,
+      y: current.y + ((next.y - current.y) / outgoingDistance) * cornerRadius,
+    };
+    commands.push(
+      `L ${round2(beforeCorner.x)} ${round2(beforeCorner.y)}`,
+      `Q ${current.x} ${current.y} ${round2(afterCorner.x)} ${round2(afterCorner.y)}`,
+    );
+  }
+  return commands.join(' ');
+}
 
-    for (const [layerIdx, layer] of LAYERS.entries()) {
-      const items = [...(byLayer.get(layer) ?? [])].sort((a, b) => `${a.ref.namespace ?? ''}/${a.label}`.localeCompare(`${b.ref.namespace ?? ''}/${b.label}`));
-      for (const [idx, node] of items.entries()) {
-        flowNodes.push({
-          id: node.id,
-          type: 'topology',
-          position: { x: layerIdx * 300, y: yOffset + idx * 104 },
-          data: { graphNode: node },
-          draggable: true,
-        });
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function pointAtFraction(points: RoutePoint[], fraction: number): RoutePoint {
+  let total = 0;
+  for (let index = 0; index < points.length - 1; index += 1) {
+    total += Math.hypot(points[index + 1]!.x - points[index]!.x, points[index + 1]!.y - points[index]!.y);
+  }
+  let remaining = total * fraction;
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const from = points[index]!;
+    const to = points[index + 1]!;
+    const length = Math.hypot(to.x - from.x, to.y - from.y);
+    if (length >= remaining) {
+      const t = length === 0 ? 0 : remaining / length;
+      return { x: from.x + (to.x - from.x) * t, y: from.y + (to.y - from.y) * t };
+    }
+    remaining -= length;
+  }
+  return points[points.length - 1] ?? { x: 0, y: 0 };
+}
+
+// Parallel edges of the same kind often share a corridor, which would stack
+// their labels on the exact same midpoint. Slide colliding labels along their
+// own route until they find a free spot.
+function placeEdgeLabels(edges: TopologyFlowEdge[]): TopologyFlowEdge[] {
+  const fractions = [0.5, 0.38, 0.62, 0.26, 0.74, 0.14, 0.86];
+  const occupied: RoutePoint[] = [];
+  return edges.map((edge) => {
+    const points = edge.data?.routePoints ?? [];
+    if (!edge.label || points.length < 2) return edge;
+    let chosen: RoutePoint | undefined;
+    for (const fraction of fractions) {
+      const candidate = pointAtFraction(points, fraction);
+      if (!occupied.some((point) => Math.abs(point.x - candidate.x) < 64 && Math.abs(point.y - candidate.y) < 18)) {
+        chosen = candidate;
+        break;
       }
     }
-    for (const edge of graph.edges) {
-      if (!keep.has(edge.source) || !keep.has(edge.target)) continue;
-      flowEdges.push({
-        id: edge.id,
-        source: edge.source,
-        target: edge.target,
-        label: edge.kind === 'owns' ? undefined : (edge.label ?? edge.kind),
-        type: 'smoothstep',
-        animated: edge.kind === 'routes' || edge.kind === 'selects',
-        markerEnd: { type: MarkerType.ArrowClosed, color: EDGE_COLOR[edge.kind] },
-        style: { strokeWidth: 1.7, stroke: EDGE_COLOR[edge.kind] },
-        labelStyle: { fill: EDGE_COLOR[edge.kind], fontWeight: 700, fontSize: 11 },
-        labelBgPadding: [4, 2],
-        labelBgBorderRadius: 3,
-      });
-    }
-    yOffset += layerHeight + 140;
-  }
+    chosen ??= pointAtFraction(points, 0.5);
+    occupied.push(chosen);
+    return { ...edge, data: { ...edge.data, routePoints: points, labelPoint: chosen } };
+  });
+}
 
-  return { nodes: flowNodes, edges: flowEdges, warnings, problemNodes };
+const nodeTypes = { topology: TopologyNode };
+const edgeTypes = { routed: TopologyEdge };
+
+interface FlowState {
+  nodes: TopologyFlowNode[];
+  edges: TopologyFlowEdge[];
+  warnings: string[];
+  problemNodes: GraphNode[];
+}
+
+const emptyFlow: FlowState = { nodes: [], edges: [], warnings: [], problemNodes: [] };
+
+function toFlowState(layout: TopologyLayout): FlowState {
+  return {
+    nodes: layout.nodes.map(({ node, position }) => ({
+      id: node.id,
+      type: 'topology',
+      position,
+      data: { graphNode: node },
+      draggable: true,
+    })),
+    edges: placeEdgeLabels(layout.edges.map(({ edge, routePoints }) => ({
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      type: 'routed',
+      label: edge.kind === 'owns' ? undefined : (edge.label ?? edge.kind),
+      animated: edge.kind === 'routes' || edge.kind === 'selects',
+      markerEnd: { type: MarkerType.ArrowClosed, color: EDGE_COLOR[edge.kind] },
+      style: { strokeWidth: 1.7, stroke: EDGE_COLOR[edge.kind] },
+      labelStyle: { fill: EDGE_COLOR[edge.kind], fontWeight: 700, fontSize: 11 },
+      data: { routePoints },
+    }))),
+    warnings: layout.warnings,
+    problemNodes: layout.problemNodes,
+  };
 }
 
 function isFocusedNode(node: GraphNode, focus: NonNullable<TopologyGraphProps['focus']>): boolean {
@@ -186,32 +317,78 @@ export default function TopologyGraphImpl({
   const openDetail = useDetailStore((s) => s.open);
   const pushDetail = useDetailStore((s) => s.push);
   const [selectedNodeId, setSelectedNodeId] = useState<string>();
-  const layout = useMemo(() => flowLayout(graphs, hideDisconnected), [graphs, hideDisconnected]);
-  const activeSelectedNodeId = layout.nodes.some((node) => node.id === selectedNodeId) ? selectedNodeId : undefined;
+  const [flow, setFlow] = useState<FlowState>(emptyFlow);
+  const [layoutPending, setLayoutPending] = useState(false);
+  const instanceRef = useRef<ReactFlowInstance<TopologyFlowNode, TopologyFlowEdge> | null>(null);
+
+  // ELK layout is async, so positions land in state instead of a useMemo.
+  useEffect(() => {
+    let cancelled = false;
+    setLayoutPending(true);
+    layoutTopology(graphs, hideDisconnected)
+      .then((layout) => {
+        if (cancelled) return;
+        setFlow(toFlowState(layout));
+        setLayoutPending(false);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        console.error('topology layout failed', err);
+        setFlow(emptyFlow);
+        setLayoutPending(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [graphs, hideDisconnected]);
+
+  // Re-fit the viewport when the set of displayed nodes changes (not on drag).
+  const nodeIdsKey = useMemo(() => flow.nodes.map((node) => node.id).sort().join(), [flow.nodes]);
+  useEffect(() => {
+    if (!nodeIdsKey) return;
+    const frame = requestAnimationFrame(() => {
+      void instanceRef.current?.fitView({ maxZoom: 1 });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [nodeIdsKey]);
+
+  const onNodesChange = useCallback((changes: NodeChange<TopologyFlowNode>[]) => {
+    setFlow((f) => ({ ...f, nodes: applyNodeChanges(changes, f.nodes) }));
+  }, []);
+
+  const onNodeDragStop = useCallback(() => {
+    setFlow((f) => {
+      const boxes = f.nodes.map((node) => topologyNodeBox(node.id, node.position, node.data.graphNode));
+      const routes = routeEdges(boxes, f.edges);
+      return { ...f, edges: placeEdgeLabels(f.edges.map((edge) => ({ ...edge, data: { routePoints: routes.get(edge.id) ?? [] } }))) };
+    });
+  }, []);
+
+  const activeSelectedNodeId = flow.nodes.some((node) => node.id === selectedNodeId) ? selectedNodeId : undefined;
 
   const connectedNodeIds = useMemo(() => {
     if (!activeSelectedNodeId) return undefined;
     const connected = new Set([activeSelectedNodeId]);
-    for (const edge of layout.edges) {
+    for (const edge of flow.edges) {
       if (edge.source === activeSelectedNodeId) connected.add(edge.target);
       if (edge.target === activeSelectedNodeId) connected.add(edge.source);
     }
     return connected;
-  }, [activeSelectedNodeId, layout.edges]);
+  }, [activeSelectedNodeId, flow.edges]);
 
-  const nodes = useMemo(
+  const nodes = useMemo<TopologyFlowNode[]>(
     () =>
-      layout.nodes.map((node) => ({
+      flow.nodes.map((node) => ({
         ...node,
         selected: node.id === activeSelectedNodeId,
         style: { ...node.style, opacity: !connectedNodeIds || connectedNodeIds.has(node.id) ? 1 : 0.22 },
       })),
-    [activeSelectedNodeId, connectedNodeIds, layout.nodes],
+    [activeSelectedNodeId, connectedNodeIds, flow.nodes],
   );
 
-  const edges = useMemo(
+  const edges = useMemo<TopologyFlowEdge[]>(
     () =>
-      layout.edges.map((edge) => {
+      flow.edges.map((edge) => {
         const connected = !activeSelectedNodeId || edge.source === activeSelectedNodeId || edge.target === activeSelectedNodeId;
         return {
           ...edge,
@@ -220,9 +397,9 @@ export default function TopologyGraphImpl({
           labelStyle: { ...edge.labelStyle, opacity: connected ? 1 : 0.1 },
         };
       }),
-    [activeSelectedNodeId, layout.edges],
+    [activeSelectedNodeId, flow.edges],
   );
-  const { warnings, problemNodes } = layout;
+  const { warnings, problemNodes } = flow;
 
   const inspectNode = (node: Node) => {
     const graphNode = (node.data as TopologyNodeData).graphNode;
@@ -282,12 +459,18 @@ export default function TopologyGraphImpl({
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
         fitView
         minZoom={0.12}
         maxZoom={2}
         nodesDraggable
         nodesConnectable={false}
         elementsSelectable
+        onInit={(instance) => {
+          instanceRef.current = instance;
+        }}
+        onNodesChange={onNodesChange}
+        onNodeDragStop={onNodeDragStop}
         onNodeClick={(_event, node) => setSelectedNodeId(node.id)}
         onNodeDoubleClick={(_event, node) => inspectNode(node)}
         onPaneClick={() => setSelectedNodeId(undefined)}
@@ -333,7 +516,7 @@ export default function TopologyGraphImpl({
         )}
       </Box>
 
-      {!isLoading && nodes.length === 0 && (
+      {!isLoading && !layoutPending && nodes.length === 0 && (
         <Box sx={{ position: 'absolute', inset: 0, display: 'grid', placeItems: 'center', pointerEvents: 'none' }}>
           <Box sx={{ textAlign: 'center', px: 2 }}>
             <Typography variant="subtitle2">{emptyTitle}</Typography>

--- a/client/src/components/columns.tsx
+++ b/client/src/components/columns.tsx
@@ -74,7 +74,8 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
   labels: (opts) => ({
     field: 'labels',
     headerName: 'Labels',
-    width: 220,
+    flex: 1,
+    minWidth: 220,
     sortable: false,
     valueGetter: (_v, row) =>
       Object.entries(obj(row).metadata.labels ?? {})

--- a/client/src/components/columns.tsx
+++ b/client/src/components/columns.tsx
@@ -768,6 +768,7 @@ export function makeNodeAllocationLookup(pods: ClusterRow[]): NodeAllocationLook
 export function buildCrdColumns(cols: PrinterColumn[]): Col[] {
   return cols.map((c, i): Col => {
     const numeric = c.type === 'integer' || c.type === 'number';
+    const statusLike = /^(ready|readiness|state|status|phase|health|healthy|available)$/i.test(c.name.trim());
     const value = (row: ClusterRow): unknown => evalPrinterColumnPath(row.obj, c.jsonPath);
     return {
       field: `crd_${i}_${c.name}`,
@@ -782,7 +783,12 @@ export function buildCrdColumns(cols: PrinterColumn[]): Col[] {
         if (typeof v === 'object') return JSON.stringify(v).slice(0, 200);
         return String(v);
       },
-      renderCell: c.type === 'date' ? (params) => <AgeCell timestamp={(value(params.row) as string | undefined) || undefined} /> : undefined,
+      renderCell:
+        c.type === 'date'
+          ? (params) => <AgeCell timestamp={(value(params.row) as string | undefined) || undefined} />
+          : statusLike
+            ? (params) => <StatusChip status={String(params.value ?? '')} />
+            : undefined,
     };
   });
 }

--- a/client/src/components/detail/CrdDetail.tsx
+++ b/client/src/components/detail/CrdDetail.tsx
@@ -15,6 +15,7 @@ import type { KubeObject } from '@kubus/shared';
 import { GenericDetail } from './GenericDetail.js';
 
 interface JsonSchema {
+  $ref?: string;
   type?: string | string[];
   format?: string;
   title?: string;
@@ -29,6 +30,7 @@ interface JsonSchema {
   oneOf?: JsonSchema[];
   anyOf?: JsonSchema[];
   allOf?: JsonSchema[];
+  definitions?: Record<string, JsonSchema>;
   'x-kubernetes-int-or-string'?: boolean;
   'x-kubernetes-preserve-unknown-fields'?: boolean;
   'x-kubernetes-list-type'?: string;
@@ -177,7 +179,7 @@ export function CrdSchemaDetail({ obj, versionName }: { obj: KubeObject; version
       )}
       <Box>
         {rootFields.map(({ name, fieldSchema, required }) => (
-          <SchemaField key={name} name={name} schema={fieldSchema} required={required} depth={0} />
+          <SchemaField key={name} name={name} schema={fieldSchema} required={required} depth={0} definitions={{}} />
         ))}
       </Box>
       {printerColumns.length > 0 && (
@@ -216,6 +218,28 @@ export function CrdSchemaDetail({ obj, versionName }: { obj: KubeObject; version
   );
 }
 
+/** Expandable schema tree for the self-contained OpenAPI document returned by /schema. */
+export function OpenApiSchemaDetail({ document }: { document: Record<string, unknown> }) {
+  const schema = document as JsonSchema;
+  const definitions = schema.definitions ?? {};
+  const rootFields = rootSchemaFields(resolveSchema(schema, definitions), definitions);
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {rootFields.map(({ name, fieldSchema, required }) => (
+        <SchemaField
+          key={name}
+          name={name}
+          schema={fieldSchema}
+          required={required}
+          depth={0}
+          definitions={definitions}
+        />
+      ))}
+    </Box>
+  );
+}
+
 function InfoRow({ label, value }: { label: string; value: string | undefined }) {
   if (!value) return null;
   return (
@@ -226,9 +250,9 @@ function InfoRow({ label, value }: { label: string; value: string | undefined })
   );
 }
 
-function rootSchemaFields(schema: JsonSchema | undefined): Array<{ name: string; fieldSchema: JsonSchema; required: boolean }> {
-  const properties = mergedProperties(schema);
-  const required = new Set(mergedRequired(schema));
+function rootSchemaFields(schema: JsonSchema | undefined, definitions: Record<string, JsonSchema> = {}): Array<{ name: string; fieldSchema: JsonSchema; required: boolean }> {
+  const properties = mergedProperties(schema, definitions);
+  const required = new Set(mergedRequired(schema, definitions));
   const names = new Set([...Object.keys(STANDARD_ROOT_FIELDS), ...Object.keys(properties)]);
   return [...names].map((name) => ({
     name,
@@ -237,14 +261,27 @@ function rootSchemaFields(schema: JsonSchema | undefined): Array<{ name: string;
   }));
 }
 
-function SchemaField({ name, schema, required, depth }: { name: string; schema: JsonSchema; required: boolean; depth: number }) {
-  const description = schema.description ?? schema.title;
-  const nestedChildren = childFields(schema);
+function SchemaField({
+  name,
+  schema,
+  required,
+  depth,
+  definitions,
+}: {
+  name: string;
+  schema: JsonSchema;
+  required: boolean;
+  depth: number;
+  definitions: Record<string, JsonSchema>;
+}) {
+  const resolvedSchema = resolveSchema(schema, definitions);
+  const description = resolvedSchema.description ?? resolvedSchema.title;
+  const nestedChildren = childFields(resolvedSchema, definitions);
   const children = depth < MAX_SCHEMA_DEPTH ? nestedChildren : [];
   const canExpand = children.length > 0;
   const [expanded, setExpanded] = useState(false);
-  const meta = schemaMeta(schema);
-  const typeLabel = displayType(schema);
+  const meta = schemaMeta(resolvedSchema);
+  const typeLabel = displayType(resolvedSchema, definitions);
 
   const toggleExpanded = () => {
     // Don't collapse/expand when the user is selecting description text.
@@ -289,8 +326,8 @@ function SchemaField({ name, schema, required, depth }: { name: string; schema: 
                 {typeLabel}
               </Typography>
               {required && <Chip label="required" size="small" variant="outlined" sx={{ height: 18, fontSize: 10 }} />}
-              {schema.nullable && <Chip label="nullable" size="small" variant="outlined" sx={{ height: 18, fontSize: 10 }} />}
-              {schema['x-kubernetes-preserve-unknown-fields'] && <Chip label="preserve unknown" size="small" variant="outlined" sx={{ height: 18, fontSize: 10 }} />}
+              {resolvedSchema.nullable && <Chip label="nullable" size="small" variant="outlined" sx={{ height: 18, fontSize: 10 }} />}
+              {resolvedSchema['x-kubernetes-preserve-unknown-fields'] && <Chip label="preserve unknown" size="small" variant="outlined" sx={{ height: 18, fontSize: 10 }} />}
               {meta.map((m) => (
                 <Chip key={m} label={m} size="small" variant="outlined" sx={{ height: 18, fontSize: 10, maxWidth: 360 }} title={m} />
               ))}
@@ -309,42 +346,57 @@ function SchemaField({ name, schema, required, depth }: { name: string; schema: 
         </Typography>
       )}
       {expanded && children.map((child) => (
-        <SchemaField key={child.name} name={child.name} schema={child.fieldSchema} required={child.required} depth={depth + 1} />
+        <SchemaField
+          key={child.name}
+          name={child.name}
+          schema={child.fieldSchema}
+          required={child.required}
+          depth={depth + 1}
+          definitions={definitions}
+        />
       ))}
     </Box>
   );
 }
 
-function childFields(schema: JsonSchema): Array<{ name: string; fieldSchema: JsonSchema; required: boolean }> {
-  const container = schema.type === 'array' && schema.items ? schema.items : schema;
-  const properties = mergedProperties(container);
-  const required = new Set(mergedRequired(container));
+function childFields(schema: JsonSchema, definitions: Record<string, JsonSchema>): Array<{ name: string; fieldSchema: JsonSchema; required: boolean }> {
+  const container = resolveSchema(schema.type === 'array' && schema.items ? schema.items : schema, definitions);
+  const properties = mergedProperties(container, definitions);
+  const required = new Set(mergedRequired(container, definitions));
   const entries = Object.entries(properties).map(([name, fieldSchema]) => ({ name, fieldSchema, required: required.has(name) }));
 
   if (entries.length > 0) return entries;
   const additional = container.additionalProperties;
   if (typeof additional === 'object' && additional) {
-    const mapChildren = Object.entries(mergedProperties(additional)).map(([name, fieldSchema]) => ({
+    const mapChildren = Object.entries(mergedProperties(additional, definitions)).map(([name, fieldSchema]) => ({
       name: `<value>.${name}`,
       fieldSchema,
-      required: mergedRequired(additional).includes(name),
+      required: mergedRequired(additional, definitions).includes(name),
     }));
     if (mapChildren.length > 0) return mapChildren;
   }
   return [];
 }
 
-function mergedProperties(schema: JsonSchema | undefined): Record<string, JsonSchema> {
+function mergedProperties(schema: JsonSchema | undefined, definitions: Record<string, JsonSchema>): Record<string, JsonSchema> {
   if (!schema) return {};
+  const resolved = resolveSchema(schema, definitions);
   return {
-    ...schema.allOf?.reduce<Record<string, JsonSchema>>((acc, branch) => ({ ...acc, ...mergedProperties(branch) }), {}),
-    ...(schema.properties ?? {}),
+    ...resolved.allOf?.reduce<Record<string, JsonSchema>>((acc, branch) => ({ ...acc, ...mergedProperties(branch, definitions) }), {}),
+    ...(resolved.properties ?? {}),
   };
 }
 
-function mergedRequired(schema: JsonSchema | undefined): string[] {
+function mergedRequired(schema: JsonSchema | undefined, definitions: Record<string, JsonSchema>): string[] {
   if (!schema) return [];
-  return [...new Set([...(schema.allOf?.flatMap((branch) => mergedRequired(branch)) ?? []), ...(schema.required ?? [])])];
+  const resolved = resolveSchema(schema, definitions);
+  return [...new Set([...(resolved.allOf?.flatMap((branch) => mergedRequired(branch, definitions)) ?? []), ...(resolved.required ?? [])])];
+}
+
+function resolveSchema(schema: JsonSchema, definitions: Record<string, JsonSchema>): JsonSchema {
+  if (!schema.$ref?.startsWith('#/definitions/')) return schema;
+  const referenced = definitions[schema.$ref.slice('#/definitions/'.length)];
+  return referenced ? { ...referenced, ...schema, $ref: undefined } : schema;
 }
 
 function mergeSchema(base: JsonSchema | undefined, override: JsonSchema | undefined): JsonSchema {
@@ -375,17 +427,18 @@ function typeColor(typeLabel: string): string {
   }
 }
 
-function displayType(schema: JsonSchema): string {
-  if (schema['x-kubernetes-int-or-string']) return 'int-or-string';
-  if (Array.isArray(schema.type)) return schema.type.join(' | ');
-  if (schema.type === 'array') return `array<${displayType(schema.items ?? {})}>`;
-  if (schema.type === 'object' && typeof schema.additionalProperties === 'object') {
-    return `map<${displayType(schema.additionalProperties)}>`;
+function displayType(schema: JsonSchema, definitions: Record<string, JsonSchema> = {}): string {
+  const resolved = resolveSchema(schema, definitions);
+  if (resolved['x-kubernetes-int-or-string']) return 'int-or-string';
+  if (Array.isArray(resolved.type)) return resolved.type.join(' | ');
+  if (resolved.type === 'array') return `array<${displayType(resolved.items ?? {}, definitions)}>`;
+  if (resolved.type === 'object' && typeof resolved.additionalProperties === 'object') {
+    return `map<${displayType(resolved.additionalProperties, definitions)}>`;
   }
-  if (schema.type) return schema.format ? `${schema.type} (${schema.format})` : schema.type;
-  const union = schema.oneOf ?? schema.anyOf;
-  if (union?.length) return union.map((s) => displayType(s)).join(' | ');
-  if (schema.allOf?.length) return schema.allOf.map((s) => displayType(s)).find((t) => t !== 'unknown') ?? 'object';
+  if (resolved.type) return resolved.format ? `${resolved.type} (${resolved.format})` : resolved.type;
+  const union = resolved.oneOf ?? resolved.anyOf;
+  if (union?.length) return union.map((s) => displayType(s, definitions)).join(' | ');
+  if (resolved.allOf?.length) return resolved.allOf.map((s) => displayType(s, definitions)).find((t) => t !== 'unknown') ?? 'object';
   return 'unknown';
 }
 

--- a/client/src/components/topology-layout.ts
+++ b/client/src/components/topology-layout.ts
@@ -1,0 +1,478 @@
+import ELK, { type ElkExtendedEdge, type ElkNode } from 'elkjs/lib/elk.bundled.js';
+import type { GraphEdge, GraphNode, RelationshipGraph } from '@kubus/shared';
+
+export const NODE_WIDTH = 236;
+
+export const LAYERS: GraphNode['layer'][] = ['entry', 'route', 'service', 'workload', 'replicaset', 'pod', 'storage', 'node', 'operator', 'other'];
+
+const elk = new ELK();
+
+const layerSpacing = 150;
+const nodeSpacing = 48;
+const graphGap = 140;
+const routePadding = 18;
+const routeEndpointOffset = 34;
+const routeOuterMargin = 160;
+const routeBendPenalty = 42;
+
+export interface RoutePoint {
+  x: number;
+  y: number;
+}
+
+export interface LayoutBox {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PlacedNode {
+  node: GraphNode;
+  position: RoutePoint;
+}
+
+export interface RoutedGraphEdge {
+  edge: GraphEdge;
+  routePoints: RoutePoint[];
+}
+
+export interface TopologyLayout {
+  nodes: PlacedNode[];
+  edges: RoutedGraphEdge[];
+  warnings: string[];
+  problemNodes: GraphNode[];
+}
+
+// Mirrors the rendered TopologyNode: chip row + title, plus optional
+// sublabel/reason rows. Only used to size layout/routing obstacle boxes,
+// so being a few pixels off is harmless.
+export function estimateNodeHeight(node: GraphNode): number {
+  return 58 + (node.sublabel ? 20 : 0) + (node.reason ? 22 : 0);
+}
+
+export function topologyNodeBox(id: string, position: RoutePoint, node: GraphNode): LayoutBox {
+  return { id, x: position.x, y: position.y, width: NODE_WIDTH, height: estimateNodeHeight(node) };
+}
+
+function degreeMap(edges: GraphEdge[]): Map<string, number> {
+  const degree = new Map<string, number>();
+  for (const edge of edges) {
+    degree.set(edge.source, (degree.get(edge.source) ?? 0) + 1);
+    degree.set(edge.target, (degree.get(edge.target) ?? 0) + 1);
+  }
+  return degree;
+}
+
+// Lays out each graph with ELK (layered, semantic layers pinned via
+// partitioning so columns keep their entry→…→other order), stacks the graphs
+// vertically, then routes every edge orthogonally around the node boxes so
+// lines never run underneath panels.
+export async function layoutTopology(graphs: RelationshipGraph[] | undefined, hideDisconnected: boolean): Promise<TopologyLayout> {
+  const placed: PlacedNode[] = [];
+  const keptEdges: GraphEdge[] = [];
+  const warnings: string[] = [];
+  const problemNodes: GraphNode[] = [];
+  let yOffset = 0;
+
+  for (const [graphIdx, graph] of (graphs ?? []).entries()) {
+    warnings.push(...graph.warnings.map((w) => `${graph.ctx}: ${w}`));
+    const degree = degreeMap(graph.edges);
+    const kept: GraphNode[] = [];
+    const keep = new Set<string>();
+    for (const node of graph.nodes) {
+      const isProblem = node.status === 'warning' || node.status === 'error';
+      if (hideDisconnected && (degree.get(node.id) ?? 0) === 0 && !isProblem) continue;
+      keep.add(node.id);
+      kept.push(node);
+      if (isProblem) problemNodes.push(node);
+    }
+    if (kept.length === 0) continue;
+    const graphEdges = graph.edges.filter((edge) => keep.has(edge.source) && keep.has(edge.target));
+    keptEdges.push(...graphEdges);
+
+    const elkGraph: ElkNode = {
+      id: `graph-${graphIdx}`,
+      layoutOptions: {
+        'elk.algorithm': 'layered',
+        'elk.direction': 'RIGHT',
+        'elk.edgeRouting': 'ORTHOGONAL',
+        'elk.partitioning.activate': 'true',
+        'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
+        'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+        'elk.layered.layering.strategy': 'NETWORK_SIMPLEX',
+        'elk.layered.spacing.nodeNodeBetweenLayers': `${layerSpacing}`,
+        'elk.spacing.nodeNode': `${nodeSpacing}`,
+        'elk.spacing.edgeEdge': '26',
+        'elk.spacing.edgeNode': '42',
+        'elk.padding': '[top=24,left=24,bottom=24,right=24]',
+      },
+      children: kept.map((node) => ({
+        id: node.id,
+        width: NODE_WIDTH,
+        height: estimateNodeHeight(node),
+        layoutOptions: {
+          'elk.partitioning.partition': `${Math.max(0, LAYERS.indexOf(node.layer))}`,
+        },
+      })),
+      edges: graphEdges.map<ElkExtendedEdge>((edge) => ({
+        id: edge.id,
+        sources: [edge.source],
+        targets: [edge.target],
+      })),
+    };
+
+    const result = await elk.layout(elkGraph);
+    const layoutById = new Map((result.children ?? []).map((child) => [child.id, child]));
+    let maxY = yOffset;
+    for (const node of kept) {
+      const child = layoutById.get(node.id);
+      const position = { x: Math.round(child?.x ?? 0), y: Math.round(child?.y ?? 0) + yOffset };
+      placed.push({ node, position });
+      maxY = Math.max(maxY, position.y + estimateNodeHeight(node));
+    }
+    yOffset = maxY + graphGap;
+  }
+
+  const boxes = placed.map((p) => topologyNodeBox(p.node.id, p.position, p.node));
+  const routes = routeEdges(boxes, keptEdges);
+  return {
+    nodes: placed,
+    edges: keptEdges.map((edge) => ({ edge, routePoints: routes.get(edge.id) ?? [] })),
+    warnings,
+    problemNodes,
+  };
+}
+
+// Routes every edge from the right side of its source box to the left side of
+// its target box, avoiding all node boxes. Also used to re-route after the
+// user drags a node.
+export function routeEdges(boxes: LayoutBox[], edges: Array<{ id: string; source: string; target: string }>): Map<string, RoutePoint[]> {
+  const boxById = new Map(boxes.map((box) => [box.id, box]));
+  const bounds = boxesBounds(boxes);
+  const obstacles = boxes.map((box) => expandedBox(box, routePadding));
+  const routes = new Map<string, RoutePoint[]>();
+  for (const edge of edges) {
+    const source = boxById.get(edge.source);
+    const target = boxById.get(edge.target);
+    if (!source || !target) continue;
+    routes.set(edge.id, routeSingleEdge(source, target, boxes, obstacles, bounds));
+  }
+  return routes;
+}
+
+function routeSingleEdge(source: LayoutBox, target: LayoutBox, boxes: LayoutBox[], obstacles: LayoutBox[], bounds: LayoutBox): RoutePoint[] {
+  const start: RoutePoint = { x: source.x + source.width, y: Math.round(source.y + source.height / 2) };
+  const end: RoutePoint = { x: target.x, y: Math.round(target.y + target.height / 2) };
+
+  // Cheap path first: a single bend in the gap between layers covers the vast
+  // majority of forward edges without touching the grid router.
+  if (start.x <= end.x) {
+    const direct = compactRoute([
+      start,
+      { x: Math.round((start.x + end.x) / 2), y: start.y },
+      { x: Math.round((start.x + end.x) / 2), y: end.y },
+      end,
+    ]);
+    if (!routeIntersectsBoxes(direct, boxes)) return direct;
+  }
+
+  const routeStart = { x: start.x + routeEndpointOffset, y: start.y };
+  const routeEnd = { x: end.x - routeEndpointOffset, y: end.y };
+  // Restrict the routing grid to boxes near the corridor between the two
+  // endpoints — candidate coordinates only span that region, so far-away
+  // boxes can never intersect a candidate segment.
+  const corridor = expandedBox(pointsBounds([routeStart, routeEnd]), routeOuterMargin + routePadding + 1);
+  const localObstacles = obstacles.filter((box) => boxesIntersect(box, corridor));
+  const routed = findOrthogonalRoute(routeStart, routeEnd, localObstacles, pointsBounds([routeStart, routeEnd]));
+
+  return compactRoute([
+    start,
+    routeStart,
+    ...(routed ?? fallbackRoute(routeStart, routeEnd, bounds)).slice(1, -1),
+    routeEnd,
+    end,
+  ]);
+}
+
+// A* over the Hanan grid spanned by obstacle borders, with a penalty per bend
+// so routes prefer straight runs.
+function findOrthogonalRoute(start: RoutePoint, end: RoutePoint, obstacles: LayoutBox[], bounds: LayoutBox): RoutePoint[] | null {
+  const xCoordinates = uniqueSortedNumbers([
+    start.x,
+    end.x,
+    bounds.x - routeOuterMargin,
+    bounds.x + bounds.width + routeOuterMargin,
+    ...obstacles.flatMap((box) => [box.x - routePadding, box.x + box.width + routePadding]),
+  ]);
+  const yCoordinates = uniqueSortedNumbers([
+    start.y,
+    end.y,
+    bounds.y - routeOuterMargin,
+    bounds.y + bounds.height + routeOuterMargin,
+    ...obstacles.flatMap((box) => [box.y - routePadding, box.y + box.height + routePadding]),
+  ]);
+  const points: RoutePoint[] = [];
+  const pointIndex = new Map<string, number>();
+
+  for (const y of yCoordinates) {
+    for (const x of xCoordinates) {
+      const point = { x, y };
+      if (obstacles.some((box) => pointInsideBox(point, box))) continue;
+      pointIndex.set(pointKey(point), points.length);
+      points.push(point);
+    }
+  }
+
+  const startIndex = pointIndex.get(pointKey(start));
+  const endIndex = pointIndex.get(pointKey(end));
+  if (startIndex === undefined || endIndex === undefined) return null;
+
+  const adjacency = buildRouteAdjacency(points, obstacles);
+  const path = shortestRoute(points, adjacency, startIndex, endIndex);
+  return path ? compactRoute(path.map((index) => points[index]!)) : null;
+}
+
+function buildRouteAdjacency(points: RoutePoint[], obstacles: LayoutBox[]): number[][] {
+  const adjacency = Array.from({ length: points.length }, () => [] as number[]);
+  const rows = new Map<number, number[]>();
+  const columns = new Map<number, number[]>();
+
+  points.forEach((point, index) => {
+    rows.set(point.y, [...(rows.get(point.y) ?? []), index]);
+    columns.set(point.x, [...(columns.get(point.x) ?? []), index]);
+  });
+
+  for (const row of rows.values()) {
+    row.sort((first, second) => points[first]!.x - points[second]!.x);
+    connectVisibleNeighbors(row, adjacency, points, obstacles);
+  }
+  for (const column of columns.values()) {
+    column.sort((first, second) => points[first]!.y - points[second]!.y);
+    connectVisibleNeighbors(column, adjacency, points, obstacles);
+  }
+  return adjacency;
+}
+
+function connectVisibleNeighbors(sortedIndexes: number[], adjacency: number[][], points: RoutePoint[], obstacles: LayoutBox[]): void {
+  for (let index = 0; index < sortedIndexes.length - 1; index += 1) {
+    const first = sortedIndexes[index]!;
+    const second = sortedIndexes[index + 1]!;
+    if (obstacles.some((box) => segmentIntersectsBox(points[first]!, points[second]!, box))) continue;
+    adjacency[first]!.push(second);
+    adjacency[second]!.push(first);
+  }
+}
+
+function shortestRoute(points: RoutePoint[], adjacency: number[][], startIndex: number, endIndex: number): number[] | null {
+  const directions = 3;
+  const directionStart = 0;
+  const directionHorizontal = 1;
+  const directionVertical = 2;
+  const totalStates = points.length * directions;
+  const distances = Array.from({ length: totalStates }, () => Number.POSITIVE_INFINITY);
+  const previous = Array<{ state: number; pointIndex: number } | null>(totalStates).fill(null);
+  const heap = new RouteHeap();
+  const startState = startIndex * directions + directionStart;
+  distances[startState] = 0;
+  heap.push({ state: startState, distance: 0, priority: 0 });
+
+  while (heap.size) {
+    const current = heap.pop();
+    if (!current || current.distance !== distances[current.state]) continue;
+
+    const currentPointIndex = Math.floor(current.state / directions);
+    const currentDirection = current.state % directions;
+    if (currentPointIndex === endIndex) return reconstructRoute(previous, current.state);
+
+    for (const nextPointIndex of adjacency[currentPointIndex] ?? []) {
+      const nextDirection = points[currentPointIndex]!.x === points[nextPointIndex]!.x ? directionVertical : directionHorizontal;
+      const bendCost = currentDirection !== directionStart && currentDirection !== nextDirection ? routeBendPenalty : 0;
+      const nextState = nextPointIndex * directions + nextDirection;
+      const nextDistance = distances[current.state]! + manhattanDistance(points[currentPointIndex]!, points[nextPointIndex]!) + bendCost;
+      if (nextDistance >= distances[nextState]!) continue;
+
+      distances[nextState] = nextDistance;
+      previous[nextState] = { state: current.state, pointIndex: currentPointIndex };
+      heap.push({
+        state: nextState,
+        distance: nextDistance,
+        priority: nextDistance + manhattanDistance(points[nextPointIndex]!, points[endIndex]!),
+      });
+    }
+  }
+  return null;
+}
+
+function reconstructRoute(previous: Array<{ state: number; pointIndex: number } | null>, endState: number): number[] {
+  const directions = 3;
+  const path = [Math.floor(endState / directions)];
+  let currentState = endState;
+  while (previous[currentState]) {
+    const currentPrevious = previous[currentState]!;
+    path.push(currentPrevious.pointIndex);
+    currentState = currentPrevious.state;
+  }
+  return path.reverse();
+}
+
+// Last resort when the grid router fails: loop around the nearer outer edge
+// of the whole layout, which is always clear of nodes.
+function fallbackRoute(start: RoutePoint, end: RoutePoint, bounds: LayoutBox): RoutePoint[] {
+  const y =
+    Math.abs(start.y - (bounds.y - routeOuterMargin)) < Math.abs(start.y - (bounds.y + bounds.height + routeOuterMargin))
+      ? bounds.y - routeOuterMargin
+      : bounds.y + bounds.height + routeOuterMargin;
+  return compactRoute([start, { x: start.x, y }, { x: end.x, y }, end]);
+}
+
+// Drops duplicate points and merges collinear runs into single segments.
+function compactRoute(points: RoutePoint[]): RoutePoint[] {
+  const deduped = points.filter((point, index) => {
+    const previous = points[index - 1];
+    return !previous || previous.x !== point.x || previous.y !== point.y;
+  });
+  const compacted: RoutePoint[] = [];
+  for (const point of deduped) {
+    const previous = compacted[compacted.length - 1];
+    const beforePrevious = compacted[compacted.length - 2];
+    if (
+      previous &&
+      beforePrevious &&
+      ((beforePrevious.x === previous.x && previous.x === point.x) || (beforePrevious.y === previous.y && previous.y === point.y))
+    ) {
+      compacted[compacted.length - 1] = point;
+      continue;
+    }
+    compacted.push(point);
+  }
+  return compacted;
+}
+
+function routeIntersectsBoxes(routePoints: RoutePoint[], boxes: LayoutBox[]): boolean {
+  for (let index = 0; index < routePoints.length - 1; index += 1) {
+    if (boxes.some((box) => segmentIntersectsBox(routePoints[index]!, routePoints[index + 1]!, box))) return true;
+  }
+  return false;
+}
+
+function segmentIntersectsBox(start: RoutePoint, end: RoutePoint, box: LayoutBox): boolean {
+  if (start.y === end.y) {
+    if (start.y <= box.y || start.y >= box.y + box.height) return false;
+    return rangesOverlap(start.x, end.x, box.x, box.x + box.width);
+  }
+  if (start.x === end.x) {
+    if (start.x <= box.x || start.x >= box.x + box.width) return false;
+    return rangesOverlap(start.y, end.y, box.y, box.y + box.height);
+  }
+  return false;
+}
+
+function rangesOverlap(firstStart: number, firstEnd: number, secondStart: number, secondEnd: number): boolean {
+  const firstMin = Math.min(firstStart, firstEnd);
+  const firstMax = Math.max(firstStart, firstEnd);
+  const secondMin = Math.min(secondStart, secondEnd);
+  const secondMax = Math.max(secondStart, secondEnd);
+  return firstMin < secondMax && firstMax > secondMin;
+}
+
+function boxesIntersect(first: LayoutBox, second: LayoutBox): boolean {
+  return (
+    first.x < second.x + second.width &&
+    first.x + first.width > second.x &&
+    first.y < second.y + second.height &&
+    first.y + first.height > second.y
+  );
+}
+
+function expandedBox(box: LayoutBox, padding: number): LayoutBox {
+  return { id: box.id, x: box.x - padding, y: box.y - padding, width: box.width + padding * 2, height: box.height + padding * 2 };
+}
+
+function boxesBounds(boxes: LayoutBox[]): LayoutBox {
+  if (!boxes.length) return { id: 'bounds', x: 0, y: 0, width: 0, height: 0 };
+  const minX = Math.min(...boxes.map((box) => box.x));
+  const minY = Math.min(...boxes.map((box) => box.y));
+  const maxX = Math.max(...boxes.map((box) => box.x + box.width));
+  const maxY = Math.max(...boxes.map((box) => box.y + box.height));
+  return { id: 'bounds', x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+function pointsBounds(points: RoutePoint[]): LayoutBox {
+  const minX = Math.min(...points.map((point) => point.x));
+  const minY = Math.min(...points.map((point) => point.y));
+  const maxX = Math.max(...points.map((point) => point.x));
+  const maxY = Math.max(...points.map((point) => point.y));
+  return { id: 'bounds', x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+function pointInsideBox(point: RoutePoint, box: LayoutBox): boolean {
+  return point.x > box.x && point.x < box.x + box.width && point.y > box.y && point.y < box.y + box.height;
+}
+
+function pointKey(point: RoutePoint): string {
+  return `${point.x}:${point.y}`;
+}
+
+function uniqueSortedNumbers(values: number[]): number[] {
+  return [...new Set(values.map((value) => Math.round(value)))].sort((first, second) => first - second);
+}
+
+function manhattanDistance(first: RoutePoint, second: RoutePoint): number {
+  return Math.abs(first.x - second.x) + Math.abs(first.y - second.y);
+}
+
+interface HeapItem {
+  state: number;
+  distance: number;
+  priority: number;
+}
+
+class RouteHeap {
+  private readonly items: HeapItem[] = [];
+
+  get size(): number {
+    return this.items.length;
+  }
+
+  push(item: HeapItem): void {
+    this.items.push(item);
+    this.bubbleUp(this.items.length - 1);
+  }
+
+  pop(): HeapItem | undefined {
+    if (!this.items.length) return undefined;
+    const top = this.items[0];
+    const last = this.items.pop();
+    if (last && this.items.length) {
+      this.items[0] = last;
+      this.bubbleDown(0);
+    }
+    return top;
+  }
+
+  private bubbleUp(index: number): void {
+    let currentIndex = index;
+    while (currentIndex > 0) {
+      const parentIndex = Math.floor((currentIndex - 1) / 2);
+      if (this.items[parentIndex]!.priority <= this.items[currentIndex]!.priority) return;
+      [this.items[parentIndex], this.items[currentIndex]] = [this.items[currentIndex]!, this.items[parentIndex]!];
+      currentIndex = parentIndex;
+    }
+  }
+
+  private bubbleDown(index: number): void {
+    let currentIndex = index;
+    while (true) {
+      const leftIndex = currentIndex * 2 + 1;
+      const rightIndex = currentIndex * 2 + 2;
+      let smallestIndex = currentIndex;
+      if (leftIndex < this.items.length && this.items[leftIndex]!.priority < this.items[smallestIndex]!.priority) smallestIndex = leftIndex;
+      if (rightIndex < this.items.length && this.items[rightIndex]!.priority < this.items[smallestIndex]!.priority) smallestIndex = rightIndex;
+      if (smallestIndex === currentIndex) return;
+      [this.items[currentIndex], this.items[smallestIndex]] = [this.items[smallestIndex]!, this.items[currentIndex]!];
+      currentIndex = smallestIndex;
+    }
+  }
+}

--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -94,6 +94,13 @@ export function BottomDock({ containerRef }: { containerRef: React.RefObject<HTM
               key={tab.id}
               value={tab.id}
               sx={{ minHeight: 32, py: 0, textTransform: 'none' }}
+              onMouseDown={(e) => {
+                // Prevent Chromium's middle-click autoscroll so onAuxClick fires cleanly.
+                if (e.button === 1) e.preventDefault();
+              }}
+              onAuxClick={(e) => {
+                if (e.button === 1) closeTab(tab.id);
+              }}
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   {tab.kind === 'terminal' || tab.kind === 'node-shell' ? <TerminalIcon sx={{ fontSize: 14 }} /> : <SubjectIcon sx={{ fontSize: 14 }} />}

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -28,7 +28,7 @@ import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { NavLink, useLocation, useNavigate } from 'react-router';
-import { BUILTIN_NAV_GROUPS, groupToPath, pluralLabel, type FavoriteItem, type ResourceKindInfo, type SavedView } from '@kubus/shared';
+import { BUILTIN_NAV_GROUPS, groupToPath, gvkForResource, gvkLabel, pluralLabel, type FavoriteItem, type ResourceKindInfo, type SavedView } from '@kubus/shared';
 import { useApiResourcesForContexts } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
@@ -73,9 +73,19 @@ function kindFavorite(k: NavKind): FavoriteItem {
   return {
     id: `kind:${k.group}/${k.version}/${k.plural}`,
     title: k.label,
-    subtitle: `${k.group || 'core'}/${k.version}`,
+    subtitle: gvkLabel(k),
     path: kindPath(k.group, k.version, k.plural),
   };
+}
+
+/** Resolve old persisted kind favorites to a full GVK once discovery is available. */
+function favoriteGvk(favorite: FavoriteItem, resources: ResourceKindInfo[]): string | undefined {
+  if (!favorite.id.startsWith('kind:')) return favorite.subtitle;
+  const [group, version, plural] = favorite.id.slice('kind:'.length).split('/');
+  if (group === undefined || !version || !plural) return favorite.subtitle;
+  const discovered = resources.find((r) => r.group === group && r.version === version && r.plural === plural);
+  const resource = discovered ?? gvkForResource(group, version, plural);
+  return resource ? gvkLabel(resource) : favorite.subtitle;
 }
 
 // Star toggle revealed on row hover (always visible once active). Rendered as a
@@ -139,12 +149,14 @@ function dedupeCustomNavKinds(kinds: ResourceKindInfo[]): ResourceKindInfo[] {
 function NavEntry({
   to,
   label,
+  subtitle,
   icon,
   favorite,
   favoriteAction,
 }: {
   to: string;
   label: string;
+  subtitle?: string;
   icon?: React.ReactElement;
   favorite?: FavoriteItem;
   favoriteAction?: ReactNode;
@@ -162,12 +174,20 @@ function NavEntry({
       dense
       selected={active}
       {...newTabHandlers}
-      sx={{ pl: icon ? 1.5 : ITEM_INDENT, py: 0.375, pr: favorite ? (favoriteAction ? 7 : 4) : undefined }}
+      sx={{ pl: icon ? 1.5 : ITEM_INDENT, py: subtitle ? 0.25 : 0.375, pr: favorite ? (favoriteAction ? 7 : 4) : undefined }}
     >
       {icon && (
         <ListItemIcon sx={{ minWidth: 26, color: 'text.secondary', '& svg': { fontSize: 17 } }}>{icon}</ListItemIcon>
       )}
-      <ListItemText primary={label} slotProps={{ primary: { variant: 'body2', noWrap: true } }} />
+      <ListItemText
+        primary={label}
+        secondary={subtitle}
+        sx={{ my: subtitle ? 0.25 : undefined }}
+        slotProps={{
+          primary: { variant: 'body2', noWrap: true, sx: subtitle ? { lineHeight: 1.25 } : undefined },
+          secondary: { noWrap: true, title: subtitle, sx: { fontSize: 10.5, fontStyle: 'italic', lineHeight: 1.1 } },
+        }}
+      />
     </ListItemButton>
   );
   if (!favorite) return button;
@@ -560,10 +580,20 @@ export function NavDrawer() {
                     </Box>
                   );
                 }
-                if (!matches(fav.title)) return null;
+                const subtitle = favoriteGvk(fav, apiResources?.resources ?? []);
+                if (!matches(fav.title) && !(subtitle && matches(subtitle))) return null;
                 return (
                   <Box key={fav.id}>
-                    {favoriteDragShell(fav, <NavEntry to={fav.path ?? '/'} label={fav.title} favorite={fav} favoriteAction={favoriteDragHandle(fav)} />)}
+                    {favoriteDragShell(
+                      fav,
+                      <NavEntry
+                        to={fav.path ?? '/'}
+                        label={fav.title}
+                        subtitle={subtitle}
+                        favorite={fav}
+                        favoriteAction={favoriteDragHandle(fav)}
+                      />,
+                    )}
                   </Box>
                 );
               })}

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useDeferredValue, useMemo, useState, type DragEvent, type ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import Drawer from '@mui/material/Drawer';
@@ -26,6 +26,7 @@ import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 import GppMaybeOutlinedIcon from '@mui/icons-material/GppMaybeOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 import { BUILTIN_NAV_GROUPS, groupToPath, pluralLabel, type FavoriteItem, type ResourceKindInfo, type SavedView } from '@kubus/shared';
 import { useApiResourcesForContexts } from '../api/queries.js';
@@ -37,6 +38,7 @@ import { GROUP_ICONS } from './tab-meta.js';
 const WIDTH = 228;
 // Indent of group items so they line up under the group label (button pl 16px + icon 26px).
 const ITEM_INDENT = '42px';
+const FAVORITE_DRAG_TYPE = 'application/x-kubus-favorite';
 
 /**
  * Browser-style modifiers on nav links: Ctrl/Cmd+click opens a background
@@ -134,7 +136,19 @@ function dedupeCustomNavKinds(kinds: ResourceKindInfo[]): ResourceKindInfo[] {
   return [...byKind.values()];
 }
 
-function NavEntry({ to, label, icon, favorite }: { to: string; label: string; icon?: React.ReactElement; favorite?: FavoriteItem }) {
+function NavEntry({
+  to,
+  label,
+  icon,
+  favorite,
+  favoriteAction,
+}: {
+  to: string;
+  label: string;
+  icon?: React.ReactElement;
+  favorite?: FavoriteItem;
+  favoriteAction?: ReactNode;
+}) {
   const location = useLocation();
   const active = location.pathname === to;
   const isFav = useNavigationStore((s) => (favorite ? s.favorites.some((x) => x.id === favorite.id) : false));
@@ -142,7 +156,14 @@ function NavEntry({ to, label, icon, favorite }: { to: string; label: string; ic
   const removeFavorite = useNavigationStore((s) => s.removeFavorite);
   const newTabHandlers = useOpenInNewTab(to);
   const button = (
-    <ListItemButton component={NavLink} to={to} dense selected={active} {...newTabHandlers} sx={{ pl: icon ? 1.5 : ITEM_INDENT, py: 0.375, pr: favorite ? 4 : undefined }}>
+    <ListItemButton
+      component={NavLink}
+      to={to}
+      dense
+      selected={active}
+      {...newTabHandlers}
+      sx={{ pl: icon ? 1.5 : ITEM_INDENT, py: 0.375, pr: favorite ? (favoriteAction ? 7 : 4) : undefined }}
+    >
       {icon && (
         <ListItemIcon sx={{ minWidth: 26, color: 'text.secondary', '& svg': { fontSize: 17 } }}>{icon}</ListItemIcon>
       )}
@@ -154,11 +175,14 @@ function NavEntry({ to, label, icon, favorite }: { to: string; label: string; ic
     <ListItem
       disablePadding
       secondaryAction={
-        <FavStar
-          active={isFav}
-          label={`${isFav ? 'Remove' : 'Add'} favorite ${label}`}
-          onToggle={() => (isFav ? removeFavorite(favorite.id) : addFavorite(favorite))}
-        />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+          {favoriteAction}
+          <FavStar
+            active={isFav}
+            label={`${isFav ? 'Remove' : 'Add'} favorite ${label}`}
+            onToggle={() => (isFav ? removeFavorite(favorite.id) : addFavorite(favorite))}
+          />
+        </Box>
       }
       sx={{ '& .MuiListItemSecondaryAction-root': { right: 4 }, '&:hover .fav-star': { opacity: 1 } }}
     >
@@ -205,12 +229,14 @@ function GroupHeader({
   open,
   onClick,
   favorite,
+  favoriteAction,
 }: {
   title: string;
   icon?: React.ReactElement;
   open: boolean;
   onClick: () => void;
   favorite?: { active: boolean; onToggle: () => void };
+  favoriteAction?: ReactNode;
 }) {
   return (
     <ListItemButton
@@ -230,10 +256,106 @@ function GroupHeader({
           label={`${favorite.active ? 'Remove' : 'Add'} favorite category ${title}`}
         />
       )}
+      {favoriteAction}
       <ExpandMoreIcon
         sx={{ fontSize: 16, opacity: 0.6, transform: open ? 'none' : 'rotate(-90deg)', transition: 'transform 120ms ease' }}
       />
     </ListItemButton>
+  );
+}
+
+type FavoriteDropTarget = { id: string; position: 'before' | 'after' };
+
+function favoriteDropPosition(e: DragEvent<HTMLElement>): FavoriteDropTarget['position'] {
+  const rect = e.currentTarget.getBoundingClientRect();
+  return e.clientY < rect.top + rect.height / 2 ? 'before' : 'after';
+}
+
+function FavoriteDragHandle({
+  favorite,
+  onDragStart,
+  onDragEnd,
+}: {
+  favorite: FavoriteItem;
+  onDragStart: (favorite: FavoriteItem, e: DragEvent<HTMLElement>) => void;
+  onDragEnd: () => void;
+}) {
+  return (
+    <Tooltip title="Drag to reorder">
+      <IconButton
+        component="span"
+        aria-label={`Reorder favorite ${favorite.title}`}
+        size="small"
+        draggable
+        className="favorite-drag-handle"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        onDragStart={(e) => onDragStart(favorite, e)}
+        onDragEnd={onDragEnd}
+        sx={{
+          cursor: 'grab',
+          color: 'text.secondary',
+          opacity: 0,
+          transition: 'opacity 120ms ease',
+          '&:active': { cursor: 'grabbing' },
+          '& svg': { fontSize: 17 },
+          '&:focus-visible': { opacity: 1 },
+        }}
+      >
+        <DragIndicatorIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+function FavoriteDragShell({
+  favorite,
+  draggingId,
+  dropTarget,
+  children,
+  onDropTarget,
+  onDropFavorite,
+  onClearDropTarget,
+}: {
+  favorite: FavoriteItem;
+  draggingId: string | null;
+  dropTarget: FavoriteDropTarget | null;
+  children: ReactNode;
+  onDropTarget: (target: FavoriteDropTarget) => void;
+  onDropFavorite: (target: FavoriteDropTarget) => void;
+  onClearDropTarget: (id: string) => void;
+}) {
+  const activeDrop = dropTarget?.id === favorite.id ? dropTarget.position : undefined;
+  const canDrop = !!draggingId && draggingId !== favorite.id;
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        opacity: draggingId === favorite.id ? 0.45 : 1,
+        '&:hover .favorite-drag-handle': { opacity: 1 },
+      }}
+      onDragOver={(e) => {
+        if (!canDrop) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        onDropTarget({ id: favorite.id, position: favoriteDropPosition(e) });
+      }}
+      onDragLeave={(e) => {
+        if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+        onClearDropTarget(favorite.id);
+      }}
+      onDrop={(e) => {
+        if (!canDrop) return;
+        e.preventDefault();
+        onDropFavorite({ id: favorite.id, position: favoriteDropPosition(e) });
+      }}
+    >
+      {activeDrop === 'before' && <Box sx={{ position: 'absolute', top: 0, left: 10, right: 10, height: 2, bgcolor: 'primary.main', zIndex: 2 }} />}
+      {children}
+      {activeDrop === 'after' && <Box sx={{ position: 'absolute', bottom: 0, left: 10, right: 10, height: 2, bgcolor: 'primary.main', zIndex: 2 }} />}
+    </Box>
   );
 }
 
@@ -245,6 +367,7 @@ export function NavDrawer() {
   const removeSavedView = useNavigationStore((s) => s.removeSavedView);
   const addFavorite = useNavigationStore((s) => s.addFavorite);
   const removeFavorite = useNavigationStore((s) => s.removeFavorite);
+  const moveFavorite = useNavigationStore((s) => s.moveFavorite);
   // Favorited categories ('fav:<title>') start collapsed so they show as a
   // single entry rather than flooding Favorites with every kind.
   const [collapsed, setCollapsed] = useState<Set<string>>(() => {
@@ -255,6 +378,8 @@ export function NavDrawer() {
     return set;
   });
   const [filter, setFilter] = useState('');
+  const [draggingFavoriteId, setDraggingFavoriteId] = useState<string | null>(null);
+  const [favoriteDropTarget, setFavoriteDropTarget] = useState<FavoriteDropTarget | null>(null);
   const deferredFilter = useDeferredValue(filter);
 
   const toggleGroup = (title: string) =>
@@ -308,6 +433,45 @@ export function NavDrawer() {
   const matches = (label: string) => !f || label.toLowerCase().includes(f);
   // While filtering, always expand so matches are visible.
   const isOpen = (title: string) => !!f || !collapsed.has(title);
+  const canReorderFavorites = favorites.length > 1 && !f;
+  const clearFavoriteDrag = () => {
+    setDraggingFavoriteId(null);
+    setFavoriteDropTarget(null);
+  };
+  const favoriteDragHandle = (fav: FavoriteItem) =>
+    canReorderFavorites ? (
+      <FavoriteDragHandle
+        favorite={fav}
+        onDragStart={(favorite, e) => {
+          e.stopPropagation();
+          e.dataTransfer.effectAllowed = 'move';
+          e.dataTransfer.setData(FAVORITE_DRAG_TYPE, favorite.id);
+          setDraggingFavoriteId(favorite.id);
+        }}
+        onDragEnd={clearFavoriteDrag}
+      />
+    ) : undefined;
+  const favoriteDragShell = (fav: FavoriteItem, children: ReactNode) =>
+    canReorderFavorites ? (
+      <FavoriteDragShell
+        favorite={fav}
+        draggingId={draggingFavoriteId}
+        dropTarget={favoriteDropTarget}
+        onDropTarget={setFavoriteDropTarget}
+        onClearDropTarget={(id) => {
+          setFavoriteDropTarget((target) => (target?.id === id ? null : target));
+        }}
+        onDropFavorite={({ id, position }) => {
+          const draggedId = draggingFavoriteId;
+          clearFavoriteDrag();
+          if (draggedId) moveFavorite(draggedId, id, position);
+        }}
+      >
+        {children}
+      </FavoriteDragShell>
+    ) : (
+      children
+    );
 
   return (
     <Drawer
@@ -377,13 +541,17 @@ export function NavDrawer() {
                   const key = `fav:${fav.title}`;
                   return (
                     <Box key={fav.id}>
-                      <GroupHeader
-                        title={fav.title}
-                        icon={GROUP_ICONS[fav.title] ?? <ExtensionOutlinedIcon />}
-                        open={isOpen(key)}
-                        onClick={() => toggleGroup(key)}
-                        favorite={{ active: true, onToggle: () => removeFavorite(fav.id) }}
-                      />
+                      {favoriteDragShell(
+                        fav,
+                        <GroupHeader
+                          title={fav.title}
+                          icon={GROUP_ICONS[fav.title] ?? <ExtensionOutlinedIcon />}
+                          open={isOpen(key)}
+                          onClick={() => toggleGroup(key)}
+                          favorite={{ active: true, onToggle: () => removeFavorite(fav.id) }}
+                          favoriteAction={favoriteDragHandle(fav)}
+                        />,
+                      )}
                       <Collapse in={isOpen(key)}>
                         {kinds.map((k) => (
                           <NavEntry key={`${k.group}/${k.version}/${k.plural}`} to={kindPath(k.group, k.version, k.plural)} label={k.label} />
@@ -393,7 +561,11 @@ export function NavDrawer() {
                   );
                 }
                 if (!matches(fav.title)) return null;
-                return <NavEntry key={fav.id} to={fav.path ?? '/'} label={fav.title} favorite={fav} />;
+                return (
+                  <Box key={fav.id}>
+                    {favoriteDragShell(fav, <NavEntry to={fav.path ?? '/'} label={fav.title} favorite={fav} favoriteAction={favoriteDragHandle(fav)} />)}
+                  </Box>
+                );
               })}
             </Collapse>
           </Box>

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -117,7 +117,7 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
   const rows = useMemo<Row[]>(() => {
     if (stage) {
       const f = deferredQuery.trim().toLowerCase();
-      return actionsForRef(stage.ref.kind)
+      return actionsForRef(stage.ref)
         .filter((a) => !f || a.title.toLowerCase().includes(f))
         .map((action) => ({ type: 'action', action }));
     }

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -86,6 +86,7 @@ export function ResourceListPage() {
   );
   const builtinKind = useMemo(() => gvkForResource(group, version, plural), [group, version, plural]);
   const kind = kindInfo?.kind ?? builtinKind?.kind ?? plural;
+  const behaviorKind = builtinKind?.kind === kind ? kind : undefined;
   const resourceTitle = pluralLabel(kind);
   const namespaced = kindInfo?.namespaced ?? true;
   const isCustomKind = !!kindInfo?.custom;
@@ -95,11 +96,11 @@ export function ResourceListPage() {
   const labelSelector = searchParams.get('label') ?? '';
 
   const list = useFilteredList(group, version, plural, namespaced, { labelSelector });
-  const isPodOrNode = kind === 'Pod' || kind === 'Node';
-  const { data: podMetrics } = useResourceMetrics(isPodOrNode ? selected : [], kind === 'Node' ? 'nodes' : 'pods');
+  const isPodOrNode = behaviorKind === 'Pod' || behaviorKind === 'Node';
+  const { data: podMetrics } = useResourceMetrics(isPodOrNode ? selected : [], behaviorKind === 'Node' ? 'nodes' : 'pods');
   const metricsUnavailable = isPodOrNode ? selected.filter((ctx) => podMetrics?.get(ctx)?.available === false) : [];
-  const nodePods = useWatchedList(kind === 'Node' ? selected : [], '', 'v1', 'pods');
-  const nodeAllocation = useMemo(() => (kind === 'Node' ? makeNodeAllocationLookup(nodePods.rows) : undefined), [kind, nodePods.rows]);
+  const nodePods = useWatchedList(behaviorKind === 'Node' ? selected : [], '', 'v1', 'pods');
+  const nodeAllocation = useMemo(() => (behaviorKind === 'Node' ? makeNodeAllocationLookup(nodePods.rows) : undefined), [behaviorKind, nodePods.rows]);
 
   const [createOpen, setCreateOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<ClusterRow[]>([]);
@@ -175,10 +176,10 @@ export function ResourceListPage() {
     [group, version, plural, kind],
   );
 
-  const metricsLookup = useMemo(() => makeMetricsLookup(kind, podMetrics), [kind, podMetrics]);
+  const metricsLookup = useMemo(() => makeMetricsLookup(behaviorKind ?? 'Resource', podMetrics), [behaviorKind, podMetrics]);
 
   const columns = useMemo(() => {
-    const ids = columnsForKind(kind, namespaced);
+    const ids = columnsForKind(behaviorKind ?? 'Resource', namespaced);
     const opts = { multiCluster: selected.length > 1, metrics: metricsLookup, nodeAllocation, onLabelClick: addLabelFilter };
     const cols = buildColumns(ids, opts);
     if (isCustomKind && printerCols?.length) {
@@ -197,7 +198,7 @@ export function ResourceListPage() {
       renderCell: (p) => <RowActions target={rowActionTarget(p.row)} />,
     });
     return cols;
-  }, [kind, namespaced, selected.length, metricsLookup, nodeAllocation, isCustomKind, printerCols, rowActionTarget, addLabelFilter]);
+  }, [behaviorKind, namespaced, selected.length, metricsLookup, nodeAllocation, isCustomKind, printerCols, rowActionTarget, addLabelFilter]);
   const hiddenFields = useMemo(() => (isCustomKind && printerCols?.length ? crdHiddenFields(printerCols) : []), [isCustomKind, printerCols]);
 
   const supportsGvr = (r: ResourceKindInfo) => r.group === group && r.version === version && r.plural === plural;
@@ -286,7 +287,7 @@ export function ResourceListPage() {
         rows={list.rows}
         columns={columns}
         loading={Object.values(list.status).some((s) => s.state === 'loading')}
-        kind={kind}
+        kind={behaviorKind ?? 'Resource'}
         metricsLookup={metricsLookup}
         filter={textFilter}
         labelSelector={labelSelector}

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -252,7 +252,7 @@ export function ResourceListPage() {
               component="button"
               variant="h6"
               underline="hover"
-              color="inherit"
+              color="primary"
               title={`Open CRD ${crdSelection.name}`}
               onClick={() => pushDetail(crdSelection)}
             >

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -12,7 +12,7 @@ import SubjectIcon from '@mui/icons-material/Subject';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import BookmarkAddOutlinedIcon from '@mui/icons-material/BookmarkAddOutlined';
 import { useParams, useSearchParams } from 'react-router';
-import { columnsForKind, groupFromPath, groupToPath, gvkForResource, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
+import { columnsForKind, groupFromPath, groupToPath, gvkForResource, gvkLabel, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
 import { useApiResourcesForContexts, useCrdColumns, useCreateResource, useDryRunResource, useFilteredList, useResourceMetrics, useWatchedList, type ClusterRow } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useDockStore, dockTabId } from '../state/dock.js';
@@ -88,6 +88,7 @@ export function ResourceListPage() {
   const kind = kindInfo?.kind ?? builtinKind?.kind ?? plural;
   const behaviorKind = builtinKind?.kind === kind ? kind : undefined;
   const resourceTitle = pluralLabel(kind);
+  const resourceGvk = gvkLabel({ group, version, kind });
   const namespaced = kindInfo?.namespaced ?? true;
   const isCustomKind = !!kindInfo?.custom;
 
@@ -245,7 +246,7 @@ export function ResourceListPage() {
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <DetailUrlSync sel={sel} />
       <Box sx={{ px: 1.5, pt: 1.5 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
           {crdSelection ? (
             <Link
               component="button"
@@ -260,6 +261,9 @@ export function ResourceListPage() {
           ) : (
             <Typography variant="h6">{resourceTitle}</Typography>
           )}
+          <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+            {resourceGvk}
+          </Typography>
         </Box>
         {errors.map(([ctx, s]) => (
           <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -17,6 +17,7 @@ import { useApiResourcesForContexts, useCrdColumns, useCreateResource, useDryRun
 import { useClustersStore } from '../state/clusters.js';
 import { useDockStore, dockTabId } from '../state/dock.js';
 import { ResourceTable } from '../components/ResourceTable.js';
+import { ApiResourceDrawer } from '../components/ApiResourceDrawer.js';
 import { buildColumns, buildCrdColumns, crdHiddenFields, makeMetricsLookup, makeNodeAllocationLookup } from '../components/columns.js';
 import type { ResourceSelection } from '../components/ResourceDetailDrawer.js';
 import { useDetailStore } from '../state/detail.js';
@@ -91,6 +92,10 @@ export function ResourceListPage() {
   const resourceGvk = gvkLabel({ group, version, kind });
   const namespaced = kindInfo?.namespaced ?? true;
   const isCustomKind = !!kindInfo?.custom;
+  const resourceInfo = useMemo<ResourceKindInfo>(
+    () => kindInfo ?? { group, version, plural, kind, namespaced: builtinKind?.namespaced ?? true, verbs: [] },
+    [kindInfo, group, version, plural, kind, builtinKind],
+  );
 
   const [searchParams, setSearchParams] = useSearchParams();
   const textFilter = searchParams.get('q') ?? '';
@@ -104,6 +109,7 @@ export function ResourceListPage() {
   const nodeAllocation = useMemo(() => (behaviorKind === 'Node' ? makeNodeAllocationLookup(nodePods.rows) : undefined), [behaviorKind, nodePods.rows]);
 
   const [createOpen, setCreateOpen] = useState(false);
+  const [apiResourceOpen, setApiResourceOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<ClusterRow[]>([]);
   const [contextAction, setContextAction] = useState<{ target: RowActionTarget; mouseX: number; mouseY: number } | null>(null);
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
@@ -149,21 +155,22 @@ export function ResourceListPage() {
     [setSearchParams],
   );
 
-  // CRD printer columns: taken from the first selected cluster that serves
-  // this GVR — multi-cluster CRD definition drift is not reconciled.
-  const crdCtx = useMemo(
+  // Schema and CRD printer columns come from the first selected cluster that
+  // serves this GVR — multi-cluster definition drift is not reconciled.
+  const resourceCtx = useMemo(
     () => selected.find((c) => (apiResources?.byContext[c] ?? []).some((r) => r.group === group && r.version === version && r.plural === plural)),
     [selected, apiResources, group, version, plural],
   );
-  const { data: printerCols } = useCrdColumns(crdCtx, group, version, plural, isCustomKind);
+  const { data: printerCols } = useCrdColumns(resourceCtx, group, version, plural, isCustomKind);
 
-  // For CRD-backed kinds the page title links to the defining CRD.
+  // CRD-backed kinds additionally expose their defining CRD from the generic
+  // API Resource view.
   const pushDetail = useDetailStore((s) => s.push);
   const openDetail = useDetailStore((s) => s.open);
   const crdSelection: ResourceSelection | undefined =
-    isCustomKind && crdCtx && group
+    isCustomKind && resourceCtx && group
       ? {
-          ctx: crdCtx,
+          ctx: resourceCtx,
           group: 'apiextensions.k8s.io',
           version: 'v1',
           plural: 'customresourcedefinitions',
@@ -247,20 +254,16 @@ export function ResourceListPage() {
       <DetailUrlSync sel={sel} />
       <Box sx={{ px: 1.5, pt: 1.5 }}>
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
-          {crdSelection ? (
-            <Link
-              component="button"
-              variant="h6"
-              underline="hover"
-              color="primary"
-              title={`Open CRD ${crdSelection.name}`}
-              onClick={() => pushDetail(crdSelection)}
-            >
-              {resourceTitle}
-            </Link>
-          ) : (
-            <Typography variant="h6">{resourceTitle}</Typography>
-          )}
+          <Link
+            component="button"
+            variant="h6"
+            underline="hover"
+            color="primary"
+            title={`Open API resource ${resourceGvk}`}
+            onClick={() => setApiResourceOpen(true)}
+          >
+            {resourceTitle}
+          </Link>
           <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
             {resourceGvk}
           </Typography>
@@ -363,6 +366,20 @@ export function ResourceListPage() {
           onClose={() => setContextMenuOpen(false)}
         />
       )}
+      <ApiResourceDrawer
+        open={apiResourceOpen}
+        ctx={resourceCtx}
+        resource={resourceInfo}
+        onClose={() => setApiResourceOpen(false)}
+        onOpenCrd={
+          crdSelection
+            ? () => {
+                setApiResourceOpen(false);
+                pushDetail(crdSelection);
+              }
+            : undefined
+        }
+      />
       <Dialog open={createOpen} onClose={() => setCreateOpen(false)} maxWidth="md" fullWidth slotProps={{ paper: { sx: { height: '80vh' } } }}>
         <DialogTitle>Create resource{selected.length > 1 ? ` on ${selected[0]}` : ''}</DialogTitle>
         <DialogContent sx={{ p: 0, display: 'flex', flexDirection: 'column' }}>

--- a/client/src/state/navigation.ts
+++ b/client/src/state/navigation.ts
@@ -8,6 +8,7 @@ interface NavigationState {
   savedViews: SavedView[];
   addFavorite: (item: FavoriteItem) => void;
   removeFavorite: (id: string) => void;
+  moveFavorite: (id: string, targetId: string, position: 'before' | 'after') => void;
   isFavorite: (id: string) => boolean;
   addSavedView: (view: SavedView) => void;
   removeSavedView: (id: string) => void;
@@ -23,6 +24,18 @@ export const useNavigationStore = create<NavigationState>()(
           favorites: [item, ...s.favorites.filter((f) => f.id !== item.id)].slice(0, 40),
         })),
       removeFavorite: (id) => set((s) => ({ favorites: s.favorites.filter((f) => f.id !== id) })),
+      moveFavorite: (id, targetId, position) =>
+        set((s) => {
+          if (id === targetId) return s;
+          const moving = s.favorites.find((f) => f.id === id);
+          if (!moving) return s;
+          const withoutMoving = s.favorites.filter((f) => f.id !== id);
+          const targetIndex = withoutMoving.findIndex((f) => f.id === targetId);
+          if (targetIndex === -1) return s;
+          const next = [...withoutMoving];
+          next.splice(position === 'after' ? targetIndex + 1 : targetIndex, 0, moving);
+          return { favorites: next };
+        }),
       isFavorite: (id) => get().favorites.some((f) => f.id === id),
       addSavedView: (view) =>
         set((s) => ({

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@xyflow/react':
         specifier: ^12.11.2
         version: 12.11.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      elkjs:
+        specifier: ^0.11.1
+        version: 0.11.1
       js-yaml:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1672,6 +1675,9 @@ packages:
     resolution: {integrity: sha512-DPfxpQLd4NL3BJ8DBxYAfmLUKKesF5Rx9dQx5FyczAP8bhOPScjHE48GArVeXu68LlAainuwkmQTQvdZwpIIAQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
+
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -4675,6 +4681,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  elkjs@0.11.1: {}
+
   emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.5:
@@ -4946,7 +4954,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -5327,11 +5335,11 @@ snapshots:
 
   node-abi@4.33.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-domexception@1.0.0: {}
 
@@ -5352,7 +5360,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.19
       tinyglobby: 0.2.17
       undici: 6.27.0

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/routes/search.ts
+++ b/server/src/routes/search.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from 'fastify';
-import { groupToPath, type ResourceRef, type SearchResult } from '@kubus/shared';
+import { groupToPath, gvkLabel, type ResourceRef, type SearchResult } from '@kubus/shared';
 import type { AppContext } from '../app.js';
 import type { ClusterHandle } from '../kube/cluster-manager.js';
 import type { IndexedResourceSearchEntry } from '../kube/search-index.js';
@@ -120,7 +120,7 @@ async function searchContext(handle: ClusterHandle, query: string, limit: number
       id: `kind:${kind.group}/${kind.version}/${kind.plural}`,
       kind: 'kind',
       title: kind.kind,
-      subtitle: kind.group ? `${kind.group}/${kind.version}` : kind.version,
+      subtitle: gvkLabel(kind),
       // Kinds outrank resource hits of equal match quality: there are few of
       // them and they are usually what a short query like "art" is after.
       score: score + 20,

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/src/resource-meta.ts
+++ b/shared/src/resource-meta.ts
@@ -12,6 +12,11 @@ export interface GVK {
   namespaced: boolean;
 }
 
+/** Compact, unambiguous group/version/kind label for resource UI. */
+export function gvkLabel(gvk: Pick<GVK, 'group' | 'version' | 'kind'>): string {
+  return `${gvk.group || 'core'}/${gvk.version}/${gvk.kind}`;
+}
+
 export interface NavGroup {
   title: string;
   kinds: GVK[];


### PR DESCRIPTION
## Summary

- overhaul the topology graph with an ELK-based layout, routed edges, clearer labels, drag rerouting, and automatic viewport fitting
- add browser-style middle-click behavior for opening navigation routes and closing dock tabs
- make favorites reorderable and show/search their full GVK
- add an API resource drawer with metadata and OpenAPI schema views for every resource, plus navigation to backing CRDs
- use full GVK identity so custom resources do not inherit behavior from same-named built-ins
- improve CRD status and link styling, table column sizing, and resource drawer alignment