### PR TITLE
shortcut cheatsheet, error boundaries, consistent layout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,8 @@ import { buildTheme } from './theme.js';
 import { setTitleBarMode } from './titlebar-overlay.js';
 import { useClustersStore } from './state/clusters.js';
 import { AppRouter } from './router.js';
+import { ErrorBoundary } from './components/ErrorBoundary.js';
+import { ToastHost } from './components/ToastHost.js';
 import { UpdateNotification } from './components/UpdateNotification.js';
 import { TitleBarAwareBackdrop } from './components/TitleBarAwareBackdrop.js';
 
@@ -29,7 +31,10 @@ export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AppRouter />
+      <ErrorBoundary label="Kubus">
+        <AppRouter />
+      </ErrorBoundary>
+      <ToastHost />
       <UpdateNotification />
     </ThemeProvider>
   );

--- a/client/src/components/ClusterSectionHeader.tsx
+++ b/client/src/components/ClusterSectionHeader.tsx
@@ -1,0 +1,14 @@
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+
+/** Header for one cluster's section on multi-cluster stacked pages (Overview, Metrics, Network). */
+export function ClusterSectionHeader({ ctx, children }: { ctx: string; children?: React.ReactNode }) {
+  return (
+    <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center', flexWrap: 'wrap', rowGap: 1 }}>
+      <HubOutlinedIcon sx={{ fontSize: 18, color: 'primary.main' }} />
+      <Typography variant="h6">{ctx}</Typography>
+      {children}
+    </Stack>
+  );
+}

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import { Component, type ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
+import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined';
+
+interface Props {
+  children: ReactNode;
+  /** Names the crashed surface in the fallback, e.g. "This tab" or "The details panel". */
+  label?: string;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Catches render errors so one crashing surface (a tab pane, the detail
+ * drawer) shows an inline fallback instead of white-screening the whole app.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', flex: 1, height: '100%', flexDirection: 'column', gap: 1.5, p: 4 }}>
+        <Box
+          sx={(theme) => ({
+            width: 72,
+            height: 72,
+            borderRadius: '50%',
+            display: 'grid',
+            placeItems: 'center',
+            color: 'error.main',
+            bgcolor: alpha(theme.palette.error.main, theme.palette.mode === 'dark' ? 0.12 : 0.07),
+            '& svg': { fontSize: 36 },
+          })}
+        >
+          <ErrorOutlinedIcon />
+        </Box>
+        <Typography variant="h6">{this.props.label ?? 'This view'} ran into an error</Typography>
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ maxWidth: 560, textAlign: 'center', fontFamily: 'monospace', whiteSpace: 'pre-wrap', overflowWrap: 'anywhere' }}
+        >
+          {error.message}
+        </Typography>
+        <Button variant="outlined" onClick={() => this.setState({ error: null })}>
+          Try again
+        </Button>
+      </Box>
+    );
+  }
+}

--- a/client/src/components/MetricsServerControls.tsx
+++ b/client/src/components/MetricsServerControls.tsx
@@ -7,13 +7,13 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import Snackbar from '@mui/material/Snackbar';
 import Typography from '@mui/material/Typography';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import type { MetricsServerStatus } from '@kubus/shared';
 import { useInstallMetricsServer, useUninstallMetricsServer } from '../api/queries.js';
 import { useIsProtected } from '../state/clusters.js';
+import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 
 /**
@@ -24,7 +24,6 @@ import { ConfirmDialog } from './ConfirmDialog.js';
 export function InstallMetricsServerButton({ ctx, size = 'small' }: { ctx: string; size?: 'small' | 'medium' }) {
   const [open, setOpen] = useState(false);
   const [insecureTls, setInsecureTls] = useState(false);
-  const [toast, setToast] = useState<string>();
   const install = useInstallMetricsServer();
   const isProtected = useIsProtected(ctx);
 
@@ -69,11 +68,11 @@ export function InstallMetricsServerButton({ ctx, size = 'small' }: { ctx: strin
                 {
                   onSuccess: (r) => {
                     setOpen(false);
-                    setToast(`metrics-server installed (${r.applied.length} resources applied) — waiting for first samples…`);
+                    showToast('success', `metrics-server installed (${r.applied.length} resources applied) — waiting for first samples…`);
                   },
                   onError: (e) => {
                     setOpen(false);
-                    setToast(`Install failed: ${e.message}`);
+                    showToast('error', `Install failed: ${e.message}`);
                   },
                 },
               )
@@ -83,14 +82,12 @@ export function InstallMetricsServerButton({ ctx, size = 'small' }: { ctx: strin
           </Button>
         </DialogActions>
       </Dialog>
-      <Snackbar open={!!toast} autoHideDuration={6000} onClose={() => setToast(undefined)} message={toast} />
     </>
   );
 }
 
 export function UninstallMetricsServerButton({ ctx, status }: { ctx: string; status?: MetricsServerStatus }) {
   const [open, setOpen] = useState(false);
-  const [toast, setToast] = useState<string>();
   const uninstall = useUninstallMetricsServer();
   const isProtected = useIsProtected(ctx);
 
@@ -126,17 +123,16 @@ export function UninstallMetricsServerButton({ ctx, status }: { ctx: string; sta
             {
               onSuccess: (r) => {
                 setOpen(false);
-                setToast(`metrics-server uninstalled: ${r.deleted.length} resources deleted${r.failed.length ? `, ${r.failed.length} failed` : ''}`);
+                showToast('success', `metrics-server uninstalled: ${r.deleted.length} resources deleted${r.failed.length ? `, ${r.failed.length} failed` : ''}`);
               },
               onError: (e) => {
                 setOpen(false);
-                setToast(`Uninstall failed: ${e.message}`);
+                showToast('error', `Uninstall failed: ${e.message}`);
               },
             },
           )
         }
       />
-      <Snackbar open={!!toast} autoHideDuration={6000} onClose={() => setToast(undefined)} message={toast} />
     </>
   );
 }

--- a/client/src/components/NetworkAgentControls.tsx
+++ b/client/src/components/NetworkAgentControls.tsx
@@ -5,13 +5,13 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import Snackbar from '@mui/material/Snackbar';
 import Typography from '@mui/material/Typography';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import type { NetworkAgentStatus } from '@kubus/shared';
 import { useInstallNetworkAgent, useUninstallNetworkAgent } from '../api/queries.js';
 import { useIsProtected } from '../state/clusters.js';
+import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 
 /**
@@ -21,7 +21,6 @@ import { ConfirmDialog } from './ConfirmDialog.js';
  */
 export function InstallNetworkAgentButton({ ctx, size = 'small' }: { ctx: string; size?: 'small' | 'medium' }) {
   const [open, setOpen] = useState(false);
-  const [toast, setToast] = useState<string>();
   const install = useInstallNetworkAgent();
   const isProtected = useIsProtected(ctx);
 
@@ -59,11 +58,11 @@ export function InstallNetworkAgentButton({ ctx, size = 'small' }: { ctx: string
                 {
                   onSuccess: (r) => {
                     setOpen(false);
-                    setToast(`Network agent installed (${r.applied.length} resources applied) — waiting for first samples…`);
+                    showToast('success', `Network agent installed (${r.applied.length} resources applied) — waiting for first samples…`);
                   },
                   onError: (e) => {
                     setOpen(false);
-                    setToast(`Install failed: ${e.message}`);
+                    showToast('error', `Install failed: ${e.message}`);
                   },
                 },
               )
@@ -73,14 +72,12 @@ export function InstallNetworkAgentButton({ ctx, size = 'small' }: { ctx: string
           </Button>
         </DialogActions>
       </Dialog>
-      <Snackbar open={!!toast} autoHideDuration={6000} onClose={() => setToast(undefined)} message={toast} />
     </>
   );
 }
 
 export function UninstallNetworkAgentButton({ ctx, status }: { ctx: string; status?: NetworkAgentStatus }) {
   const [open, setOpen] = useState(false);
-  const [toast, setToast] = useState<string>();
   const uninstall = useUninstallNetworkAgent();
   const isProtected = useIsProtected(ctx);
 
@@ -116,17 +113,16 @@ export function UninstallNetworkAgentButton({ ctx, status }: { ctx: string; stat
             {
               onSuccess: (r) => {
                 setOpen(false);
-                setToast(`Network agent uninstalled: ${r.deleted.length} resources deleted${r.failed.length ? `, ${r.failed.length} failed` : ''}`);
+                showToast('success', `Network agent uninstalled: ${r.deleted.length} resources deleted${r.failed.length ? `, ${r.failed.length} failed` : ''}`);
               },
               onError: (e) => {
                 setOpen(false);
-                setToast(`Uninstall failed: ${e.message}`);
+                showToast('error', `Uninstall failed: ${e.message}`);
               },
             },
           )
         }
       />
-      <Snackbar open={!!toast} autoHideDuration={6000} onClose={() => setToast(undefined)} message={toast} />
     </>
   );
 }

--- a/client/src/components/NoClustersState.tsx
+++ b/client/src/components/NoClustersState.tsx
@@ -1,0 +1,13 @@
+import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import { EmptyState } from './EmptyState.js';
+
+/** The shared zero-clusters empty state: identical copy on every page, page icon optional. */
+export function NoClustersState({ icon }: { icon?: React.ReactElement }) {
+  return (
+    <EmptyState
+      icon={icon ?? <HubOutlinedIcon />}
+      title="No cluster selected"
+      subtitle="Pick one or more clusters from the switcher in the top bar."
+    />
+  );
+}

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -14,19 +14,8 @@ import { SmartFilterInput } from './SmartFilterInput.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from './CellCopy.js';
 import type { MetricsLookup } from './columns.js';
 import { useUiPrefsStore } from '../state/prefs.js';
+import { isTextEntryTarget } from '../text-entry.js';
 import { usePaneActive } from '../layout/pane-context.js';
-
-function isTextEntryTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  return (
-    target.isContentEditable ||
-    tag === 'INPUT' ||
-    tag === 'TEXTAREA' ||
-    tag === 'SELECT' ||
-    !!target.closest('[contenteditable="true"], [role="textbox"], [role="dialog"], [role="menu"], [role="listbox"], .monaco-editor')
-  );
-}
 
 interface Props {
   rows: ClusterRow[];
@@ -112,14 +101,25 @@ export function ResourceTable({
 
   const hiddenKey = (hiddenFields ?? []).join(',');
   const visibilityFromHidden = () => Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []);
-  const [visibility, setVisibility] = useState<GridColumnVisibilityModel>(visibilityFromHidden);
-  // Reset user-edited visibility when the default-hidden set changes, without
+  // A saved model wins over the default-hidden set; without one, visibility
+  // starts from (and resets with) the defaults.
+  const storedVisibility = useUiPrefsStore((s) => (tableId ? s.columnVisibility[tableId] : undefined));
+  const setStoredVisibility = useUiPrefsStore((s) => s.setColumnVisibility);
+  const [visibility, setVisibility] = useState<GridColumnVisibilityModel>(() => storedVisibility ?? visibilityFromHidden());
+  // Reset unsaved visibility when the default-hidden set changes, without
   // paying an extra effect-driven render pass.
   const [prevHiddenKey, setPrevHiddenKey] = useState(hiddenKey);
   if (prevHiddenKey !== hiddenKey) {
     setPrevHiddenKey(hiddenKey);
-    setVisibility(visibilityFromHidden());
+    setVisibility(storedVisibility ?? visibilityFromHidden());
   }
+  const handleVisibilityChange = useCallback(
+    (model: GridColumnVisibilityModel) => {
+      setVisibility(model);
+      if (tableId) setStoredVisibility(tableId, model);
+    },
+    [tableId, setStoredVisibility],
+  );
   const tableDensity = useUiPrefsStore((s) => s.tableDensity);
   // Retrieve this table's saved column widths (if any)
   const storedWidths = useUiPrefsStore((s) => (tableId ? s.columnWidths[tableId] : undefined));
@@ -304,7 +304,7 @@ export function ResourceTable({
             : undefined
         }
         columnVisibilityModel={visibility}
-        onColumnVisibilityModelChange={setVisibility}
+        onColumnVisibilityModelChange={handleVisibilityChange}
         onColumnWidthChange={tableId ? (params) => setColumnWidth(tableId, params.colDef.field, params.width) : undefined}
         onCellKeyDown={handleCopyCellKeyDown}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -106,11 +106,13 @@ export function ResourceTable({
   const storedVisibility = useUiPrefsStore((s) => (tableId ? s.columnVisibility[tableId] : undefined));
   const setStoredVisibility = useUiPrefsStore((s) => s.setColumnVisibility);
   const [visibility, setVisibility] = useState<GridColumnVisibilityModel>(() => storedVisibility ?? visibilityFromHidden());
-  // Reset unsaved visibility when the default-hidden set changes, without
-  // paying an extra effect-driven render pass.
-  const [prevHiddenKey, setPrevHiddenKey] = useState(hiddenKey);
-  if (prevHiddenKey !== hiddenKey) {
-    setPrevHiddenKey(hiddenKey);
+  // Re-seed visibility when this instance is reused for another table (same
+  // route, different kind — tableId changes) or when the default-hidden set
+  // changes, without paying an extra effect-driven render pass.
+  const visibilityKey = `${tableId ?? ''}|${hiddenKey}`;
+  const [prevVisibilityKey, setPrevVisibilityKey] = useState(visibilityKey);
+  if (prevVisibilityKey !== visibilityKey) {
+    setPrevVisibilityKey(visibilityKey);
     setVisibility(storedVisibility ?? visibilityFromHidden());
   }
   const handleVisibilityChange = useCallback(

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -15,7 +15,6 @@ import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import Snackbar from '@mui/material/Snackbar';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -55,6 +54,7 @@ import {
 import { watchClient } from '../api/ws/watch-client.js';
 import { useDockStore, dockTabId, type DockTab } from '../state/dock.js';
 import { useIsProtected } from '../state/clusters.js';
+import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 import { FileCopyDialog } from './FileCopyDialog.js';
 import { podContainerNames } from '../kube-display.js';
@@ -115,37 +115,27 @@ async function openLogsForTarget(target: RowActionTarget, addTab: (tab: DockTab)
 export function RowLogsButton({ target }: { target: RowActionTarget }) {
   const addTab = useDockStore((s) => s.addTab);
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const actionKind = gvkForResource(target.group, target.version, target.plural)?.kind === target.kind ? target.kind : undefined;
   if (!actionKind || !isLogTargetKind(actionKind)) return null;
   return (
-    <>
-      <Tooltip title="Logs">
-        <span>
-          <IconButton
-            size="small"
-            aria-label={`Logs for ${target.obj.metadata.name}`}
-            disabled={busy}
-            onClick={(e) => {
-              e.stopPropagation();
-              setBusy(true);
-              openLogsForTarget(target, addTab)
-                .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
-                .finally(() => setBusy(false));
-            }}
-          >
-            <SubjectIcon fontSize="small" />
-          </IconButton>
-        </span>
-      </Tooltip>
-      {error !== null && (
-        <Snackbar open autoHideDuration={5000} onClose={() => setError(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
-          <Alert severity="error" variant="filled" onClose={() => setError(null)}>
-            {error}
-          </Alert>
-        </Snackbar>
-      )}
-    </>
+    <Tooltip title="Logs">
+      <span>
+        <IconButton
+          size="small"
+          aria-label={`Logs for ${target.obj.metadata.name}`}
+          disabled={busy}
+          onClick={(e) => {
+            e.stopPropagation();
+            setBusy(true);
+            openLogsForTarget(target, addTab)
+              .catch((err: unknown) => showToast('error', err instanceof Error ? err.message : String(err)))
+              .finally(() => setBusy(false));
+          }}
+        >
+          <SubjectIcon fontSize="small" />
+        </IconButton>
+      </span>
+    </Tooltip>
   );
 }
 
@@ -175,7 +165,6 @@ export function RowActions({ target }: { target: RowActionTarget }) {
 
 export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose }: RowActionMenuProps) {
   const [dialog, setDialog] = useState<'delete' | 'scale' | 'forward' | 'drain' | 'restart-rs' | 'set-image' | 'debug' | 'node-shell' | 'files' | null>(null);
-  const [toast, setToast] = useState<{ severity: 'success' | 'error'; text: string } | null>(null);
   const [logsBusy, setLogsBusy] = useState(false);
 
   const del = useDeleteResource();
@@ -194,8 +183,8 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const isProtected = useIsProtected(ctx);
   const close = onClose;
 
-  const ok = (text: string) => setToast({ severity: 'success', text });
-  const fail = (err: unknown) => setToast({ severity: 'error', text: err instanceof Error ? err.message : String(err) });
+  const ok = (text: string) => showToast('success', text);
+  const fail = (err: unknown) => showToast('error', err instanceof Error ? err.message : String(err));
 
   const scalable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'ReplicaSet';
   const restartable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'DaemonSet';
@@ -552,12 +541,6 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
       {dialog === 'set-image' && <SetImageDialog target={target} onClose={() => setDialog(null)} onDone={ok} onError={fail} />}
       {dialog === 'forward' && <PortForwardDialog target={target} onClose={() => setDialog(null)} onDone={ok} onError={fail} />}
       {dialog === 'drain' && <DrainDialog target={target} onClose={() => setDialog(null)} />}
-
-      <Snackbar open={!!toast} autoHideDuration={5000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
-        <Alert severity={toast?.severity} variant="filled" onClose={() => setToast(null)}>
-          {toast?.text}
-        </Alert>
-      </Snackbar>
     </>
   );
 }

--- a/client/src/components/ShortcutHelpDialog.tsx
+++ b/client/src/components/ShortcutHelpDialog.tsx
@@ -1,0 +1,147 @@
+import { Fragment } from 'react';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Grid from '@mui/material/Grid';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import CloseIcon from '@mui/icons-material/Close';
+import { MOD_KEY_LABEL } from '../platform.js';
+
+const MOD = MOD_KEY_LABEL;
+
+interface Shortcut {
+  /** Alternative key combos, each an array of keys pressed together. */
+  combos: string[][];
+  description: string;
+}
+
+const SECTIONS: Array<{ title: string; shortcuts: Shortcut[] }> = [
+  {
+    title: 'Global',
+    shortcuts: [
+      { combos: [[MOD, 'K']], description: 'Open the command palette' },
+      { combos: [['?']], description: 'Keyboard shortcuts (this dialog)' },
+      { combos: [[MOD, '1–9']], description: 'Open pinned favorite 1–9' },
+      { combos: [[MOD, 'W']], description: 'Close the focused dock or page tab' },
+      { combos: [['Esc']], description: 'Close dialog / details · exit maximized dock' },
+    ],
+  },
+  {
+    title: 'Command palette',
+    shortcuts: [
+      { combos: [['↑'], ['↓']], description: 'Move selection' },
+      { combos: [['Tab'], ['→']], description: 'Show actions for the selected resource' },
+      { combos: [['Enter']], description: 'Open the selected result' },
+    ],
+  },
+  {
+    title: 'Tabs & navigation',
+    shortcuts: [
+      { combos: [[MOD, 'Click'], ['Middle-click']], description: 'Open a link in a background tab' },
+      { combos: [['Middle-click']], description: 'Close a tab (on the tab strip)' },
+    ],
+  },
+  {
+    title: 'Resource lists',
+    shortcuts: [
+      { combos: [['S'], ['/'], [':']], description: 'Focus the filter input' },
+      { combos: [[MOD, 'F']], description: 'Focus the filter input' },
+      { combos: [[MOD, 'C']], description: 'Copy the focused cell' },
+      { combos: [['Right-click']], description: 'Open the row actions menu' },
+    ],
+  },
+  {
+    title: 'Logs',
+    shortcuts: [
+      { combos: [[MOD, 'F']], description: 'Focus find' },
+      { combos: [['Enter'], ['Shift', 'Enter']], description: 'Next / previous match' },
+    ],
+  },
+];
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <Box
+      component="kbd"
+      sx={{
+        fontFamily: 'monospace',
+        fontSize: 12,
+        lineHeight: 1,
+        px: 0.75,
+        py: 0.5,
+        border: 1,
+        borderColor: 'divider',
+        borderBottomWidth: 2,
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+function ShortcutRow({ combos, description }: Shortcut) {
+  return (
+    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', py: 0.5 }}>
+      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 150, flexWrap: 'wrap', rowGap: 0.5, flexShrink: 0 }}>
+        {combos.map((combo, i) => (
+          <Fragment key={i}>
+            {i > 0 && (
+              <Typography variant="caption" color="text.secondary">
+                or
+              </Typography>
+            )}
+            <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center' }}>
+              {combo.map((key, j) => (
+                <Fragment key={j}>
+                  {j > 0 && (
+                    <Typography variant="caption" color="text.secondary">
+                      +
+                    </Typography>
+                  )}
+                  <Kbd>{key}</Kbd>
+                </Fragment>
+              ))}
+            </Stack>
+          </Fragment>
+        ))}
+      </Stack>
+      <Typography variant="body2" color="text.secondary">
+        {description}
+      </Typography>
+    </Stack>
+  );
+}
+
+export function ShortcutHelpDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
+        Keyboard shortcuts
+        <Box sx={{ flex: 1 }} />
+        <IconButton size="small" onClick={onClose} aria-label="Close">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Grid container spacing={3}>
+          {SECTIONS.map((section) => (
+            <Grid key={section.title} size={{ xs: 12, sm: 6 }}>
+              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                {section.title}
+              </Typography>
+              {section.shortcuts.map((s) => (
+                <ShortcutRow key={s.description + s.combos.map((c) => c.join()).join()} {...s} />
+              ))}
+            </Grid>
+          ))}
+        </Grid>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/ToastHost.tsx
+++ b/client/src/components/ToastHost.tsx
@@ -1,0 +1,22 @@
+import Alert from '@mui/material/Alert';
+import Snackbar from '@mui/material/Snackbar';
+import { useToastStore } from '../state/toast.js';
+
+/** The single snackbar for all `showToast` notifications; mounted once in App. */
+export function ToastHost() {
+  const toast = useToastStore((s) => s.toast);
+  const dismiss = useToastStore((s) => s.dismiss);
+  return (
+    <Snackbar
+      key={toast?.id}
+      open={!!toast}
+      autoHideDuration={5000}
+      onClose={dismiss}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert severity={toast?.severity ?? 'info'} variant="filled" onClose={dismiss}>
+        {toast?.message}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -1,12 +1,10 @@
 import { useMemo, useState } from 'react';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Link from '@mui/material/Link';
-import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
 import Table from '@mui/material/Table';
@@ -28,6 +26,7 @@ import { AgeCell } from '../AgeCell.js';
 import { containerResources, podDebugContainers, podSummary } from '../../kube-display.js';
 import { usePodEnv, useResourceMetrics, useStopDebug } from '../../api/queries.js';
 import { useDetailStore } from '../../state/detail.js';
+import { showToast } from '../../state/toast.js';
 import { useDockStore, dockTabId } from '../../state/dock.js';
 
 interface ContainerSpec {
@@ -163,7 +162,6 @@ function DebugContainersSection({ obj, ctx }: { obj: KubeObject; ctx: string }) 
   const debugContainers = podDebugContainers(obj);
   const stop = useStopDebug();
   const addTab = useDockStore((s) => s.addTab);
-  const [toast, setToast] = useState<{ severity: 'success' | 'error'; text: string } | null>(null);
   if (!debugContainers.length) return null;
   const namespace = obj.metadata.namespace ?? '';
   const pod = obj.metadata.name;
@@ -216,8 +214,8 @@ function DebugContainersSection({ obj, ctx }: { obj: KubeObject; ctx: string }) 
                         stop.mutate(
                           { ctx, body: { namespace, pod, container: c.name } },
                           {
-                            onSuccess: () => setToast({ severity: 'success', text: `Stopping ${c.name} — it exits within a second` }),
-                            onError: (e) => setToast({ severity: 'error', text: e instanceof Error ? e.message : String(e) }),
+                            onSuccess: () => showToast('success', `Stopping ${c.name} — it exits within a second`),
+                            onError: (e) => showToast('error', e instanceof Error ? e.message : String(e)),
                           },
                         )
                       }
@@ -231,11 +229,6 @@ function DebugContainersSection({ obj, ctx }: { obj: KubeObject; ctx: string }) 
           ))}
         </TableBody>
       </Table>
-      <Snackbar open={!!toast} autoHideDuration={5000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
-        <Alert severity={toast?.severity} variant="filled" onClose={() => setToast(null)}>
-          {toast?.text}
-        </Alert>
-      </Snackbar>
     </Section>
   );
 }

--- a/client/src/components/detail/RolloutHistory.tsx
+++ b/client/src/components/detail/RolloutHistory.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import Snackbar from '@mui/material/Snackbar';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -13,6 +12,7 @@ import UndoIcon from '@mui/icons-material/Undo';
 import type { KubeObject } from '@kubus/shared';
 import { useRolloutHistory, useRolloutUndo } from '../../api/queries.js';
 import { useIsProtected } from '../../state/clusters.js';
+import { showToast } from '../../state/toast.js';
 import { AgeCell } from '../AgeCell.js';
 import { ConfirmDialog } from '../ConfirmDialog.js';
 
@@ -23,7 +23,6 @@ export function RolloutHistory({ ctx, kind, obj }: { ctx: string; kind: 'Deploym
   const undo = useRolloutUndo();
   const isProtected = useIsProtected(ctx);
   const [confirmRevision, setConfirmRevision] = useState<number | null>(null);
-  const [toast, setToast] = useState<{ severity: 'success' | 'error'; text: string } | null>(null);
   const paused = !!(obj.spec as { paused?: boolean })?.paused;
 
   if (error) return <Alert severity="error" sx={{ m: 2 }}>{error.message}</Alert>;
@@ -96,21 +95,16 @@ export function RolloutHistory({ ctx, kind, obj }: { ctx: string; kind: 'Deploym
             {
               onSuccess: () => {
                 setConfirmRevision(null);
-                setToast({ severity: 'success', text: `Rolled back ${name} to revision ${confirmRevision}` });
+                showToast('success', `Rolled back ${name} to revision ${confirmRevision}`);
               },
               onError: (e) => {
                 setConfirmRevision(null);
-                setToast({ severity: 'error', text: e instanceof Error ? e.message : String(e) });
+                showToast('error', e instanceof Error ? e.message : String(e));
               },
             },
           )
         }
       />
-      <Snackbar open={!!toast} autoHideDuration={5000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
-        <Alert severity={toast?.severity} variant="filled" onClose={() => setToast(null)}>
-          {toast?.text}
-        </Alert>
-      </Snackbar>
     </>
   );
 }

--- a/client/src/components/grid-prefs.ts
+++ b/client/src/components/grid-prefs.ts
@@ -1,0 +1,30 @@
+import { useCallback, useMemo } from 'react';
+import type { GridColDef, GridColumnResizeParams, GridDensity, GridValidRowModel } from '@mui/x-data-grid';
+import { useUiPrefsStore } from '../state/prefs.js';
+
+/**
+ * Shared prefs for plain DataGrid pages (Events, Helm, Port Forwards): the
+ * Settings density preference plus per-table persisted column widths, matching
+ * ResourceTable's behavior.
+ */
+export function useGridPrefs<R extends GridValidRowModel>(
+  tableId: string,
+  columns: GridColDef<R>[],
+): { density: GridDensity; columns: GridColDef<R>[]; onColumnWidthChange: (params: GridColumnResizeParams) => void } {
+  const tableDensity = useUiPrefsStore((s) => s.tableDensity);
+  const storedWidths = useUiPrefsStore((s) => s.columnWidths[tableId]);
+  const setColumnWidth = useUiPrefsStore((s) => s.setColumnWidth);
+  const sizedColumns = useMemo(
+    () =>
+      columns.map((column) => {
+        const width = storedWidths?.[column.field];
+        return width === undefined ? column : { ...column, width, flex: undefined };
+      }),
+    [columns, storedWidths],
+  );
+  const onColumnWidthChange = useCallback(
+    (params: GridColumnResizeParams) => setColumnWidth(tableId, params.colDef.field, params.width),
+    [setColumnWidth, tableId],
+  );
+  return { density: tableDensity === 'comfortable' ? 'standard' : 'compact', columns: sizedColumns, onColumnWidthChange };
+}

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { NavDrawer } from './NavDrawer.js';
 import { TabsBar } from './TabsBar.js';
 import { TabPanes } from './TabPanes.js';
 import { BottomDock } from './BottomDock.js';
+import { ErrorBoundary } from '../components/ErrorBoundary.js';
 import { useDockStore } from '../state/dock.js';
 import { useDetailStore } from '../state/detail.js';
 import { useTabsStore } from '../state/tabs.js';
@@ -47,7 +48,8 @@ export function AppShell() {
   }, [closeDetail, navigate]);
 
   // Cmd/Ctrl+W closes the focused dock tab (logs/terminal), then the active
-  // page tab, and only closes the window once a single page tab remains.
+  // page tab. With a single page tab left it does nothing — the chord must
+  // never close the window itself.
   useEffect(() => {
     const desktop = window.kubusDesktop;
     if (!desktop?.onCloseTab) return;
@@ -63,9 +65,7 @@ export function AppShell() {
         const next = useTabsStore.getState();
         const active = next.tabs.find((t) => t.id === next.activeId);
         if (active) void navigate(active.path);
-        return;
       }
-      desktop.closeWindow();
     });
   }, [navigate]);
 
@@ -85,9 +85,11 @@ export function AppShell() {
         </Box>
       </Box>
       {drawerMounted && (
-        <Suspense fallback={null}>
-          <ResourceDetailDrawer sel={detailIsEmbedded ? undefined : sel} onClose={handleDrawerClose} onBack={hasParent ? back : undefined} />
-        </Suspense>
+        <ErrorBoundary label="The details panel">
+          <Suspense fallback={null}>
+            <ResourceDetailDrawer sel={detailIsEmbedded ? undefined : sel} onClose={handleDrawerClose} onBack={hasParent ? back : undefined} />
+          </Suspense>
+        </ErrorBoundary>
       )}
     </Box>
   );

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -32,6 +32,7 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 import { BUILTIN_NAV_GROUPS, groupToPath, gvkForResource, gvkLabel, pluralLabel, type FavoriteItem, type ResourceKindInfo, type SavedView } from '@kubus/shared';
 import { useApiResourcesForContexts } from '../api/queries.js';
+import { HOTKEY_MOD_LABEL } from '../platform.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useTabsStore } from '../state/tabs.js';
@@ -43,8 +44,6 @@ const ITEM_INDENT = '42px';
 const FAVORITE_DRAG_TYPE = 'application/x-kubus-favorite';
 const CUSTOM_GROUP_PREFIX = 'custom:';
 
-const IS_MAC = window.kubusDesktop ? window.kubusDesktop.platform === 'darwin' : /Mac|iP(hone|ad|od)/.test(navigator.platform);
-const HOTKEY_MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl+';
 
 /**
  * The first nine navigable favorites, in sidebar order, get Cmd/Ctrl+1–9.

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Dialog from '@mui/material/Dialog';
@@ -9,7 +8,6 @@ import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
-import Snackbar from '@mui/material/Snackbar';
 import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
@@ -25,6 +23,7 @@ import { useGlobalSearch } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useDockStore } from '../state/dock.js';
+import { showToast } from '../state/toast.js';
 import { actionsForRef, usePaletteRunner, type PaletteAction } from '../actions/resource-actions.js';
 
 function pathForRef(ref: ResourceRef): string {
@@ -82,7 +81,6 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const [stage, setStage] = useState<{ ref: ResourceRef; title: string } | null>(null);
-  const [toast, setToast] = useState<{ severity: 'success' | 'error'; text: string } | null>(null);
   const deferredQuery = useDeferredValue(query);
   const commandMode = query.startsWith('>');
   const searchQuery = stage || commandMode ? '' : query;
@@ -172,8 +170,8 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
       const { ref } = stage;
       closeAll();
       void runAction(action, ref)
-        .then((text) => setToast({ severity: 'success', text }))
-        .catch((err: unknown) => setToast({ severity: 'error', text: err instanceof Error ? err.message : String(err) }));
+        .then((text) => showToast('success', text))
+        .catch((err: unknown) => showToast('error', err instanceof Error ? err.message : String(err)));
       return;
     }
     const item = row.result;
@@ -328,11 +326,6 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
           </List>
         </DialogContent>
       </Dialog>
-      <Snackbar open={!!toast} autoHideDuration={5000} onClose={() => setToast(null)} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
-        <Alert severity={toast?.severity} variant="filled" onClose={() => setToast(null)}>
-          {toast?.text}
-        </Alert>
-      </Snackbar>
     </>
   );
 }

--- a/client/src/layout/TabPanes.tsx
+++ b/client/src/layout/TabPanes.tsx
@@ -2,6 +2,7 @@ import { memo, useContext, useMemo, useRef } from 'react';
 import Box from '@mui/material/Box';
 import { UNSAFE_LocationContext, parsePath } from 'react-router';
 import { PageRoutes } from '../router.js';
+import { ErrorBoundary } from '../components/ErrorBoundary.js';
 import { PaneActiveContext } from './pane-context.js';
 import { useTabsStore } from '../state/tabs.js';
 
@@ -58,7 +59,9 @@ const TabPane = memo(function TabPane({ id, path, active }: { id: string; path: 
     () => (
       <UNSAFE_LocationContext.Provider value={value}>
         <Box sx={{ position: 'absolute', inset: 0, overflow: 'auto', display: 'flex', flexDirection: 'column' }}>
-          <PageRoutes />
+          <ErrorBoundary label="This tab">
+            <PageRoutes />
+          </ErrorBoundary>
         </Box>
       </UNSAFE_LocationContext.Provider>
     ),

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -8,12 +8,15 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import BrightnessAutoOutlinedIcon from '@mui/icons-material/BrightnessAutoOutlined';
 import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
+import KeyboardOutlinedIcon from '@mui/icons-material/KeyboardOutlined';
 import LightModeOutlinedIcon from '@mui/icons-material/LightModeOutlined';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import SearchIcon from '@mui/icons-material/Search';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { useClustersStore } from '../state/clusters.js';
 import { useDockStore } from '../state/dock.js';
+import { isTextEntryTarget } from '../text-entry.js';
+import { ShortcutHelpDialog } from '../components/ShortcutHelpDialog.js';
 import { ClusterSwitcher } from './ClusterSwitcher.js';
 import { NamespaceFilter } from './NamespaceFilter.js';
 
@@ -32,6 +35,7 @@ export const TopBar = memo(function TopBar() {
   const setDockOpen = useDockStore((s) => s.setOpen);
   const [searchOpen, setSearchOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   // Mounted on first open, kept mounted after so close animations still play.
   const [searchMounted, setSearchMounted] = useState(false);
   const [settingsMounted, setSettingsMounted] = useState(false);
@@ -43,6 +47,11 @@ export const TopBar = memo(function TopBar() {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
         setSearchOpen(true);
+        return;
+      }
+      if (e.key === '?' && !e.metaKey && !e.ctrlKey && !e.altKey && !isTextEntryTarget(e.target)) {
+        e.preventDefault();
+        setShortcutsOpen(true);
       }
     };
     window.addEventListener('keydown', onKey);
@@ -105,6 +114,11 @@ export const TopBar = memo(function TopBar() {
               </IconButton>
             </Tooltip>
           )}
+          <Tooltip title="Keyboard shortcuts (?)">
+            <IconButton size="small" aria-label="Keyboard shortcuts" onClick={() => setShortcutsOpen(true)}>
+              <KeyboardOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
           <Tooltip title={mode === 'light' ? 'Switch to dark mode' : mode === 'dark' ? 'Follow system theme' : 'Switch to light mode'}>
             <IconButton size="small" onClick={toggleTheme}>
               {mode === 'light' ? <DarkModeOutlinedIcon fontSize="small" /> : mode === 'dark' ? <BrightnessAutoOutlinedIcon fontSize="small" /> : <LightModeOutlinedIcon fontSize="small" />}
@@ -127,6 +141,7 @@ export const TopBar = memo(function TopBar() {
           <SettingsDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
         </Suspense>
       )}
+      <ShortcutHelpDialog open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
     </>
   );
 });

--- a/client/src/pages/AuditPage.tsx
+++ b/client/src/pages/AuditPage.tsx
@@ -19,7 +19,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import DownloadIcon from '@mui/icons-material/Download';
 import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import GppMaybeOutlinedIcon from '@mui/icons-material/GppMaybeOutlined';
 import VerifiedUserOutlinedIcon from '@mui/icons-material/VerifiedUserOutlined';
 import { useQueryClient } from '@tanstack/react-query';
 import type { AuditFinding, AuditSeverity } from '@kubus/shared';
@@ -28,6 +28,8 @@ import { useClustersStore } from '../state/clusters.js';
 import { useDetailStore } from '../state/detail.js';
 import { useAuditPrefsStore } from '../state/audit.js';
 import { EmptyState } from '../components/EmptyState.js';
+import { NoClustersState } from '../components/NoClustersState.js';
+import { PageHeader } from '../components/PageHeader.js';
 
 const SEVERITIES: AuditSeverity[] = ['critical', 'high', 'medium', 'low'];
 
@@ -140,7 +142,7 @@ export function AuditPage() {
   const listErrors = reports.flatMap((r) => (r.report?.errors ?? []).map((e) => `${r.ctx}: ${e}`));
 
   if (selected.length === 0) {
-    return <EmptyState icon={<HubOutlinedIcon />} title="No cluster selected" subtitle="Pick one or more clusters from the switcher in the top bar." />;
+    return <NoClustersState icon={<GppMaybeOutlinedIcon />} />;
   }
   if (isLoading) {
     return <EmptyState icon={<CircularProgress size={40} />} title="Auditing…" subtitle={`Running security checks across ${selected.join(', ')}`} />;
@@ -157,8 +159,7 @@ export function AuditPage() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'auto', px: 1.5, pt: 1.5, pb: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-        <Typography variant="h6">Security Audit</Typography>
+      <PageHeader title="Security Audit" icon={<GppMaybeOutlinedIcon />}>
         <Typography variant="caption" color="text.secondary">
           {checksRun} checks · {totalScanned} resources · {selected.length} cluster{selected.length > 1 ? 's' : ''}
         </Typography>
@@ -180,7 +181,7 @@ export function AuditPage() {
         <Button size="small" startIcon={<DownloadIcon />} onClick={() => downloadFile('kubus-audit.sarif', 'application/json', toSarif(activeFindings))}>
           SARIF
         </Button>
-      </Box>
+      </PageHeader>
 
       <Stack direction="row" spacing={1} sx={{ mt: 1, alignItems: 'center', flexWrap: 'wrap' }}>
         {SEVERITIES.map((s) => (

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -13,7 +13,7 @@ import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import SearchIcon from '@mui/icons-material/Search';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { gvkForKind, type KubeObject } from '@kubus/shared';
 import { useApiResourcesForContexts, useWatchedList, type ClusterRow } from '../api/queries.js';
@@ -21,8 +21,10 @@ import { useClustersStore } from '../state/clusters.js';
 import { useDetailStore } from '../state/detail.js';
 import { AgeCell } from '../components/AgeCell.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
+import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
-import { EmptyState } from '../components/EmptyState.js';
+import { NoClustersState } from '../components/NoClustersState.js';
+import { PageHeader } from '../components/PageHeader.js';
 
 interface EventObj extends KubeObject {
   type?: string;
@@ -194,8 +196,10 @@ export function EventsPage() {
     return defs.map(withCellCopy);
   }, [selected.length]);
 
+  const grid = useGridPrefs('events', columns);
+
   if (selected.length === 0) {
-    return <EmptyState icon={<HubOutlinedIcon />} title="No cluster selected" subtitle="Pick one or more clusters from the switcher in the top bar." />;
+    return <NoClustersState icon={<NotificationsNoneOutlinedIcon />} />;
   }
 
   const errors = Object.entries(list.status).filter(([, s]) => s.state === 'error');
@@ -203,7 +207,9 @@ export function EventsPage() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Box sx={{ px: 1.5, pt: 1.5 }}>
-        <Typography variant="h6">Events</Typography>
+        <PageHeader title="Events" icon={<NotificationsNoneOutlinedIcon />}>
+          <Chip label={`${rows.length} events`} variant="outlined" />
+        </PageHeader>
         {errors.map(([ctx, s]) => (
           <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>
             {ctx}: {s.message ?? 'watch error'}
@@ -241,14 +247,14 @@ export function EventsPage() {
           control={<Switch size="small" checked={warningsOnly} onChange={(e) => setWarningsOnly(e.target.checked)} />}
           label={<Typography variant="body2">Warnings only</Typography>}
         />
-        <Chip label={`${rows.length} events`} variant="outlined" />
       </Stack>
       <DataGrid
         rows={rows}
-        columns={columns}
+        columns={grid.columns}
         loading={Object.values(list.status).some((s) => s.state === 'loading')}
         getRowId={(r) => r.id}
-        density="compact"
+        density={grid.density}
+        onColumnWidthChange={grid.onColumnWidthChange}
         onRowClick={(p) => openInvolved(p.row as EventRow)}
         onCellKeyDown={handleCopyCellKeyDown}
         initialState={{ sorting: { sortModel: [{ field: 'lastSeen', sort: 'desc' }] } }}

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -9,9 +9,10 @@ import type { HelmReleaseSummary } from '@kubus/shared';
 import { useHelmReleases } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
+import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { AgeCell } from '../components/AgeCell.js';
-import { EmptyState } from '../components/EmptyState.js';
+import { NoClustersState } from '../components/NoClustersState.js';
 import { PageHeader } from '../components/PageHeader.js';
 
 interface Row {
@@ -58,10 +59,10 @@ export function HelmPage() {
     return defs.map(withCellCopy);
   }, [selected.length]);
 
+  const grid = useGridPrefs('helm-releases', columns);
+
   if (selected.length === 0) {
-    return (
-      <EmptyState icon={<SailingOutlinedIcon />} title="No cluster selected" subtitle="Select a cluster to view Helm releases." />
-    );
+    return <NoClustersState icon={<SailingOutlinedIcon />} />;
   }
 
   return (
@@ -71,10 +72,11 @@ export function HelmPage() {
       </PageHeader>
       <DataGrid
         rows={rows}
-        columns={columns}
+        columns={grid.columns}
         loading={isLoading}
         getRowId={(r) => `${r.ctx}/${r.release.namespace}/${r.release.name}`}
-        density="compact"
+        density={grid.density}
+        onColumnWidthChange={grid.onColumnWidthChange}
         onRowClick={(p) => navigate(`/helm/${encodeURIComponent(p.row.ctx)}/${encodeURIComponent(p.row.release.namespace)}/${encodeURIComponent(p.row.release.name)}`)}
         onCellKeyDown={handleCopyCellKeyDown}
         sx={{ border: 0, '& .MuiDataGrid-row': { cursor: 'pointer' }, ...copyCellGridSx }}

--- a/client/src/pages/HelmReleaseDetail.tsx
+++ b/client/src/pages/HelmReleaseDetail.tsx
@@ -5,7 +5,6 @@ import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Link from '@mui/material/Link';
-import Snackbar from '@mui/material/Snackbar';
 import Stack from '@mui/material/Stack';
 import Tab from '@mui/material/Tab';
 import Table from '@mui/material/Table';
@@ -27,6 +26,7 @@ import { StatusChip } from '../components/StatusChip.js';
 import { AgeCell } from '../components/AgeCell.js';
 import { ConfirmDialog } from '../components/ConfirmDialog.js';
 import { useIsProtected } from '../state/clusters.js';
+import { showToast } from '../state/toast.js';
 
 export function HelmReleaseDetailPage() {
   const { ctx, ns, name } = useParams<{ ctx: string; ns: string; name: string }>();
@@ -40,7 +40,6 @@ export function HelmReleaseDetailPage() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [rollbackTo, setRollbackTo] = useState<number | null>(null);
   const [diffRange, setDiffRange] = useState<{ from: number; to: number } | null>(null);
-  const [toast, setToast] = useState<string>();
 
   const valuesYaml = useMemo(() => (release ? dumpYaml(release.values ?? {}, { noRefs: true }) : ''), [release]);
   const computedYaml = useMemo(() => (release ? dumpYaml(release.computedValues ?? {}, { noRefs: true }) : ''), [release]);
@@ -154,12 +153,12 @@ export function HelmReleaseDetailPage() {
             {
               onSuccess: (r) => {
                 setConfirmOpen(false);
-                setToast(`Uninstalled: ${r.deleted.length} resources deleted${r.failed.length ? `, ${r.failed.length} failed` : ''}`);
+                showToast('success', `Uninstalled: ${r.deleted.length} resources deleted${r.failed.length ? `, ${r.failed.length} failed` : ''}`);
                 setTimeout(() => navigate('/helm'), 1200);
               },
               onError: (e) => {
                 setConfirmOpen(false);
-                setToast(`Uninstall failed: ${e.message}`);
+                showToast('error', `Uninstall failed: ${e.message}`);
               },
             },
           )
@@ -185,11 +184,11 @@ export function HelmReleaseDetailPage() {
             {
               onSuccess: (r) => {
                 setRollbackTo(null);
-                setToast(`Rolled back to revision ${rollbackTo} (new revision ${r.newRevision}, ${r.applied.length} applied${r.pruned.length ? `, ${r.pruned.length} pruned` : ''}${r.failed.length ? `, ${r.failed.length} failed` : ''})`);
+                showToast('success', `Rolled back to revision ${rollbackTo} (new revision ${r.newRevision}, ${r.applied.length} applied${r.pruned.length ? `, ${r.pruned.length} pruned` : ''}${r.failed.length ? `, ${r.failed.length} failed` : ''})`);
               },
               onError: (e) => {
                 setRollbackTo(null);
-                setToast(`Rollback failed: ${e.message}`);
+                showToast('error', `Rollback failed: ${e.message}`);
               },
             },
           )
@@ -206,7 +205,6 @@ export function HelmReleaseDetailPage() {
           onClose={() => setDiffRange(null)}
         />
       )}
-      <Snackbar open={!!toast} autoHideDuration={5000} onClose={() => setToast(undefined)} message={toast} />
     </Box>
   );
 }

--- a/client/src/pages/MetricsPage.tsx
+++ b/client/src/pages/MetricsPage.tsx
@@ -13,8 +13,8 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
+import Skeleton from '@mui/material/Skeleton';
 import { alpha, useTheme } from '@mui/material/styles';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
 import MemoryOutlinedIcon from '@mui/icons-material/MemoryOutlined';
 import SdStorageOutlinedIcon from '@mui/icons-material/SdStorageOutlined';
@@ -25,7 +25,8 @@ import { LineChart } from '@mui/x-charts/LineChart';
 import type { ClusterMetricsSummary, MetricsSeriesEntry } from '@kubus/shared';
 import { useMetricsServerStatus, useMetricsSummary } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
-import { EmptyState } from '../components/EmptyState.js';
+import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
+import { NoClustersState } from '../components/NoClustersState.js';
 import { InstallMetricsServerButton, UninstallMetricsServerButton } from '../components/MetricsServerControls.js';
 import { formatBytes, formatCpu } from '../components/format.js';
 
@@ -42,7 +43,7 @@ export function MetricsPage() {
   const selected = useClustersStore((s) => s.selected);
 
   if (selected.length === 0) {
-    return <EmptyState icon={<QueryStatsOutlinedIcon />} title="Metrics" subtitle="Select one or more clusters in the top bar to see usage graphs." />;
+    return <NoClustersState icon={<QueryStatsOutlinedIcon />} />;
   }
 
   return (
@@ -65,9 +66,7 @@ function ClusterMetricsSection({ ctx }: { ctx: string }) {
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center', flexWrap: 'wrap', rowGap: 1 }}>
-        <HubOutlinedIcon sx={{ fontSize: 18, color: 'primary.main' }} />
-        <Typography variant="h6">{ctx}</Typography>
+      <ClusterSectionHeader ctx={ctx}>
         {status?.version && <Chip size="small" variant="outlined" label={`metrics-server ${status.version}`} />}
         {installed && (
           <Chip
@@ -79,10 +78,10 @@ function ClusterMetricsSection({ ctx }: { ctx: string }) {
         )}
         <Box sx={{ flex: 1 }} />
         {installed && <UninstallMetricsServerButton ctx={ctx} status={status} />}
-      </Stack>
+      </ClusterSectionHeader>
 
       {error && <Alert severity="error">{error.message}</Alert>}
-      {!error && !status && <LinearProgress />}
+      {!error && !status && <Skeleton variant="rounded" height={140} />}
 
       {status && !installed && !available && (
         <Card variant="outlined">

--- a/client/src/pages/NetworkMetricsPage.tsx
+++ b/client/src/pages/NetworkMetricsPage.tsx
@@ -13,8 +13,8 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
+import Skeleton from '@mui/material/Skeleton';
 import { alpha, useTheme } from '@mui/material/styles';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import NetworkCheckOutlinedIcon from '@mui/icons-material/NetworkCheckOutlined';
 import SpeedOutlinedIcon from '@mui/icons-material/SpeedOutlined';
 import SyncAltOutlinedIcon from '@mui/icons-material/SyncAltOutlined';
@@ -25,7 +25,8 @@ import { LineChart } from '@mui/x-charts/LineChart';
 import type { ClusterNetworkSummary, NetworkPeer, NetworkSeriesEntry } from '@kubus/shared';
 import { useNetworkAgentStatus, useNetworkSummary } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
-import { EmptyState } from '../components/EmptyState.js';
+import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
+import { NoClustersState } from '../components/NoClustersState.js';
 import { InstallNetworkAgentButton, UninstallNetworkAgentButton } from '../components/NetworkAgentControls.js';
 import { formatBps } from '../components/format.js';
 
@@ -40,13 +41,7 @@ export function NetworkMetricsPage() {
   const selected = useClustersStore((s) => s.selected);
 
   if (selected.length === 0) {
-    return (
-      <EmptyState
-        icon={<NetworkCheckOutlinedIcon />}
-        title="Network Metrics"
-        subtitle="Select one or more clusters in the top bar to see pod-to-pod traffic."
-      />
-    );
+    return <NoClustersState icon={<NetworkCheckOutlinedIcon />} />;
   }
 
   return (
@@ -69,9 +64,7 @@ function ClusterNetworkSection({ ctx }: { ctx: string }) {
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center', flexWrap: 'wrap', rowGap: 1 }}>
-        <HubOutlinedIcon sx={{ fontSize: 18, color: 'primary.main' }} />
-        <Typography variant="h6">{ctx}</Typography>
+      <ClusterSectionHeader ctx={ctx}>
         {status?.version && <Chip size="small" variant="outlined" label={`retina ${status.version}`} />}
         {installed && (
           <Chip
@@ -86,10 +79,10 @@ function ClusterNetworkSection({ ctx }: { ctx: string }) {
         )}
         <Box sx={{ flex: 1 }} />
         {installed && <UninstallNetworkAgentButton ctx={ctx} status={status} />}
-      </Stack>
+      </ClusterSectionHeader>
 
       {error && <Alert severity="error">{error.message}</Alert>}
-      {!error && !status && <LinearProgress />}
+      {!error && !status && <Skeleton variant="rounded" height={140} />}
 
       {status && !installed && !available && (
         <Card variant="outlined">

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -6,6 +6,7 @@ import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import LinearProgress from '@mui/material/LinearProgress';
+import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -20,7 +21,6 @@ import ViewInArOutlinedIcon from '@mui/icons-material/ViewInArOutlined';
 import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
 import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
@@ -28,6 +28,7 @@ import { useNavigate } from 'react-router';
 import { useNodeMetrics, useOverview } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { AgeCell } from '../components/AgeCell.js';
+import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { EmptyState } from '../components/EmptyState.js';
 import { InstallMetricsServerButton } from '../components/MetricsServerControls.js';
 import { StatusChip } from '../components/StatusChip.js';
@@ -70,11 +71,8 @@ function ClusterOverviewSection({ ctx }: { ctx: string }) {
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center' }}>
-        <HubOutlinedIcon sx={{ fontSize: 18, color: 'primary.main' }} />
-        <Typography variant="h6">{ctx}</Typography>
-      </Stack>
-      {isLoading && <LinearProgress />}
+      <ClusterSectionHeader ctx={ctx} />
+      {isLoading && <OverviewSkeleton />}
       {error && <Alert severity="error">{error.message}</Alert>}
       {data && (
         <>
@@ -227,6 +225,22 @@ function ClusterOverviewSection({ ctx }: { ctx: string }) {
         </>
       )}
     </Box>
+  );
+}
+
+/** Content-shaped placeholders matching the stat-card grid and node-usage card. */
+function OverviewSkeleton() {
+  return (
+    <>
+      <Grid container spacing={1.5} sx={{ mb: 2 }}>
+        {Array.from({ length: 8 }, (_, i) => (
+          <Grid key={i} size={{ xs: 6, sm: 4, md: 2 }}>
+            <Skeleton variant="rounded" height={62} />
+          </Grid>
+        ))}
+      </Grid>
+      <Skeleton variant="rounded" height={120} />
+    </>
   );
 }
 

--- a/client/src/pages/PortForwardsPage.tsx
+++ b/client/src/pages/PortForwardsPage.tsx
@@ -11,6 +11,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import type { PortForwardInfo } from '@kubus/shared';
 import { usePortForwards, useStopPortForward } from '../api/queries.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
+import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { EmptyState } from '../components/EmptyState.js';
 import { PageHeader } from '../components/PageHeader.js';
@@ -65,6 +66,8 @@ export function PortForwardsPage() {
     return defs.map(withCellCopy);
   }, [stop]);
 
+  const grid = useGridPrefs('port-forwards', columns);
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5 }}>
       <PageHeader title="Port Forwards" icon={<CableOutlinedIcon />}>
@@ -79,10 +82,11 @@ export function PortForwardsPage() {
       ) : (
         <DataGrid
           rows={data ?? []}
-          columns={columns}
+          columns={grid.columns}
           loading={isLoading}
           getRowId={(r) => r.id}
-          density="compact"
+          density={grid.density}
+          onColumnWidthChange={grid.onColumnWidthChange}
           onCellKeyDown={handleCopyCellKeyDown}
           sx={{ border: 0, ...copyCellGridSx }}
         />

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -13,7 +13,6 @@ import AddIcon from '@mui/icons-material/Add';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import SubjectIcon from '@mui/icons-material/Subject';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import BookmarkAddOutlinedIcon from '@mui/icons-material/BookmarkAddOutlined';
 import { useParams, useSearchParams } from 'react-router';
 import { columnsForKind, groupFromPath, groupToPath, gvkForResource, gvkLabel, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
@@ -27,7 +26,7 @@ import { ResourceDetailPanel, type ResourceSelection } from '../components/Resou
 import { clampDetailWidth, DEFAULT_DETAIL_WIDTH, useDetailStore } from '../state/detail.js';
 import { isLogTargetKind, RowActionMenu, RowActions, RowLogsButton, type RowActionTarget } from '../components/RowActions.js';
 import { YamlEditor } from '../components/YamlEditor.js';
-import { EmptyState } from '../components/EmptyState.js';
+import { NoClustersState } from '../components/NoClustersState.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { usePaneActive } from '../layout/pane-context.js';
 import { addLabelTerm } from '../label-selector.js';
@@ -438,13 +437,7 @@ export function ResourceListPage() {
   }, [list.rows, sel]);
 
   if (selected.length === 0) {
-    return (
-      <EmptyState
-        icon={<HubOutlinedIcon />}
-        title="No cluster selected"
-        subtitle="Pick one or more clusters from the switcher in the top bar."
-      />
-    );
+    return <NoClustersState />;
   }
 
   const multiLogs = kind === 'Pod' && selectedRows.length > 0;

--- a/client/src/pages/TopologyPage.tsx
+++ b/client/src/pages/TopologyPage.tsx
@@ -1,8 +1,7 @@
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
 import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
-import { EmptyState } from '../components/EmptyState.js';
+import { NoClustersState } from '../components/NoClustersState.js';
 import { PageHeader } from '../components/PageHeader.js';
 import { TopologyGraph } from '../components/TopologyGraph.js';
 import { useClustersStore } from '../state/clusters.js';
@@ -12,13 +11,7 @@ export function TopologyPage() {
   const namespaces = useClustersStore((s) => s.namespaces);
 
   if (selected.length === 0) {
-    return (
-      <EmptyState
-        icon={<HubOutlinedIcon />}
-        title="No cluster selected"
-        subtitle="Pick one or more clusters from the switcher to view topology."
-      />
-    );
+    return <NoClustersState icon={<AccountTreeOutlinedIcon />} />;
   }
 
   return (

--- a/client/src/platform.ts
+++ b/client/src/platform.ts
@@ -1,0 +1,8 @@
+/** True on macOS — the desktop app reports the real platform; browsers are sniffed. */
+export const IS_MAC = window.kubusDesktop ? window.kubusDesktop.platform === 'darwin' : /Mac|iP(hone|ad|od)/.test(navigator.platform);
+
+/** Prefix for rendering a mod-key shortcut inline, e.g. "⌘1" / "Ctrl+1". */
+export const HOTKEY_MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl+';
+
+/** The mod key as a standalone key cap, e.g. in the shortcut cheatsheet. */
+export const MOD_KEY_LABEL = IS_MAC ? '⌘' : 'Ctrl';

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -23,8 +23,11 @@ interface UiPrefsState {
   protectByDefault: boolean;
   /** User-resized column widths, keyed by table id then column field. */
   columnWidths: Record<string, Record<string, number>>;
+  /** User-toggled column visibility models, keyed by table id then column field. */
+  columnVisibility: Record<string, Record<string, boolean>>;
   set: (patch: Partial<Omit<UiPrefsState, 'set'>>) => void;
   setColumnWidth: (tableId: string, field: string, width: number) => void;
+  setColumnVisibility: (tableId: string, model: Record<string, boolean>) => void;
 }
 
 export const useUiPrefsStore = create<UiPrefsState>()(
@@ -37,10 +40,15 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       defaultShell: 'auto',
       protectByDefault: false,
       columnWidths: {},
+      columnVisibility: {},
       set: (patch) => set(patch),
       setColumnWidth: (tableId, field, width) =>
         set((state) => ({
           columnWidths: { ...state.columnWidths, [tableId]: { ...state.columnWidths[tableId], [field]: width } },
+        })),
+      setColumnVisibility: (tableId, model) =>
+        set((state) => ({
+          columnVisibility: { ...state.columnVisibility, [tableId]: model },
         })),
     }),
     { name: 'kubus-prefs', version: 0, storage: createJSONStorage(() => kubusStateStorage) },

--- a/client/src/state/toast.ts
+++ b/client/src/state/toast.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+export type ToastSeverity = 'success' | 'error' | 'info' | 'warning';
+
+interface Toast {
+  /** Distinguishes consecutive toasts so the snackbar's auto-hide timer restarts. */
+  id: number;
+  severity: ToastSeverity;
+  message: string;
+}
+
+interface ToastState {
+  toast: Toast | null;
+  show: (severity: ToastSeverity, message: string) => void;
+  dismiss: () => void;
+}
+
+let nextId = 1;
+
+export const useToastStore = create<ToastState>()((set) => ({
+  toast: null,
+  show: (severity, message) => set({ toast: { id: nextId++, severity, message } }),
+  dismiss: () => set({ toast: null }),
+}));
+
+/** Show a transient notification from anywhere (components, mutation callbacks). */
+export function showToast(severity: ToastSeverity, message: string): void {
+  useToastStore.getState().show(severity, message);
+}

--- a/client/src/text-entry.ts
+++ b/client/src/text-entry.ts
@@ -1,0 +1,12 @@
+/** True when a key event targets a surface that consumes typing (inputs, editors, menus, dialogs). */
+export function isTextEntryTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    target.isContentEditable ||
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    !!target.closest('[contenteditable="true"], [role="textbox"], [role="dialog"], [role="menu"], [role="listbox"], .monaco-editor')
+  );
+}

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -24,8 +24,8 @@ contextBridge.exposeInMainWorld('kubusDesktop', {
     return ipcRenderer.invoke('kubus:check-for-update', options);
   },
   // Fires when the user presses the OS close-window chord (Cmd/Ctrl+W). Returns
-  // an unsubscribe. The renderer closes the focused dock tab, or calls
-  // closeWindow() when there is nothing docked to close.
+  // an unsubscribe. The renderer closes the focused dock tab or page tab; it
+  // never closes the window from this chord.
   onCloseTab(callback: () => void): () => void {
     const listener = (): void => callback();
     ipcRenderer.on('kubus:close-tab', listener);


### PR DESCRIPTION
## What

- **Error boundaries** at three levels — app root, each tab pane, and the detail drawer. A render crash now shows an inline fallback with a retry button instead of white-screening the whole app; with the always-live-panes tab model, one broken tab no longer takes down the others.
- **Keyboard shortcut cheatsheet** — new keyboard icon in the top bar and the `?` key open a dialog listing every shortcut (palette, favorites, tab handling, list filters, cell copy, log find).
- **Consistent page headers** — Events and Security Audit now use the shared `PageHeader` (icon + title + count/actions) like Helm/Topology/Diff; the duplicated cluster-section header on Overview/Metrics/Network became a shared `ClusterSectionHeader`.
- **One shared "No cluster selected" empty state** — same copy and layout on every page (previously five different variants); Overview keeps its "Welcome to Kubus" landing state.
- **Global toast host** — a single snackbar driven by a small store replaces seven per-component `Snackbar` implementations. Success/error severities are consistent, and toasts survive their originating component unmounting (e.g. after a delete).
- **Grid preferences everywhere** — Events/Helm/Port Forwards now honor the table density setting and persist column widths (previously main resource table only), and column show/hide is persisted per table (widths were saved but visibility reset on restart).
- **Skeleton loaders** — content-shaped placeholders on Overview (stat cards + node usage) and on the Metrics/Network initial status load, instead of bare progress bars.
- **Ctrl/Cmd+W never closes the window** — the chord closes the focused dock tab, then the active page tab, and is a no-op on the last tab.

## Verification

- `pnpm typecheck` and `pnpm lint` clean across the workspace.
- Headless browser run against a kind cluster covering: zero-cluster empty states, cheatsheet via icon and `?`, Events header + count chip, and an end-to-end toast from a rollout restart.