### PR TITLE
fix installed app startup failures

### DIFF
--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -29,10 +29,10 @@ interface EventObj extends KubeObject {
   reason?: string;
   message?: string;
   count?: number;
-  lastTimestamp?: string;
-  firstTimestamp?: string;
-  eventTime?: string;
-  series?: { count?: number; lastObservedTime?: string };
+  lastTimestamp?: string | null;
+  firstTimestamp?: string | null;
+  eventTime?: string | null;
+  series?: { count?: number; lastObservedTime?: string | null };
   involvedObject?: { kind?: string; name?: string; namespace?: string; uid?: string; apiVersion?: string };
 }
 
@@ -45,16 +45,16 @@ interface EventRow {
   lastSeen?: string;
 }
 
-function maxTime(...ts: Array<string | undefined>): string | undefined {
+function maxTime(...ts: Array<string | null | undefined>): string | undefined {
   return ts
-    .filter((t): t is string => t !== undefined)
+    .filter((t): t is string => typeof t === 'string' && t.length > 0)
     .sort((a, b) => a.localeCompare(b))
     .at(-1);
 }
 
-function minTime(...ts: Array<string | undefined>): string | undefined {
+function minTime(...ts: Array<string | null | undefined>): string | undefined {
   return ts
-    .filter((t): t is string => t !== undefined)
+    .filter((t): t is string => typeof t === 'string' && t.length > 0)
     .sort((a, b) => a.localeCompare(b))
     .at(0);
 }

--- a/electron/scripts/after-pack.cjs
+++ b/electron/scripts/after-pack.cjs
@@ -29,7 +29,8 @@ exports.default = async function afterPack(context) {
     executablePath,
     [
       '#!/bin/sh',
-      'APP_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"',
+      '# Resolve update-alternatives links such as /usr/bin/kubus.',
+      'APP_DIR="$(dirname -- "$(readlink -f -- "$0")")"',
       'if [ -n "$APPIMAGE" ]; then',
       `  exec "$APP_DIR/${executableName}.bin" --ozone-platform=x11 --no-sandbox "$@"`,
       'fi',


### PR DESCRIPTION
## Summary

- tolerate null and empty Kubernetes Event timestamps so the Events page cannot blank the renderer
- resolve the packaged Linux executable directory when launched through the `/usr/bin/kubus` alternative

## Root cause

A lint cleanup changed timestamp filtering from truthy values to undefined-only values. Kubernetes can return `null` timestamps, which then reached `localeCompare()` and crashed the React render when the saved route was `/events`.

The Linux wrapper also derived its directory directly from `$0`. When invoked through the installed alternative, it looked for `kubus.bin` under `/usr/bin` instead of `/opt/Kubus`.

## Impact

The installed application now renders the Events page for real cluster data instead of showing a white window, and both the desktop launcher and direct `kubus` command resolve the packaged executable correctly.

## Validation

- `pnpm --filter @kubus/client build`
- `pnpm lint`
- `pnpm typecheck`
- `node --check electron/scripts/after-pack.cjs`
- built and reinstalled the Debian package
- launched `/usr/bin/kubus` against the live cluster and confirmed 17 events rendered with no page errors