### PR TITLE
Refine favorites and fix release update metadata

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - "docs/**"
       - "zensical.toml"
-      - "hack/write-latest-manifest.mjs"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
@@ -31,25 +30,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - run: pip install zensical
       - run: zensical build --clean --strict
-      - name: Write update manifest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          if gh release view --repo "$GH_REPO" --json tagName,name,url,publishedAt > /tmp/kubus-latest-release.json; then
-            node hack/write-latest-manifest.mjs /tmp/kubus-latest-release.json site/latest.json
-          else
-            echo "No release metadata available; skipping update manifest."
-            rm -f site/latest.json
-          fi
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,10 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_tag || github.ref_name }}
     steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
       - uses: actions/download-artifact@v8
         with:
           path: release-assets
@@ -105,6 +109,10 @@ jobs:
             gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --generate-notes
           fi
 
+          gh release view "$RELEASE_TAG" --json tagName,name,url,publishedAt > /tmp/kubus-release.json
+          node hack/write-latest-manifest.mjs /tmp/kubus-release.json /tmp/latest.json
+          artifacts+=(/tmp/latest.json)
+
           while IFS= read -r asset_name; do
             case "$asset_name" in
               kubus-*-mac-x64.*|kubus-*-mac-arm64.*|kubus-*.blockmap|latest*.yml)
@@ -114,46 +122,3 @@ jobs:
           done < <(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')
 
           gh release upload "$RELEASE_TAG" "${artifacts[@]}" --clobber
-
-  deploy-update-manifest:
-    if: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish_tag != '') }}
-    needs: publish
-    runs-on: ubuntu-latest
-    concurrency:
-      group: pages
-      cancel-in-progress: false
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    env:
-      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_tag || github.ref_name }}
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-      - run: pip install zensical
-      - run: zensical build --clean --strict
-      - name: Build Pages update manifest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json tagName,name,url,publishedAt > /tmp/kubus-latest-release.json
-          node hack/write-latest-manifest.mjs /tmp/kubus-latest-release.json site/latest.json
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
-        with:
-          name: github-pages-${{ github.run_attempt }}
-          path: site
-      - id: deployment
-        uses: actions/deploy-pages@v5
-        with:
-          artifact_name: github-pages-${{ github.run_attempt }}

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "5.0.1",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.5.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -90,7 +90,7 @@ function favoriteGvk(favorite: FavoriteItem, resources: ResourceKindInfo[]): str
   return resource ? gvkLabel(resource) : favorite.subtitle;
 }
 
-// Star toggle revealed on row hover (always visible once active).
+// Star toggle revealed on row hover; filled vs outlined shows favorite state.
 function FavStar({ active, onToggle, label }: { active: boolean; onToggle: () => void; label: string }) {
   return (
     <Tooltip title={active ? 'Remove favorite' : 'Add favorite'}>
@@ -104,8 +104,8 @@ function FavStar({ active, onToggle, label }: { active: boolean; onToggle: () =>
           onToggle();
         }}
         sx={{
-          opacity: active ? 1 : 0,
-          color: active ? 'warning.main' : 'text.secondary',
+          opacity: 0,
+          color: 'text.secondary',
           transition: 'opacity 120ms ease',
           '& svg': { fontSize: 16 },
           '&:focus-visible': { opacity: 1 },

--- a/docs/community/releasing.md
+++ b/docs/community/releasing.md
@@ -20,6 +20,7 @@ That's it. The release workflow then:
 1. Builds installers on each platform's runner.
 2. Creates the GitHub release for the tag if it doesn't exist yet.
 3. Attaches the `.exe`, `.dmg`, `.AppImage` and `.deb` artifacts to it.
+4. Publishes `latest.json`, which powers the in-app update check, as a release asset.
 
 !!! tip "Releasing from the GitHub UI"
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "5.0.1",
+  "version": "0.5.1",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.5.0",
+  "version": "5.0.1",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -30,7 +30,7 @@ const isLinux = process.platform === 'linux';
 
 // Must match the client TopBar height: its toolbar doubles as the titlebar.
 const TITLEBAR_HEIGHT = 52;
-const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/Kubus/latest.json';
+const UPDATE_MANIFEST_URL = 'https://github.com/FloSch62/Kubus/releases/latest/download/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 
 let mainWindow: BrowserWindow | undefined;

--- a/hack/write-latest-manifest.mjs
+++ b/hack/write-latest-manifest.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const [sourcePath = '', outPath = 'site/latest.json'] = process.argv.slice(2);
+const [sourcePath = '', outPath = 'latest.json'] = process.argv.slice(2);
 
 function readJson(file) {
   if (!file) return undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "5.0.1",
+  "version": "0.5.1",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.5.0",
+  "version": "5.0.1",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "5.0.1",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.5.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/routes/app.ts
+++ b/server/src/routes/app.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance } from 'fastify';
 import type { AppInfo, UpdateCheckResult } from '@kubus/shared';
 import type { AppContext } from '../app.js';
 
-const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/Kubus/latest.json';
+const UPDATE_MANIFEST_URL = 'https://github.com/FloSch62/Kubus/releases/latest/download/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 
 interface UpdateManifest {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "5.0.1",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.5.0",
+  "version": "5.0.1",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- soften the favorite star styling in the navigation drawer
- bump all workspace package versions to 0.5.1
- publish `latest.json` as an asset of each GitHub release
- make desktop and server update checks read the latest release asset
- keep documentation deployments independent from update metadata

## Root cause

The docs and release workflows could deploy different `latest.json` files to GitHub Pages under the same commit SHA. GitHub Pages reported the second deployment as successful while continuing to serve the artifact from the first deployment, leaving the update check on an older release.

Publishing the manifest with the release gives update metadata one owner and removes the competing Pages deployments.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build-docs`
- parsed both modified workflow files as YAML
- generated and validated a representative `latest.json` payload