### PR TITLE
Full keyboard support, discoverable shortcuts, and list UX improvements

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { useClustersStore } from './state/clusters.js';
 import { AppRouter } from './router.js';
 import { ErrorBoundary } from './components/ErrorBoundary.js';
 import { ToastHost } from './components/ToastHost.js';
+import { BackendStatusBanner } from './components/BackendStatusBanner.js';
 import { UpdateNotification } from './components/UpdateNotification.js';
 import { TitleBarAwareBackdrop } from './components/TitleBarAwareBackdrop.js';
 
@@ -35,6 +36,7 @@ export default function App() {
         <AppRouter />
       </ErrorBoundary>
       <ToastHost />
+      <BackendStatusBanner />
       <UpdateNotification />
     </ThemeProvider>
   );

--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -1,4 +1,5 @@
 import type { ApiErrorBody } from '@kubus/shared';
+import { reportAuthInvalid, reportBackendDown, reportBackendUp } from '../state/backend.js';
 
 let token = '';
 
@@ -34,11 +35,30 @@ function authHeaders(init?: HeadersInit): Headers {
   return headers;
 }
 
+/**
+ * Fetch that feeds the global backend-status store: connection failures and
+ * 401s are cross-cutting states (server gone / token stale), not per-call
+ * errors, so every call site reports them here instead of handling them.
+ */
+async function statusFetch(path: string, init?: RequestInit): Promise<Response> {
+  let res: Response;
+  try {
+    res = await fetch(path, {
+      ...init,
+      headers: authHeaders(init?.headers),
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') throw err;
+    reportBackendDown();
+    throw new ApiError(0, 'Cannot reach the Kubus backend');
+  }
+  reportBackendUp();
+  if (res.status === 401) reportAuthInvalid();
+  return res;
+}
+
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(path, {
-    ...init,
-    headers: authHeaders(init?.headers),
-  });
+  const res = await statusFetch(path, init);
   const text = await res.text();
   let body: unknown;
   try {
@@ -55,10 +75,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
 
 /** Authenticated fetch returning the raw Response (for blob/stream downloads). */
 export async function apiFetchRaw(path: string, init?: RequestInit): Promise<Response> {
-  const res = await fetch(path, {
-    ...init,
-    headers: authHeaders(init?.headers),
-  });
+  const res = await statusFetch(path, init);
   if (!res.ok) {
     let message = `${res.status} ${res.statusText}`;
     try {

--- a/client/src/api/mutation-errors.ts
+++ b/client/src/api/mutation-errors.ts
@@ -1,0 +1,10 @@
+import type { MutationMeta } from '@tanstack/react-query';
+
+const LOCAL_ERROR_KEY = 'errorHandledLocally';
+
+/** Attach to mutations whose caller or rendered state already surfaces failures. */
+export const LOCAL_ERROR_HANDLING_META = { [LOCAL_ERROR_KEY]: true } as const satisfies MutationMeta;
+
+export function isMutationErrorHandledLocally(meta: MutationMeta | undefined): boolean {
+  return meta?.[LOCAL_ERROR_KEY] === true;
+}

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -75,6 +75,7 @@ import type {
 } from '@kubus/shared';
 import { groupToPath } from '@kubus/shared';
 import { apiFetch } from './http.js';
+import { LOCAL_ERROR_HANDLING_META } from './mutation-errors.js';
 import { watchClient } from './ws/watch-client.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useRefetchInterval } from '../state/prefs.js';
@@ -157,6 +158,7 @@ export function useClusterCa(ctx: string, enabled: boolean) {
 export function useEditCluster() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, body }: { ctx: string; body: EditClusterRequest }) =>
       apiFetch<ContextInfo[]>(`/api/contexts/${encodeURIComponent(ctx)}/cluster`, {
         method: 'PUT',
@@ -174,6 +176,7 @@ export function useEditCluster() {
 export function useDeleteCluster() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: (ctx: string) => apiFetch<ContextInfo[]>(`/api/contexts/${encodeURIComponent(ctx)}`, { method: 'DELETE' }),
     onSuccess: (contexts, ctx) => {
       useClustersStore.getState().removeContext(ctx);
@@ -187,6 +190,7 @@ export function useDeleteCluster() {
 export function useSetSshHost() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, body }: { ctx: string; body: SetSshHostRequest }) =>
       apiFetch<ContextInfo[]>(`/api/contexts/${encodeURIComponent(ctx)}/ssh-host`, {
         method: 'PUT',
@@ -220,6 +224,7 @@ export function useKubeconfigSettings(enabled = true) {
 export function useSetKubeconfig() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: (body: SetKubeconfigRequest) =>
       apiFetch<KubeconfigSettings>('/api/settings/kubeconfig', {
         method: 'PUT',
@@ -236,6 +241,7 @@ export function useSetKubeconfig() {
 export function useImportKubeconfig() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: (body: KubeconfigImportRequest) =>
       apiFetch<KubeconfigImportResponse>('/api/settings/kubeconfig/import', {
         method: 'POST',
@@ -603,6 +609,7 @@ export async function resolveLogTargetPods(sel: {
 export function useApplyResource() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, group, version, plural, name, namespace, yamlBody }: { ctx: string; group: string; version: string; plural: string; name: string; namespace?: string; yamlBody: string }) =>
       apiFetch<KubeObject>(resourceUrl(ctx, group, version, plural, name, namespace), {
         method: 'PUT',
@@ -615,6 +622,7 @@ export function useApplyResource() {
 
 export function useCreateResource() {
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, yamlBody }: { ctx: string; yamlBody: string }) =>
       apiFetch<KubeObject>(`/api/contexts/${encodeURIComponent(ctx)}/resources`, {
         method: 'POST',
@@ -626,6 +634,7 @@ export function useCreateResource() {
 
 export function useDryRunResource() {
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, yamlBody }: { ctx: string; yamlBody: string }) =>
       apiFetch<ResourceDryRunResponse>(`/api/contexts/${encodeURIComponent(ctx)}/resources/dry-run`, {
         method: 'POST',
@@ -637,6 +646,7 @@ export function useDryRunResource() {
 
 export function useDeleteResource() {
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, group, version, plural, name, namespace }: { ctx: string; group: string; version: string; plural: string; name: string; namespace?: string }) =>
       apiFetch(resourceUrl(ctx, group, version, plural, name, namespace), { method: 'DELETE' }),
   });
@@ -652,41 +662,42 @@ function actionMutation<T, R = { ok: boolean }>(action: string) {
 }
 
 export function useScale() {
-  return useMutation({ mutationFn: actionMutation<ScaleRequest>('scale') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<ScaleRequest>('scale') });
 }
 export function useRolloutRestart() {
-  return useMutation({ mutationFn: actionMutation<RolloutRestartRequest>('rollout-restart') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<RolloutRestartRequest>('rollout-restart') });
 }
 export function useCordon() {
-  return useMutation({ mutationFn: actionMutation<CordonRequest>('cordon') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<CordonRequest>('cordon') });
 }
 export function useDrain() {
-  return useMutation({ mutationFn: actionMutation<DrainRequest, DrainStartedResponse>('drain') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<DrainRequest, DrainStartedResponse>('drain') });
 }
 export function useTriggerCronJob() {
-  return useMutation({ mutationFn: actionMutation<TriggerCronJobRequest, { jobName: string }>('trigger-cronjob') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<TriggerCronJobRequest, { jobName: string }>('trigger-cronjob') });
 }
 export function useSuspendCronJob() {
-  return useMutation({ mutationFn: actionMutation<SuspendCronJobRequest>('suspend-cronjob') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<SuspendCronJobRequest>('suspend-cronjob') });
 }
 export function useSetImage() {
-  return useMutation({ mutationFn: actionMutation<SetImageRequest>('set-image') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<SetImageRequest>('set-image') });
 }
 export function useRerunJob() {
-  return useMutation({ mutationFn: actionMutation<RerunJobRequest, { jobName: string }>('rerun-job') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<RerunJobRequest, { jobName: string }>('rerun-job') });
 }
 export function useRolloutUndo() {
-  return useMutation({ mutationFn: actionMutation<RolloutUndoRequest>('rollout-undo') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<RolloutUndoRequest>('rollout-undo') });
 }
 export function useRolloutPause() {
-  return useMutation({ mutationFn: actionMutation<RolloutPauseRequest>('rollout-pause') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<RolloutPauseRequest>('rollout-pause') });
 }
 export function useDebugPod() {
-  return useMutation({ mutationFn: actionMutation<DebugPodRequest, DebugPodResponse>('debug-pod') });
+  return useMutation({ meta: LOCAL_ERROR_HANDLING_META, mutationFn: actionMutation<DebugPodRequest, DebugPodResponse>('debug-pod') });
 }
 export function useStopDebug() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: actionMutation<StopDebugRequest>('stop-debug'),
     // The idle loop notices the stop file within ~1s — refetch after that so
     // the pod object actually shows the container as terminated.
@@ -791,6 +802,7 @@ function invalidateMetricsServer(qc: ReturnType<typeof useQueryClient>): void {
 export function useInstallMetricsServer() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, body }: { ctx: string; body: MetricsServerInstallRequest }) =>
       apiFetch<MetricsServerInstallResult>(`/api/contexts/${encodeURIComponent(ctx)}/metrics-server/install`, {
         method: 'POST',
@@ -804,6 +816,7 @@ export function useInstallMetricsServer() {
 export function useUninstallMetricsServer() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx }: { ctx: string }) =>
       apiFetch<MetricsServerUninstallResult>(`/api/contexts/${encodeURIComponent(ctx)}/metrics-server`, { method: 'DELETE' }),
     onSuccess: () => invalidateMetricsServer(qc),
@@ -838,6 +851,7 @@ function invalidateNetworkAgent(qc: ReturnType<typeof useQueryClient>): void {
 export function useInstallNetworkAgent() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx }: { ctx: string }) =>
       apiFetch<NetworkAgentInstallResult>(`/api/contexts/${encodeURIComponent(ctx)}/network-agent/install`, { method: 'POST' }),
     onSuccess: () => invalidateNetworkAgent(qc),
@@ -847,6 +861,7 @@ export function useInstallNetworkAgent() {
 export function useUninstallNetworkAgent() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx }: { ctx: string }) =>
       apiFetch<NetworkAgentUninstallResult>(`/api/contexts/${encodeURIComponent(ctx)}/network-agent`, { method: 'DELETE' }),
     onSuccess: () => invalidateNetworkAgent(qc),
@@ -1051,6 +1066,7 @@ export function useHelmRevision(ctx: string | undefined, ns: string | undefined,
 export function useHelmUninstall() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, ns, name, skipHooks, deleteCrds }: { ctx: string; ns: string; name: string; skipHooks?: boolean; deleteCrds?: boolean }) => {
       const q = new URLSearchParams();
       if (skipHooks) q.set('skipHooks', 'true');
@@ -1072,6 +1088,7 @@ export function useHelmUninstall() {
 export function useHelmRollback() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({
       ctx,
       ns,
@@ -1126,6 +1143,7 @@ function invalidateHelmRepoData(qc: ReturnType<typeof useQueryClient>) {
 export function useAddHelmRepo() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: (repo: HelmRepo) =>
       apiFetch<HelmRepo>('/api/helm/repos', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(repo) }),
     onSuccess: () => invalidateHelmRepoData(qc),
@@ -1135,6 +1153,7 @@ export function useAddHelmRepo() {
 export function useRemoveHelmRepo() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: (name: string) => apiFetch(`/api/helm/repos/${encodeURIComponent(name)}`, { method: 'DELETE' }),
     onSuccess: () => invalidateHelmRepoData(qc),
   });
@@ -1267,6 +1286,7 @@ export interface HelmUpgradeVars {
 export function useHelmUpgrade() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, ns, name, ...body }: HelmUpgradeVars) =>
       apiFetch<HelmOperationStarted>(`/api/contexts/${encodeURIComponent(ctx)}/helm/releases/${encodeURIComponent(ns)}/${encodeURIComponent(name)}/upgrade`, {
         method: 'POST',
@@ -1280,6 +1300,7 @@ export function useHelmUpgrade() {
 /** Server-side render without applying — backs the upgrade preview diff. */
 export function useHelmUpgradeDryRun() {
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, ns, name, ...body }: HelmUpgradeVars) =>
       apiFetch<HelmDryRunResult>(`/api/contexts/${encodeURIComponent(ctx)}/helm/releases/${encodeURIComponent(ns)}/${encodeURIComponent(name)}/upgrade`, {
         method: 'POST',
@@ -1296,6 +1317,7 @@ export interface HelmInstallVars extends Omit<HelmInstallRequest, 'dryRun'> {
 export function useHelmInstall() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, ...body }: HelmInstallVars) =>
       apiFetch<HelmOperationStarted>(`/api/contexts/${encodeURIComponent(ctx)}/helm/install`, {
         method: 'POST',
@@ -1308,6 +1330,7 @@ export function useHelmInstall() {
 
 export function useHelmInstallDryRun() {
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, ...body }: HelmInstallVars) =>
       apiFetch<HelmDryRunResult>(`/api/contexts/${encodeURIComponent(ctx)}/helm/install`, {
         method: 'POST',
@@ -1338,6 +1361,7 @@ export function usePortForwards() {
 export function useStartPortForward() {
   const qc = useQueryClient();
   return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx, body }: { ctx: string; body: PortForwardRequest }) =>
       apiFetch<PortForwardInfo>(`/api/contexts/${encodeURIComponent(ctx)}/portforwards`, {
         method: 'POST',

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -492,11 +492,16 @@ export function resourceUrl(ctx: string, group: string, version: string, plural:
   return `/api/contexts/${encodeURIComponent(ctx)}/resources/${groupToPath(group)}/${version}/${plural}/${encodeURIComponent(name)}${q ? `?${q}` : ''}`;
 }
 
-export function useResource(sel: { ctx: string; group: string; version: string; plural: string; name: string; namespace?: string; reveal?: boolean } | undefined) {
+export function useResource(
+  sel: { ctx: string; group: string; version: string; plural: string; name: string; namespace?: string; reveal?: boolean } | undefined,
+  opts?: { liveMs?: number },
+) {
+  const interval = useRefetchInterval(opts?.liveMs ?? 0);
   return useQuery({
     queryKey: ['resource', sel],
     queryFn: () => apiFetch<KubeObject>(resourceUrl(sel!.ctx, sel!.group, sel!.version, sel!.plural, sel!.name, sel!.namespace, sel!.reveal ? { reveal: 'true' } : undefined)),
     enabled: !!sel,
+    refetchInterval: opts?.liveMs ? interval : false,
   });
 }
 

--- a/client/src/api/ws/watch-client.ts
+++ b/client/src/api/ws/watch-client.ts
@@ -62,7 +62,8 @@ class WatchClient {
     });
   }
 
-  private reconnectNow(): void {
+  /** Skip any pending backoff — used when connectivity is known to be back. */
+  reconnectNow(): void {
     if (this.subs.size === 0 && this.broadcastHandlers.size === 0) return;
     if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) return;
     this.reconnectDelay = 1000;

--- a/client/src/components/BackendStatusBanner.tsx
+++ b/client/src/components/BackendStatusBanner.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import Alert from '@mui/material/Alert';
+import CircularProgress from '@mui/material/CircularProgress';
+import Snackbar from '@mui/material/Snackbar';
+import { useQueryClient } from '@tanstack/react-query';
+import { apiFetch } from '../api/http.js';
+import { watchClient } from '../api/ws/watch-client.js';
+import { useBackendStore } from '../state/backend.js';
+
+const RETRY_MS = 3000;
+
+/**
+ * Global banner for the two cross-cutting backend failure states: the server
+ * not answering at all, and the session token no longer being accepted.
+ * While unreachable it pings until the server answers, then refetches
+ * everything so the app snaps back without a manual reload.
+ */
+export function BackendStatusBanner() {
+  const unreachable = useBackendStore((s) => s.unreachable);
+  const authInvalid = useBackendStore((s) => s.authInvalid);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!unreachable) return;
+    let cancelled = false;
+    const timer = setInterval(() => {
+      // A successful response flips the store back via statusFetch.
+      apiFetch('/api/app/info')
+        .then(() => {
+          if (cancelled) return;
+          watchClient.reconnectNow();
+          void queryClient.invalidateQueries();
+        })
+        .catch(() => {});
+    }, RETRY_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [unreachable, queryClient]);
+
+  const open = unreachable || authInvalid;
+  // Bottom-left keeps clear of ToastHost, which owns bottom-center.
+  return (
+    <Snackbar open={open} anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}>
+      <Alert
+        severity={authInvalid ? 'error' : 'warning'}
+        variant="filled"
+        icon={authInvalid ? undefined : <CircularProgress color="inherit" size={18} />}
+      >
+        {authInvalid
+          ? 'Session is no longer valid — restart Kubus to reconnect.'
+          : 'Backend connection lost — retrying…'}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/client/src/components/GoHint.tsx
+++ b/client/src/components/GoHint.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Fade from '@mui/material/Fade';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router';
+import { GO_TARGETS, GO_TIMEOUT_MS } from '../shortcuts.js';
+import { useUiStore } from '../state/ui.js';
+import { Kbd } from './Kbd.js';
+
+/** Delay before the panel appears — fast typists (g p in one motion) never see it. */
+const SHOW_DELAY_MS = 200;
+
+/**
+ * Which-key style panel for the `g` go-to sequences: press g, and after a
+ * beat every destination shows up with its key. Items are clickable too, so
+ * the panel doubles as a mouse launcher. Any outside click, Escape, timeout,
+ * or non-matching key dismisses it.
+ */
+export function GoHint() {
+  const pendingSince = useUiStore((s) => s.goPendingSince);
+  const clearGoPending = useUiStore((s) => s.clearGoPending);
+  const navigate = useNavigate();
+  const [show, setShow] = useState(false);
+  const rootRef = useRef<HTMLOutputElement>(null);
+
+  useEffect(() => {
+    if (!pendingSince) {
+      setShow(false);
+      return;
+    }
+    const showTimer = window.setTimeout(() => setShow(true), SHOW_DELAY_MS);
+    const expireTimer = window.setTimeout(clearGoPending, GO_TIMEOUT_MS);
+    // A click elsewhere cancels the pending sequence; clicks inside the panel
+    // are its own buttons.
+    const onPointerDown = (ev: PointerEvent) => {
+      if (!(ev.target instanceof Node) || !rootRef.current?.contains(ev.target)) clearGoPending();
+    };
+    window.addEventListener('pointerdown', onPointerDown, true);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(expireTimer);
+      window.removeEventListener('pointerdown', onPointerDown, true);
+    };
+  }, [pendingSince, clearGoPending]);
+
+  return (
+    <Fade in={show && !!pendingSince} unmountOnExit>
+      <Paper
+        ref={rootRef}
+        elevation={8}
+        component="output"
+        aria-label="Go to destinations"
+        sx={{
+          position: 'fixed',
+          bottom: 20,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          zIndex: (theme) => theme.zIndex.snackbar,
+          p: 1.25,
+          borderRadius: 2,
+          border: 1,
+          borderColor: 'divider',
+          maxWidth: 'min(760px, calc(100vw - 32px))',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 0.75, px: 0.5 }}>
+          <Typography variant="caption" sx={{ fontWeight: 650 }}>
+            Go to
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            press a key…
+          </Typography>
+          <Box sx={{ flex: 1, minWidth: 16 }} />
+          <Typography variant="caption" color="text.disabled">
+            Esc to cancel
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {GO_TARGETS.map((t) => (
+            <ButtonBase
+              key={t.key}
+              onClick={() => {
+                clearGoPending();
+                void navigate(t.path);
+              }}
+              sx={{ display: 'flex', gap: 0.75, alignItems: 'center', px: 1, py: 0.5, borderRadius: 1, '&:hover': { bgcolor: 'action.hover' } }}
+            >
+              <Kbd>{t.key.toUpperCase()}</Kbd>
+              <Typography variant="body2">{t.label}</Typography>
+            </ButtonBase>
+          ))}
+        </Box>
+      </Paper>
+    </Fade>
+  );
+}

--- a/client/src/components/Kbd.tsx
+++ b/client/src/components/Kbd.tsx
@@ -1,0 +1,30 @@
+import Box from '@mui/material/Box';
+
+/** Keycap chip shared by the shortcut cheatsheet and the go-to panel. */
+export function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      component="kbd"
+      sx={{
+        fontFamily: 'monospace',
+        fontSize: 11.5,
+        fontWeight: 600,
+        lineHeight: 1,
+        px: 0.75,
+        py: 0.5,
+        minWidth: 22,
+        textAlign: 'center',
+        display: 'inline-block',
+        border: 1,
+        borderColor: 'divider',
+        borderBottomWidth: 2,
+        borderRadius: 1,
+        bgcolor: 'action.hover',
+        color: 'text.primary',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/client/src/components/LogViewer.tsx
+++ b/client/src/components/LogViewer.tsx
@@ -346,7 +346,18 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
             </MenuItem>
           ))}
         </Select>
-        <TextField placeholder="Filter (regex)…" value={filter} onChange={(e) => setFilter(e.target.value)} sx={{ width: 200 }} />
+        <TextField
+          placeholder="Filter (regex)…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key !== 'Escape') return;
+            e.stopPropagation();
+            if (filter) setFilter('');
+            else (e.target as HTMLElement).blur();
+          }}
+          sx={{ width: 200 }}
+        />
         <TextField
           placeholder="Find…"
           inputRef={findRef}
@@ -359,6 +370,16 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
             if (e.key === 'Enter') {
               e.preventDefault();
               findStep(e.shiftKey ? -1 : 1);
+              return;
+            }
+            if (e.key === 'Escape') {
+              e.stopPropagation();
+              if (find) {
+                setFind('');
+                setCursor(0);
+              } else {
+                (e.target as HTMLElement).blur();
+              }
             }
           }}
           sx={{ width: 170 }}

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { layout } from '../theme.js';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -111,7 +112,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   const hasMetrics = behaviorKind === 'Pod' || behaviorKind === 'Node';
   const hasRolloutHistory = behaviorKind === 'Deployment' || behaviorKind === 'StatefulSet';
   const showMap = !isCrd;
-  const drawerTopOffset = 52;
+  const drawerTopOffset = layout.topBarHeight;
   const drawerPaperSx = {
     top: `${drawerTopOffset}px`,
     height: `calc(100% - ${drawerTopOffset}px)`,

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -86,7 +86,12 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
     if (!hasSel) setFullScreen(false);
   }, [hasSel]);
 
-  const { data: obj, refetch } = useResource(sel ? { ...sel, reveal: isSecret && reveal } : undefined);
+  // Live-refresh the object while Overview is showing so stuck pods, rollouts
+  // and conditions update in place; other tabs (YAML editing!) keep the
+  // snapshot they opened with.
+  const { data: obj, refetch } = useResource(sel ? { ...sel, reveal: isSecret && reveal } : undefined, {
+    liveMs: tab === 'overview' ? 5000 : undefined,
+  });
   const { data: backingCrd } = useResource(backingCrdSelection);
   const { data: events } = useResourceEvents(tab === 'events' && sel ? { ctx: sel.ctx, name: sel.name, kind: sel.kind, namespace: sel.namespace } : undefined);
   const apply = useApplyResource();

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -20,6 +20,7 @@ import { dump as dumpYaml } from 'js-yaml';
 import { gvkForResource, type KubeObject } from '@kubus/shared';
 import { useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
 import { withoutManagedFields } from '../kube-display.js';
+import { isTextEntryTarget } from '../text-entry.js';
 import { YamlEditor, useYamlSchema } from './YamlEditor.js';
 import { GenericDetail } from './detail/GenericDetail.js';
 import { DeploymentDetail } from './detail/DeploymentDetail.js';
@@ -174,7 +175,18 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
       }}
     >
       {sel && (
-        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          onKeyDown={(e) => {
+            // Alt+← steps back through the related-resource stack — but not
+            // while typing (macOS Option+← moves the caret by word).
+            if (e.key === 'ArrowLeft' && e.altKey && !e.ctrlKey && !e.metaKey && onBack && !isTextEntryTarget(e.target)) {
+              e.preventDefault();
+              e.stopPropagation();
+              onBack();
+            }
+          }}
+          sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+        >
           <Stack direction="row" sx={{ px: 2, py: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center' }}>
             {onBack && (
               <IconButton onClick={onBack} sx={{ mr: 1 }}>

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -189,10 +189,10 @@ export function ResourceTable({
   };
 
   const focusSearch = useCallback(() => {
-    requestAnimationFrame(() => {
-      searchInputRef.current?.focus();
-      searchInputRef.current?.select();
-    });
+    // Focus synchronously: deferring (e.g. into a rAF) leaves a gap where
+    // keystrokes typed right after the trigger key still hit the grid.
+    searchInputRef.current?.focus();
+    searchInputRef.current?.select();
   }, []);
 
   // Tables in hidden tab panes stay mounted; only the visible one may own the

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -6,7 +6,7 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { DataGrid, type GridColDef, type GridColumnVisibilityModel, type GridRowParams } from '@mui/x-data-grid';
+import { DataGrid, type GridColDef, type GridColumnVisibilityModel, type GridRowParams, type GridSortModel } from '@mui/x-data-grid';
 import type { ClusterRow } from '../api/queries.js';
 import { matchesPlainText, matchesSmartFilter, parseSmartFilter } from '../smart-filter.js';
 import { joinLabelSelector, splitLabelSelector } from '../label-selector.js';
@@ -45,6 +45,8 @@ interface Props {
 }
 
 const labelFilterOptions = createFilterOptions<string>({ limit: 100 });
+
+const DEFAULT_SORT: GridSortModel = [{ field: 'name', sort: 'asc' }];
 
 /** All `key` and `key=value` selector terms present in the rows. */
 function labelSelectorOptions(rows: ClusterRow[]): { terms: string[]; keys: Set<string> } {
@@ -99,27 +101,35 @@ export function ResourceTable({
   useEffect(() => () => clearTimeout(commitTimer.current), []);
 
   const hiddenKey = (hiddenFields ?? []).join(',');
-  const visibilityFromHidden = () => Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []);
-  // A saved model wins over the default-hidden set; without one, visibility
-  // starts from (and resets with) the defaults.
+  // Visibility and sort are driven straight from the prefs store (keyed by
+  // tableId), so instance reuse across tables resolves the right model and
+  // external writes — a saved-view restore — apply to a mounted table
+  // immediately. A saved model wins over the default-hidden set. Tables
+  // without a tableId fall back to local state.
   const storedVisibility = useUiPrefsStore((s) => (tableId ? s.columnVisibility[tableId] : undefined));
   const setStoredVisibility = useUiPrefsStore((s) => s.setColumnVisibility);
-  const [visibility, setVisibility] = useState<GridColumnVisibilityModel>(() => storedVisibility ?? visibilityFromHidden());
-  // Re-seed visibility when this instance is reused for another table (same
-  // route, different kind — tableId changes) or when the default-hidden set
-  // changes, without paying an extra effect-driven render pass.
-  const visibilityKey = `${tableId ?? ''}|${hiddenKey}`;
-  const [prevVisibilityKey, setPrevVisibilityKey] = useState(visibilityKey);
-  if (prevVisibilityKey !== visibilityKey) {
-    setPrevVisibilityKey(visibilityKey);
-    setVisibility(storedVisibility ?? visibilityFromHidden());
-  }
+  const [localVisibility, setLocalVisibility] = useState<GridColumnVisibilityModel | undefined>(undefined);
+  const visibility = useMemo<GridColumnVisibilityModel>(
+    () => (tableId ? storedVisibility : localVisibility) ?? Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []),
+    [tableId, storedVisibility, localVisibility, hiddenKey],
+  );
   const handleVisibilityChange = useCallback(
     (model: GridColumnVisibilityModel) => {
-      setVisibility(model);
       if (tableId) setStoredVisibility(tableId, model);
+      else setLocalVisibility(model);
     },
     [tableId, setStoredVisibility],
+  );
+  const storedSort = useUiPrefsStore((s) => (tableId ? s.sortModels[tableId] : undefined));
+  const setStoredSort = useUiPrefsStore((s) => s.setSortModel);
+  const [localSort, setLocalSort] = useState<GridSortModel | undefined>(undefined);
+  const sortModel = (tableId ? storedSort : localSort) ?? DEFAULT_SORT;
+  const handleSortChange = useCallback(
+    (model: GridSortModel) => {
+      if (tableId) setStoredSort(tableId, model);
+      else setLocalSort(model);
+    },
+    [tableId, setStoredSort],
   );
   const tableDensity = useUiPrefsStore((s) => s.tableDensity);
   // Retrieve this table's saved column widths (if any)
@@ -283,7 +293,8 @@ export function ResourceTable({
         onColumnVisibilityModelChange={handleVisibilityChange}
         onColumnWidthChange={tableId ? (params) => setColumnWidth(tableId, params.colDef.field, params.width) : undefined}
         onCellKeyDown={handleCopyCellKeyDown}
-        initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
+        sortModel={sortModel}
+        onSortModelChange={handleSortChange}
         sx={{
           border: 0,
           flex: 1,

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react';
+import { layout } from '../theme.js';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
@@ -262,7 +263,7 @@ export function ResourceTable({
         // scrollbar as 0px and floats its own on top of the last column;
         // an explicit size (matching the themed 10px scrollbars) makes it
         // reserve a real gutter instead.
-        scrollbarSize={10}
+        scrollbarSize={layout.scrollbarSize}
         checkboxSelection={checkboxSelection}
         onRowSelectionModelChange={
           onSelectionChange

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -14,8 +14,7 @@ import { SmartFilterInput } from './SmartFilterInput.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from './CellCopy.js';
 import type { MetricsLookup } from './columns.js';
 import { useUiPrefsStore } from '../state/prefs.js';
-import { isTextEntryTarget } from '../text-entry.js';
-import { usePaneActive } from '../layout/pane-context.js';
+import { useQuickSearchShortcut } from './quick-search.js';
 
 interface Props {
   rows: ClusterRow[];
@@ -188,32 +187,7 @@ export function ResourceTable({
     }, 250);
   };
 
-  const focusSearch = useCallback(() => {
-    // Focus synchronously: deferring (e.g. into a rAF) leaves a gap where
-    // keystrokes typed right after the trigger key still hit the grid.
-    searchInputRef.current?.focus();
-    searchInputRef.current?.select();
-  }, []);
-
-  // Tables in hidden tab panes stay mounted; only the visible one may own the
-  // global find/quick-search shortcuts (N listeners would also race focus).
-  const paneActive = usePaneActive();
-  useEffect(() => {
-    if (!paneActive) return;
-    const onKey = (event: KeyboardEvent) => {
-      if (event.defaultPrevented || isTextEntryTarget(event.target)) return;
-      const key = event.key.toLowerCase();
-      const shortcutModifier = event.ctrlKey || event.metaKey;
-      const isFindShortcut = shortcutModifier && !event.altKey && !event.shiftKey && key === 'f';
-      const isQuickSearchShortcut = !shortcutModifier && !event.altKey && (key === 's' || key === ':' || key === '/');
-      if (!isFindShortcut && !isQuickSearchShortcut) return;
-      event.preventDefault();
-      event.stopPropagation();
-      focusSearch();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [focusSearch, paneActive]);
+  useQuickSearchShortcut(searchInputRef);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -205,7 +205,7 @@ export function ResourceTable({
   useQuickSearchShortcut(searchInputRef);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+    <Box className="kubus-table" sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Stack direction="row" spacing={1} useFlexGap sx={{ px: 1.5, py: 1, flexShrink: 0, alignItems: 'center', flexWrap: 'wrap' }}>
         <SmartFilterInput
           value={inputValue}
@@ -323,7 +323,6 @@ export function ResourceTable({
             bgcolor: 'action.selected',
             '&:hover': { bgcolor: 'action.selected' },
           },
-          '& .MuiDataGrid-cell:focus, & .MuiDataGrid-columnHeader:focus': { outline: 'none' },
           ...copyCellGridSx,
         }}
       />

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { layout } from '../theme.js';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
@@ -31,7 +31,10 @@ interface Props {
   onFilterChange?: (value: string) => void;
   onLabelSelectorChange?: (value: string) => void;
   onRowClick?: (row: ClusterRow) => void;
-  onRowContextMenu?: (row: ClusterRow, event: MouseEvent<HTMLElement>) => void;
+  /** Keyboard activation (Enter on a cell); lets pages move focus along. */
+  onRowActivate?: (row: ClusterRow) => void;
+  /** Opened by right-click or the ContextMenu / Shift+F10 keys. */
+  onRowContextMenu?: (row: ClusterRow, position: { clientX: number; clientY: number }) => void;
   /** Extra toolbar elements (e.g. create button). */
   toolbar?: ReactNode;
   /** Enable checkbox selection; returns selected rows. */
@@ -74,6 +77,7 @@ export function ResourceTable({
   onFilterChange,
   onLabelSelectorChange,
   onRowClick,
+  onRowActivate,
   onRowContextMenu,
   toolbar,
   checkboxSelection,
@@ -293,7 +297,21 @@ export function ResourceTable({
         columnVisibilityModel={visibility}
         onColumnVisibilityModelChange={handleVisibilityChange}
         onColumnWidthChange={tableId ? (params) => setColumnWidth(tableId, params.colDef.field, params.width) : undefined}
-        onCellKeyDown={handleCopyCellKeyDown}
+        onCellKeyDown={(params, event, details) => {
+          handleCopyCellKeyDown(params, event, details);
+          const row = rowsById.get(String(params.id));
+          if (!row) return;
+          // Keyboard equivalents of clicking and right-clicking a row.
+          if (event.key === 'Enter' && (onRowActivate || onRowClick)) {
+            event.preventDefault();
+            (onRowActivate ?? onRowClick)!(row);
+          } else if (onRowContextMenu && (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10'))) {
+            event.preventDefault();
+            const cell = (event.target as HTMLElement | null)?.closest?.('.MuiDataGrid-cell');
+            const rect = (cell ?? (event.target as HTMLElement)).getBoundingClientRect();
+            onRowContextMenu(row, { clientX: rect.left + 8, clientY: rect.bottom - 4 });
+          }
+        }}
         sortModel={sortModel}
         onSortModelChange={handleSortChange}
         sx={{

--- a/client/src/components/ShortcutHelpDialog.tsx
+++ b/client/src/components/ShortcutHelpDialog.tsx
@@ -50,7 +50,9 @@ const SECTIONS: Array<{ title: string; shortcuts: Shortcut[] }> = [
       { combos: [['S'], ['/'], [':']], description: 'Focus the filter input' },
       { combos: [[MOD, 'F']], description: 'Focus the filter input' },
       { combos: [[MOD, 'C']], description: 'Copy the focused cell' },
-      { combos: [['Right-click']], description: 'Open the row actions menu' },
+      { combos: [['Enter']], description: 'Open details for the focused row' },
+      { combos: [['Right-click'], ['Shift', 'F10']], description: 'Open the row actions menu' },
+      { combos: [['Esc']], description: 'Close the details panel (from inside it)' },
     ],
   },
   {

--- a/client/src/components/ShortcutHelpDialog.tsx
+++ b/client/src/components/ShortcutHelpDialog.tsx
@@ -1,149 +1,171 @@
-import { Fragment } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
-import DialogTitle from '@mui/material/DialogTitle';
-import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import ClearIcon from '@mui/icons-material/Clear';
 import CloseIcon from '@mui/icons-material/Close';
-import { MOD_KEY_LABEL } from '../platform.js';
+import SearchIcon from '@mui/icons-material/Search';
+import { SHORTCUT_SECTIONS, type ShortcutRowDef } from '../shortcuts.js';
+import { Kbd } from './Kbd.js';
 
-const MOD = MOD_KEY_LABEL;
+// The definitions live next to the handlers in shortcuts.ts so this dialog
+// cannot drift from what the app actually binds.
+const IS_DESKTOP = !!window.kubusDesktop;
 
-interface Shortcut {
-  /** Alternative key combos, each an array of keys pressed together. */
-  combos: string[][];
-  description: string;
-}
+const ALL_SECTIONS = SHORTCUT_SECTIONS.map((section) => ({
+  ...section,
+  shortcuts: section.shortcuts.filter((s) => (!s.desktopOnly || IS_DESKTOP) && (!s.webOnly || !IS_DESKTOP)),
+})).filter((section) => section.shortcuts.length > 0);
 
-const SECTIONS: Array<{ title: string; shortcuts: Shortcut[] }> = [
-  {
-    title: 'Global',
-    shortcuts: [
-      { combos: [[MOD, 'K']], description: 'Open the command palette' },
-      { combos: [['?']], description: 'Keyboard shortcuts (this dialog)' },
-      { combos: [[MOD, '1–9']], description: 'Open pinned favorite 1–9' },
-      { combos: [[MOD, 'W']], description: 'Close the focused dock or page tab' },
-      { combos: [['Esc']], description: 'Close dialog / details · exit maximized dock' },
-    ],
-  },
-  {
-    title: 'Command palette',
-    shortcuts: [
-      { combos: [['↑'], ['↓']], description: 'Move selection' },
-      { combos: [['Tab'], ['→']], description: 'Show actions for the selected resource' },
-      { combos: [['Enter']], description: 'Open the selected result' },
-    ],
-  },
-  {
-    title: 'Tabs & navigation',
-    shortcuts: [
-      { combos: [[MOD, 'Click'], ['Middle-click']], description: 'Open a link in a background tab' },
-      { combos: [['Middle-click']], description: 'Close a tab (on the tab strip)' },
-    ],
-  },
-  {
-    title: 'Resource lists',
-    shortcuts: [
-      { combos: [['S'], ['/'], [':']], description: 'Focus the filter input' },
-      { combos: [[MOD, 'F']], description: 'Focus the filter input' },
-      { combos: [[MOD, 'C']], description: 'Copy the focused cell' },
-      { combos: [['Enter']], description: 'Open details for the focused row' },
-      { combos: [['Right-click'], ['Shift', 'F10']], description: 'Open the row actions menu' },
-      { combos: [['Esc']], description: 'Close the details panel (from inside it)' },
-    ],
-  },
-  {
-    title: 'Logs',
-    shortcuts: [
-      { combos: [[MOD, 'F']], description: 'Focus find' },
-      { combos: [['Enter'], ['Shift', 'Enter']], description: 'Next / previous match' },
-    ],
-  },
-];
-
-function Kbd({ children }: { children: string }) {
+function rowMatches(sectionTitle: string, row: ShortcutRowDef, query: string): boolean {
   return (
-    <Box
-      component="kbd"
-      sx={{
-        fontFamily: 'monospace',
-        fontSize: 12,
-        lineHeight: 1,
-        px: 0.75,
-        py: 0.5,
-        border: 1,
-        borderColor: 'divider',
-        borderBottomWidth: 2,
-        borderRadius: 1,
-        bgcolor: 'action.hover',
-        whiteSpace: 'nowrap',
-      }}
-    >
-      {children}
-    </Box>
+    sectionTitle.toLowerCase().includes(query) ||
+    row.description.toLowerCase().includes(query) ||
+    row.combos.some((combo) => combo.join(' ').toLowerCase().includes(query))
   );
 }
 
-function ShortcutRow({ combos, description }: Shortcut) {
+/** Right-aligned keycaps: alternatives joined by "or", chord keys by "+", sequence keys by "then". */
+function ComboKeys({ row }: { row: ShortcutRowDef }) {
+  const joiner = row.sequence ? 'then' : '+';
   return (
-    <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center', py: 0.5 }}>
-      <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', minWidth: 150, flexWrap: 'wrap', rowGap: 0.5, flexShrink: 0 }}>
-        {combos.map((combo, i) => (
-          <Fragment key={i}>
-            {i > 0 && (
-              <Typography variant="caption" color="text.secondary">
-                or
-              </Typography>
-            )}
-            <Stack direction="row" spacing={0.25} sx={{ alignItems: 'center' }}>
-              {combo.map((key, j) => (
-                <Fragment key={j}>
-                  {j > 0 && (
-                    <Typography variant="caption" color="text.secondary">
-                      +
-                    </Typography>
-                  )}
-                  <Kbd>{key}</Kbd>
-                </Fragment>
-              ))}
-            </Stack>
-          </Fragment>
-        ))}
-      </Stack>
-      <Typography variant="body2" color="text.secondary">
-        {description}
+    <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center', flexShrink: 0, flexWrap: 'wrap', justifyContent: 'flex-end', rowGap: 0.5 }}>
+      {row.combos.map((combo, i) => (
+        <Fragment key={i}>
+          {i > 0 && (
+            <Typography variant="caption" color="text.disabled">
+              or
+            </Typography>
+          )}
+          <Stack direction="row" spacing={0.4} sx={{ alignItems: 'center' }}>
+            {combo.map((key, j) => (
+              <Fragment key={j}>
+                {j > 0 && (
+                  <Typography variant="caption" color="text.disabled" sx={{ fontSize: 10 }}>
+                    {joiner}
+                  </Typography>
+                )}
+                <Kbd>{key}</Kbd>
+              </Fragment>
+            ))}
+          </Stack>
+        </Fragment>
+      ))}
+    </Stack>
+  );
+}
+
+function ShortcutRow({ row }: { row: ShortcutRowDef }) {
+  return (
+    <Stack direction="row" spacing={2} sx={{ alignItems: 'center', justifyContent: 'space-between', py: 0.45 }}>
+      <Typography variant="body2" sx={{ minWidth: 0 }}>
+        {row.description}
       </Typography>
+      <ComboKeys row={row} />
     </Stack>
   );
 }
 
 export function ShortcutHelpDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [query, setQuery] = useState('');
+  useEffect(() => {
+    if (open) setQuery('');
+  }, [open]);
+
+  const q = query.trim().toLowerCase();
+  const sections = useMemo(() => {
+    if (!q) return ALL_SECTIONS;
+    return ALL_SECTIONS.map((section) => ({
+      ...section,
+      shortcuts: section.shortcuts.filter((row) => rowMatches(section.title, row, q)),
+    })).filter((section) => section.shortcuts.length > 0);
+  }, [q]);
+
+  // Deterministic two-column packing (greedy by row count) — CSS multi-column
+  // balancing breaks sections unpredictably inside a scroll container.
+  const columns = useMemo(() => {
+    const cols: [typeof sections, typeof sections] = [[], []];
+    const heights = [0, 0];
+    for (const section of sections) {
+      const at = heights[0]! <= heights[1]! ? 0 : 1;
+      cols[at].push(section);
+      heights[at]! += section.shortcuts.length + 2;
+    }
+    return cols;
+  }, [sections]);
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center' }}>
-        Keyboard shortcuts
-        <Box sx={{ flex: 1 }} />
-        <IconButton size="small" onClick={onClose} aria-label="Close">
-          <CloseIcon fontSize="small" />
-        </IconButton>
-      </DialogTitle>
-      <DialogContent>
-        <Grid container spacing={3}>
-          {SECTIONS.map((section) => (
-            <Grid key={section.title} size={{ xs: 12, sm: 6 }}>
-              <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-                {section.title}
-              </Typography>
-              {section.shortcuts.map((s) => (
-                <ShortcutRow key={s.description + s.combos.map((c) => c.join()).join()} {...s} />
-              ))}
-            </Grid>
-          ))}
-        </Grid>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth slotProps={{ paper: { sx: { height: 'min(680px, 85vh)' } } }}>
+      <Box sx={{ px: 3, pt: 2.5, pb: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <Typography variant="h6">Keyboard shortcuts</Typography>
+          <Box sx={{ flex: 1 }} />
+          <IconButton size="small" onClick={onClose} aria-label="Close">
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+        <TextField
+          fullWidth
+          placeholder="Search shortcuts…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            // Same Esc rhythm as the app's filters: clear first, close second.
+            if (e.key === 'Escape' && query) {
+              e.stopPropagation();
+              setQuery('');
+            }
+          }}
+          slotProps={{
+            htmlInput: { autoFocus: true },
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+              endAdornment: query ? (
+                <InputAdornment position="end">
+                  <IconButton aria-label="Clear search" size="small" onMouseDown={(e) => e.preventDefault()} onClick={() => setQuery('')}>
+                    <ClearIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
+            },
+          }}
+        />
+      </Box>
+      <DialogContent dividers sx={{ px: 3, py: 2, display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, columnGap: 5, alignItems: 'start' }}>
+        {columns.map((column, i) => (
+          <Box key={i}>
+            {column.map((section) => (
+              <Box key={section.title} sx={{ mb: 2.5 }}>
+                <Typography variant="overline" sx={{ display: 'block', mb: 0.5, color: 'text.secondary', letterSpacing: 1 }}>
+                  {section.title}
+                </Typography>
+                {section.shortcuts.map((row) => (
+                  <ShortcutRow key={row.description + row.combos.map((c) => c.join()).join()} row={row} />
+                ))}
+              </Box>
+            ))}
+          </Box>
+        ))}
+        {sections.length === 0 && (
+          <Typography variant="body2" color="text.secondary" sx={{ py: 3, textAlign: 'center', gridColumn: '1 / -1' }}>
+            No shortcuts match “{query}”.
+          </Typography>
+        )}
       </DialogContent>
+      <Box sx={{ px: 3, py: 1.25 }}>
+        <Typography variant="caption" color="text.secondary">
+          Press <Kbd>?</Kbd> anywhere to open this dialog · press <Kbd>G</Kbd> and wait to see the go-to destinations
+        </Typography>
+      </Box>
     </Dialog>
   );
 }

--- a/client/src/components/SmartFilterInput.tsx
+++ b/client/src/components/SmartFilterInput.tsx
@@ -156,6 +156,23 @@ export function SmartFilterInput({ value, onChange, kind, rows, inputRef }: Prop
           {...params}
           inputRef={inputRef}
           placeholder="Search… type / for smart filter"
+          onKeyDown={(e) => {
+            if (e.key !== 'Escape') return;
+            const input = e.target as HTMLElement;
+            // With the suggestion popup open, Escape only closes it (MUI).
+            if (input.getAttribute('aria-expanded') === 'true') return;
+            e.stopPropagation();
+            if (value) {
+              onChange('');
+              return;
+            }
+            // Empty already: leave the input and hand focus to the grid.
+            input.blur();
+            input
+              .closest('.kubus-table')
+              ?.querySelector<HTMLElement>('.MuiDataGrid-cell[tabindex="0"], .MuiDataGrid-columnHeader[tabindex="0"], .MuiDataGrid-cell')
+              ?.focus();
+          }}
           slotProps={{
             ...params.slotProps,
             input: {

--- a/client/src/components/detail/ContainerCards.tsx
+++ b/client/src/components/detail/ContainerCards.tsx
@@ -15,6 +15,8 @@ export interface ContainerCardData {
   kind?: 'init' | 'sidecar';
   /** StatusChip label, e.g. Running / Completed / CrashLoopBackOff. */
   state?: string;
+  /** Why the container is in `state` (waiting/terminated message). */
+  stateMessage?: string;
   restarts?: number;
   lastRestart?: { reason?: string; at?: string };
   ports?: string;
@@ -61,6 +63,23 @@ function ContainerCard({ c }: { c: ContainerCardData }) {
           sx={{ display: 'block', fontFamily: 'monospace', fontSize: 11, mt: 0.25 }}
         >
           {c.image}
+        </Typography>
+      )}
+      {c.stateMessage && (
+        <Typography
+          variant="caption"
+          title={c.stateMessage}
+          sx={{
+            display: '-webkit-box',
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+            wordBreak: 'break-word',
+            color: 'warning.main',
+            mt: 0.25,
+          }}
+        >
+          {c.stateMessage}
         </Typography>
       )}
       {showRestarts && (

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -18,6 +18,7 @@ import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import type { ContainerUsage, KubeObject, PodEnvVar } from '@kubus/shared';
 import { gvkForKind } from '@kubus/shared';
 import { ConditionChips, KeyValueChips, KeyValueSection, MetadataSection } from './GenericDetail.js';
+import { PodProblems } from './PodProblems.js';
 import { Section } from './Section.js';
 import { ContainerCards, type ContainerCardData } from './ContainerCards.js';
 import { ReadyCounter } from '../ReadyCounter.js';
@@ -42,7 +43,7 @@ interface ContainerStatus {
   name: string;
   ready?: boolean;
   restartCount?: number;
-  state?: Record<string, { reason?: string }>;
+  state?: Record<string, { reason?: string; message?: string }>;
   lastState?: { terminated?: { reason?: string; finishedAt?: string } };
 }
 
@@ -80,6 +81,7 @@ function containerCard(c: ContainerSpec, st: ContainerStatus | undefined, usage:
     image: c.image,
     kind,
     state: reason ? (reason === 'running' ? 'Running' : reason === 'waiting' ? 'Waiting' : reason === 'terminated' ? 'Terminated' : reason) : undefined,
+    stateMessage: stateKey && stateKey !== 'running' ? st!.state![stateKey]?.message : undefined,
     restarts: st?.restartCount,
     lastRestart: last ? { reason: last.reason, at: last.finishedAt } : undefined,
     ports: (c.ports ?? []).map((p) => `${p.containerPort}/${p.protocol ?? 'TCP'}`).join(', ') || undefined,
@@ -139,6 +141,7 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
         )}
         {!terminal && <ConditionChips obj={obj} />}
       </Stack>
+      <PodProblems obj={obj} ctx={ctx} />
       <Section title="Containers" count={mainCards.length}>
         <ContainerCards items={mainCards} />
       </Section>

--- a/client/src/components/detail/PodProblems.tsx
+++ b/client/src/components/detail/PodProblems.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from 'react';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { KubeObject } from '@kubus/shared';
+import { AgeCell } from '../AgeCell.js';
+import { useResourceEvents } from '../../api/queries.js';
+
+interface Problem {
+  /** What is failing: a condition type or a container name. */
+  source: string;
+  reason: string;
+  message?: string;
+}
+
+interface ContainerStateDetail {
+  reason?: string;
+  message?: string;
+  exitCode?: number;
+}
+
+interface ContainerStatusShape {
+  name: string;
+  state?: { waiting?: ContainerStateDetail; terminated?: ContainerStateDetail; running?: unknown };
+}
+
+interface PodStatusShape {
+  phase?: string;
+  reason?: string;
+  message?: string;
+  conditions?: Array<{ type: string; status: string; reason?: string; message?: string }>;
+  containerStatuses?: ContainerStatusShape[];
+  initContainerStatuses?: ContainerStatusShape[];
+}
+
+/** Everything currently keeping the pod from Running/Ready, in display order. */
+function podProblems(obj: KubeObject): Problem[] {
+  const status = obj.status as PodStatusShape | undefined;
+  if (!status) return [];
+  const problems: Problem[] = [];
+  // Pod-level reason (e.g. Evicted pods carry it here, not in conditions).
+  if (status.reason && status.phase !== 'Succeeded') {
+    problems.push({ source: 'Pod', reason: status.reason, message: status.message });
+  }
+  for (const c of status.conditions ?? []) {
+    // Ready/ContainersReady only aggregate the per-container states listed below.
+    if (c.type === 'Ready' || c.type === 'ContainersReady') continue;
+    if (c.status === 'True' || (!c.reason && !c.message)) continue;
+    problems.push({ source: c.type, reason: c.reason ?? `${c.type}=${c.status}`, message: c.message });
+  }
+  const containers = [...(status.initContainerStatuses ?? []), ...(status.containerStatuses ?? [])];
+  for (const cs of containers) {
+    const waiting = cs.state?.waiting;
+    if (waiting) {
+      problems.push({ source: cs.name, reason: waiting.reason ?? 'Waiting', message: waiting.message });
+      continue;
+    }
+    const terminated = cs.state?.terminated;
+    if (terminated && terminated.exitCode !== undefined && terminated.exitCode !== 0) {
+      problems.push({
+        source: cs.name,
+        reason: `${terminated.reason ?? 'Terminated'} (exit ${terminated.exitCode})`,
+        message: terminated.message,
+      });
+    }
+  }
+  return problems;
+}
+
+type EventShape = KubeObject & { type?: string; reason?: string; message?: string; count?: number; lastTimestamp?: string };
+
+function eventTime(e: EventShape): string {
+  return e.lastTimestamp ?? e.metadata.creationTimestamp ?? '';
+}
+
+/**
+ * The `kubectl describe` answer to "why is my pod stuck": every failing
+ * condition and container state plus the recent warning events (mount
+ * failures, image-pull detail, scheduling), live at the top of the overview
+ * instead of buried in tooltips and the Events tab.
+ */
+export function PodProblems({ obj, ctx }: { obj: KubeObject; ctx: string }) {
+  const problems = useMemo(() => podProblems(obj), [obj]);
+  const status = obj.status as PodStatusShape | undefined;
+  const phase = status?.phase;
+  const active = phase !== 'Succeeded' && (problems.length > 0 || phase === 'Pending' || phase === 'Failed' || phase === 'Unknown');
+  const eventsQuery = useResourceEvents(
+    active ? { ctx, name: obj.metadata.name, kind: 'Pod', namespace: obj.metadata.namespace } : undefined,
+  );
+  if (!active) return null;
+
+  const events = (eventsQuery.data?.items ?? []) as EventShape[];
+  const recent = [...events].sort((a, b) => eventTime(b).localeCompare(eventTime(a)));
+  let shown = recent.filter((e) => e.type === 'Warning').slice(0, 5);
+  // No warnings yet (e.g. a slow image pull): the latest normal event still
+  // tells the user what the pod is doing right now.
+  if (!shown.length) shown = recent.slice(0, 1);
+
+  return (
+    <Alert severity={phase === 'Failed' ? 'error' : 'warning'} sx={{ '& .MuiAlert-message': { minWidth: 0, flex: 1 } }}>
+      <AlertTitle>Why this pod isn’t ready</AlertTitle>
+      <Stack spacing={0.75}>
+        {problems.map((p, i) => (
+          <Box key={`p:${i}`}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {p.source}: {p.reason}
+            </Typography>
+            {p.message && (
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {p.message}
+              </Typography>
+            )}
+          </Box>
+        ))}
+        {shown.map((e) => (
+          <Box key={e.metadata.uid}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {e.reason ?? e.type} {e.count && e.count > 1 ? `×${e.count}` : ''}{' '}
+              <Typography component="span" variant="caption" color="text.secondary">
+                <AgeCell timestamp={eventTime(e)} variant="caption" /> ago
+              </Typography>
+            </Typography>
+            {e.message && (
+              <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {e.message}
+              </Typography>
+            )}
+          </Box>
+        ))}
+      </Stack>
+    </Alert>
+  );
+}

--- a/client/src/components/quick-search.ts
+++ b/client/src/components/quick-search.ts
@@ -22,7 +22,10 @@ export function useQuickSearchShortcut(inputRef: RefObject<HTMLInputElement | nu
       const isFindShortcut = shortcutModifier && !event.altKey && !event.shiftKey && key === 'f';
       const isQuickSearchShortcut = !shortcutModifier && !event.altKey && (key === 's' || key === ':' || key === '/');
       if (!isFindShortcut && !isQuickSearchShortcut) return;
-      event.preventDefault();
+      // `/` keeps its default action: after focus moves, the browser inserts
+      // it into the (selected) input, dropping the user straight into
+      // smart-filter syntax. The other triggers must not be typed.
+      if (key !== '/') event.preventDefault();
       event.stopPropagation();
       inputRef.current?.focus();
       inputRef.current?.select();

--- a/client/src/components/quick-search.ts
+++ b/client/src/components/quick-search.ts
@@ -1,0 +1,33 @@
+import { useEffect, type RefObject } from 'react';
+import { usePaneActive } from '../layout/pane-context.js';
+import { isTextEntryTarget } from '../text-entry.js';
+
+/**
+ * Find (Ctrl/Cmd+F) and quick-search (`s` `/` `:`) shortcuts that focus a
+ * page's search input. Gated on the pane being visible: pages stay mounted
+ * in hidden panes, and only one listener may own the shortcut.
+ *
+ * Focus is moved synchronously in the keydown handler — deferring it would
+ * open a gap where keystrokes typed right after the trigger key still hit
+ * the grid underneath.
+ */
+export function useQuickSearchShortcut(inputRef: RefObject<HTMLInputElement | null>): void {
+  const paneActive = usePaneActive();
+  useEffect(() => {
+    if (!paneActive) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || isTextEntryTarget(event.target)) return;
+      const key = event.key.toLowerCase();
+      const shortcutModifier = event.ctrlKey || event.metaKey;
+      const isFindShortcut = shortcutModifier && !event.altKey && !event.shiftKey && key === 'f';
+      const isQuickSearchShortcut = !shortcutModifier && !event.altKey && (key === 's' || key === ':' || key === '/');
+      if (!isFindShortcut && !isQuickSearchShortcut) return;
+      event.preventDefault();
+      event.stopPropagation();
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [inputRef, paneActive]);
+}

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -16,6 +16,8 @@ declare global {
       checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
       /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */
       onCloseTab(callback: () => void): () => void;
+      /** Subscribe to the tab-cycling chords (Ctrl+Tab & friends); backwards=true cycles left. */
+      onCycleTab(callback: (backwards: boolean) => void): () => void;
       /** Close the main window (fallback when no dock tab is open). */
       closeWindow(): void;
     };

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -1,6 +1,9 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { useLocation, useNavigate } from 'react-router';
+import { NAV_OVERLAY_MEDIA_QUERY, useNavUiStore } from '../state/nav-ui.js';
+import { useUiPrefsStore } from '../state/prefs.js';
 import { TopBar } from './TopBar.js';
 import { NavDrawer } from './NavDrawer.js';
 import { TabsBar } from './TabsBar.js';
@@ -18,6 +21,10 @@ const ResourceDetailDrawer = lazy(() => import('../components/ResourceDetailDraw
 
 export function AppShell() {
   useHelmOperationEvents();
+  const navOverlay = useMediaQuery(NAV_OVERLAY_MEDIA_QUERY);
+  const navCollapsed = useUiPrefsStore((s) => s.navCollapsed);
+  const navOverlayOpen = useNavUiStore((s) => s.overlayOpen);
+  const setNavOverlayOpen = useNavUiStore((s) => s.setOverlayOpen);
   const dockOpen = useDockStore((s) => s.open);
   const dockHeight = useDockStore((s) => s.height);
   const maximized = useDockStore((s) => s.maximized);
@@ -75,7 +82,7 @@ export function AppShell() {
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
       <TopBar />
       <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
-        <NavDrawer />
+        <NavDrawer overlay={navOverlay} hidden={navCollapsed} open={navOverlayOpen} onClose={() => setNavOverlayOpen(false)} />
         <Box component="main" sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
           <TabsBar />
           <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -1,18 +1,20 @@
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useLocation, useNavigate } from 'react-router';
 import { NAV_OVERLAY_MEDIA_QUERY, useNavUiStore } from '../state/nav-ui.js';
 import { useUiPrefsStore } from '../state/prefs.js';
+import { GlobalShortcuts } from '../shortcuts.js';
 import { TopBar } from './TopBar.js';
 import { NavDrawer } from './NavDrawer.js';
 import { TabsBar } from './TabsBar.js';
 import { TabPanes } from './TabPanes.js';
 import { BottomDock } from './BottomDock.js';
 import { ErrorBoundary } from '../components/ErrorBoundary.js';
+import { GoHint } from '../components/GoHint.js';
 import { useDockStore } from '../state/dock.js';
 import { useDetailStore } from '../state/detail.js';
-import { useTabsStore } from '../state/tabs.js';
 import { useHelmOperationEvents } from '../api/queries.js';
 
 // Lazy so the drawer's heavy deps (js-yaml, editors, charts) stay out of the
@@ -35,6 +37,7 @@ export function AppShell() {
   // Mounted on first open, kept mounted after so close animations still play.
   const [drawerMounted, setDrawerMounted] = useState(false);
   const dockRef = useRef<HTMLDivElement>(null);
+  const mainRef = useRef<HTMLElement>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const detailIsEmbedded = location.pathname.startsWith('/r/');
@@ -56,34 +59,36 @@ export function AppShell() {
     }
   }, [closeDetail, navigate]);
 
-  // Cmd/Ctrl+W closes the focused dock tab (logs/terminal), then the active
-  // page tab. With a single page tab left it does nothing — the chord must
-  // never close the window itself.
-  useEffect(() => {
-    const desktop = window.kubusDesktop;
-    if (!desktop?.onCloseTab) return;
-    return desktop.onCloseTab(() => {
-      const dock = useDockStore.getState();
-      if (dock.open && dock.activeId) {
-        dock.closeTab(dock.activeId);
-        return;
-      }
-      const pages = useTabsStore.getState();
-      if (pages.tabs.length > 1 && pages.activeId) {
-        pages.closeTab(pages.activeId);
-        const next = useTabsStore.getState();
-        const active = next.tabs.find((t) => t.id === next.activeId);
-        if (active) void navigate(active.path);
-      }
-    });
-  }, [navigate]);
-
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
+      <GlobalShortcuts />
+      <GoHint />
+      {/* First tab stop: jump keyboard users past the top bar and nav rail. */}
+      <ButtonBase
+        onClick={() => mainRef.current?.focus()}
+        sx={{
+          position: 'absolute',
+          top: 8,
+          left: 8,
+          zIndex: (theme) => theme.zIndex.modal + 1,
+          px: 1.5,
+          py: 1,
+          borderRadius: 1,
+          border: 1,
+          borderColor: 'divider',
+          bgcolor: 'background.paper',
+          boxShadow: 4,
+          typography: 'body2',
+          transform: 'translateY(-250%)',
+          '&:focus-visible': { transform: 'none' },
+        }}
+      >
+        Skip to content
+      </ButtonBase>
       <TopBar />
       <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
         <NavDrawer overlay={navOverlay} hidden={navCollapsed} open={navOverlayOpen} onClose={() => setNavOverlayOpen(false)} />
-        <Box component="main" sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column' }}>
+        <Box component="main" ref={mainRef} tabIndex={-1} sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', outline: 'none' }}>
           <TabsBar />
           <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
             <TabPanes />

--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { memo } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Tab from '@mui/material/Tab';
@@ -25,15 +25,8 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
   const maximized = useDockStore((s) => s.maximized);
   const setMaximized = useDockStore((s) => s.setMaximized);
 
-  useEffect(() => {
-    if (!maximized) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setMaximized(false);
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [maximized, setMaximized]);
-
+  // Escape restores a maximized dock via the global dismiss chain in
+  // GlobalShortcuts — guarded there so a focused terminal keeps its Escape.
   if (!open || tabs.length === 0) return null;
 
   // Resize by writing the container height directly to the DOM (one write per

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -34,6 +34,7 @@ import { BUILTIN_NAV_GROUPS, groupToPath, gvkForResource, gvkLabel, pluralLabel,
 import { useApiResourcesForContexts } from '../api/queries.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
 import { useClustersStore } from '../state/clusters.js';
+import { useUiPrefsStore } from '../state/prefs.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useTabsStore } from '../state/tabs.js';
 import { GROUP_ICONS } from './tab-meta.js';
@@ -256,6 +257,15 @@ function SavedViewEntry({ view, onDelete }: { view: SavedView; onDelete: (id: st
   const location = useLocation();
   const active = `${location.pathname}${location.search}` === view.path;
   const newTabHandlers = useOpenInNewTab(view.path);
+  // Views saved with a grid snapshot restore the whole table — namespaces,
+  // sort, column visibility and widths — not just the query in the path.
+  // Older views without one restore the query only.
+  const applyGridState = () => {
+    const grid = view.grid;
+    if (!grid) return;
+    if (grid.namespaces) useClustersStore.getState().setNamespaces(grid.namespaces);
+    useUiPrefsStore.getState().applyTableState(view.path.split('?')[0] ?? view.path, grid);
+  };
   return (
     <ListItem
       disablePadding
@@ -277,7 +287,21 @@ function SavedViewEntry({ view, onDelete }: { view: SavedView; onDelete: (id: st
       }
       sx={{ '& .MuiListItemSecondaryAction-root': { right: 4 } }}
     >
-      <ListItemButton component={NavLink} to={view.path} dense selected={active} {...newTabHandlers} sx={{ pl: ITEM_INDENT, py: 0.375, pr: 4.5 }}>
+      <ListItemButton
+        component={NavLink}
+        to={view.path}
+        dense
+        selected={active}
+        onClick={(e) => {
+          applyGridState();
+          newTabHandlers.onClick(e);
+        }}
+        onAuxClick={(e) => {
+          applyGridState();
+          newTabHandlers.onAuxClick(e);
+        }}
+        sx={{ pl: ITEM_INDENT, py: 0.375, pr: 4.5 }}
+      >
         <ListItemText primary={view.title} slotProps={{ primary: { variant: 'body2', noWrap: true } }} />
       </ListItemButton>
     </ListItem>

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -35,9 +35,9 @@ import { BUILTIN_NAV_GROUPS, groupToPath, gvkForResource, gvkLabel, pluralLabel,
 import { useApiResourcesForContexts } from '../api/queries.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
 import { useClustersStore } from '../state/clusters.js';
-import { useUiPrefsStore } from '../state/prefs.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useTabsStore } from '../state/tabs.js';
+import { applySavedViewGridState } from '../state/saved-view.js';
 import { GROUP_ICONS } from './tab-meta.js';
 
 const WIDTH = layout.navDrawerWidth;
@@ -61,12 +61,13 @@ function hotkeyFavorites(favorites: FavoriteItem[]): FavoriteItem[] {
  * page tab (+Shift focuses it), middle-click opens a background tab.
  * Plain clicks keep navigating the active tab via NavLink.
  */
-function useOpenInNewTab(to: string) {
+function useOpenInNewTab(to: string, pendingSavedView?: SavedView['grid']) {
   const openTab = useTabsStore((s) => s.openTab);
   const navigate = useNavigate();
   const open = (e: React.MouseEvent, foreground: boolean) => {
     e.preventDefault();
-    openTab(to, { activate: foreground, afterActive: true });
+    if (foreground && pendingSavedView) applySavedViewGridState(to, pendingSavedView);
+    openTab(to, { activate: foreground, afterActive: true, pendingSavedView: foreground ? undefined : pendingSavedView });
     if (foreground) void navigate(to);
   };
   return {
@@ -257,15 +258,14 @@ function NavEntry({
 function SavedViewEntry({ view, onDelete }: { view: SavedView; onDelete: (id: string) => void }) {
   const location = useLocation();
   const active = `${location.pathname}${location.search}` === view.path;
-  const newTabHandlers = useOpenInNewTab(view.path);
+  const newTabHandlers = useOpenInNewTab(view.path, view.grid);
   // Views saved with a grid snapshot restore the whole table — namespaces,
   // sort, column visibility and widths — not just the query in the path.
   // Older views without one restore the query only.
   const applyGridState = () => {
     const grid = view.grid;
     if (!grid) return;
-    if (grid.namespaces) useClustersStore.getState().setNamespaces(grid.namespaces);
-    useUiPrefsStore.getState().applyTableState(view.path.split('?')[0] ?? view.path, grid);
+    applySavedViewGridState(view.path, grid);
   };
   return (
     <ListItem
@@ -294,11 +294,10 @@ function SavedViewEntry({ view, onDelete }: { view: SavedView; onDelete: (id: st
         dense
         selected={active}
         onClick={(e) => {
-          applyGridState();
+          if (!e.ctrlKey && !e.metaKey) applyGridState();
           newTabHandlers.onClick(e);
         }}
         onAuxClick={(e) => {
-          applyGridState();
           newTabHandlers.onAuxClick(e);
         }}
         sx={{ pl: ITEM_INDENT, py: 0.375, pr: 4.5 }}

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -641,6 +641,12 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
           placeholder="Filter resources…"
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key !== 'Escape') return;
+            e.stopPropagation();
+            if (filter) setFilter('');
+            else (e.target as HTMLElement).blur();
+          }}
           slotProps={{
             input: {
               startAdornment: (

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -1,4 +1,5 @@
 import { memo, useDeferredValue, useEffect, useMemo, useState, type DragEvent, type ReactNode } from 'react';
+import { layout } from '../theme.js';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import Drawer from '@mui/material/Drawer';
@@ -39,7 +40,7 @@ import { useNavigationStore } from '../state/navigation.js';
 import { useTabsStore } from '../state/tabs.js';
 import { GROUP_ICONS } from './tab-meta.js';
 
-const WIDTH = 228;
+const WIDTH = layout.navDrawerWidth;
 // Indent of group items so they line up under the group label (button pl 16px + icon 26px).
 const ITEM_INDENT = '42px';
 const FAVORITE_DRAG_TYPE = 'application/x-kubus-favorite';

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -455,7 +455,16 @@ function FavoriteDragShell({
   );
 }
 
-export const NavDrawer = memo(function NavDrawer() {
+interface NavDrawerProps {
+  /** Render as a temporary overlay (narrow viewports) instead of a pinned rail. */
+  overlay: boolean;
+  /** Pinned rail collapsed to zero width; content stays mounted for hotkeys. */
+  hidden: boolean;
+  open: boolean;
+  onClose: () => void;
+}
+
+export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClose }: NavDrawerProps) {
   const selected = useClustersStore((s) => s.selected);
   const { data: apiResources } = useApiResourcesForContexts(selected);
   const favorites = useNavigationStore((s) => s.favorites);
@@ -478,6 +487,14 @@ export const NavDrawer = memo(function NavDrawer() {
   const [favoriteDropTarget, setFavoriteDropTarget] = useState<FavoriteDropTarget | null>(null);
   const deferredFilter = useDeferredValue(filter);
   const navigate = useNavigate();
+
+  // The overlay covers content — dismiss it once a nav click lands.
+  const location = useLocation();
+  const currentPath = location.pathname + location.search;
+  useEffect(() => {
+    if (overlay) onClose();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- close on navigation only
+  }, [currentPath]);
 
   // Cmd/Ctrl+1–9 jumps to the corresponding favorite. Digits come from
   // e.code so the physical number row works on any keyboard layout. Note the
@@ -595,19 +612,26 @@ export const NavDrawer = memo(function NavDrawer() {
       children
     );
 
+  const railHidden = !overlay && hidden;
   return (
     <Drawer
-      variant="permanent"
+      variant={overlay ? 'temporary' : 'permanent'}
+      open={overlay ? open : true}
+      onClose={onClose}
       sx={{
-        width: WIDTH,
+        width: overlay || railHidden ? 0 : WIDTH,
         flexShrink: 0,
+        transition: 'width 150ms ease',
         '& .MuiDrawer-paper': {
-          width: WIDTH,
-          position: 'relative',
-          borderRight: 1,
+          width: railHidden ? 0 : WIDTH,
+          borderRight: railHidden ? 0 : 1,
           borderColor: 'divider',
           overflowY: 'auto',
+          overflowX: 'hidden',
           bgcolor: (theme) => (theme.palette.mode === 'dark' ? '#151518' : '#f4f4f5'),
+          ...(overlay
+            ? { top: `${layout.topBarHeight}px`, height: `calc(100% - ${layout.topBarHeight}px)` }
+            : { position: 'relative', transition: 'width 150ms ease' }),
         },
       }}
     >

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -23,8 +23,12 @@ import { useGlobalSearch } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useDockStore } from '../state/dock.js';
+import { useTabsStore } from '../state/tabs.js';
+import { useUiStore } from '../state/ui.js';
+import { toggleNavRail } from '../shortcuts.js';
 import { showToast } from '../state/toast.js';
 import { actionsForRef, usePaletteRunner, type PaletteAction } from '../actions/resource-actions.js';
+import { HOTKEY_MOD_LABEL } from '../platform.js';
 
 function pathForRef(ref: ResourceRef): string {
   return `/r/${groupToPath(ref.group)}/${ref.version}/${ref.plural}`;
@@ -45,23 +49,41 @@ function favoriteFromResult(result: SearchResult): FavoriteItem {
   };
 }
 
+interface CommandDeps {
+  navigate: (path: string) => void;
+  toggleTheme: () => void;
+  toggleDock: () => void;
+  toggleNav: () => void;
+  openSettings: () => void;
+  openShortcuts: () => void;
+  newTab: () => void;
+  reopenTab: () => void;
+}
+
 interface StaticCommand {
   id: string;
   title: string;
   subtitle?: string;
-  run: (deps: { navigate: (path: string) => void; toggleTheme: () => void; toggleDock: () => void }) => void;
+  run: (deps: CommandDeps) => void;
 }
 
 const STATIC_COMMANDS: StaticCommand[] = [
   { id: 'cmd:theme', title: 'Toggle dark / light mode', run: (d) => d.toggleTheme() },
   { id: 'cmd:dock', title: 'Toggle terminal dock', run: (d) => d.toggleDock() },
+  { id: 'cmd:nav', title: 'Toggle navigation rail', run: (d) => d.toggleNav() },
+  { id: 'cmd:newtab', title: 'New tab', run: (d) => d.newTab() },
+  { id: 'cmd:reopen', title: 'Reopen closed tab', run: (d) => d.reopenTab() },
+  { id: 'cmd:settings', title: 'Open settings', run: (d) => d.openSettings() },
+  { id: 'cmd:shortcuts', title: 'Keyboard shortcuts', run: (d) => d.openShortcuts() },
   { id: 'cmd:overview', title: 'Go to Overview', run: (d) => d.navigate('/') },
   { id: 'cmd:events', title: 'Go to Events', run: (d) => d.navigate('/events') },
   { id: 'cmd:topology', title: 'Go to Topology', run: (d) => d.navigate('/topology') },
   { id: 'cmd:metrics', title: 'Go to Metrics', run: (d) => d.navigate('/metrics') },
+  { id: 'cmd:network', title: 'Go to Network', run: (d) => d.navigate('/network') },
   { id: 'cmd:helm', title: 'Go to Helm Releases', run: (d) => d.navigate('/helm') },
   { id: 'cmd:forwards', title: 'Go to Port Forwards', run: (d) => d.navigate('/forwards') },
   { id: 'cmd:diff', title: 'Go to Diff', run: (d) => d.navigate('/diff') },
+  { id: 'cmd:audit', title: 'Go to Audit', run: (d) => d.navigate('/audit') },
 ];
 
 type Row =
@@ -149,11 +171,26 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
   const activate = (row: Row) => {
     if (row.type === 'command') {
       row.command.run({
-        navigate,
+        navigate: (path) => void navigate(path),
         toggleTheme,
         toggleDock: () => {
           const { open, setOpen } = useDockStore.getState();
           setOpen(!open);
+        },
+        toggleNav: toggleNavRail,
+        openSettings: () => useUiStore.getState().setSettingsOpen(true),
+        openShortcuts: () => useUiStore.getState().setShortcutsOpen(true),
+        newTab: () => {
+          useTabsStore.getState().openTab('/');
+          void navigate('/');
+        },
+        reopenTab: () => {
+          const before = useTabsStore.getState().activeId;
+          useTabsStore.getState().reopenTab();
+          const s = useTabsStore.getState();
+          if (s.activeId === before) return;
+          const active = s.tabs.find((t) => t.id === s.activeId);
+          if (active) void navigate(active.path);
         },
       });
       closeAll();
@@ -185,6 +222,20 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
     else addFavorite(favoriteFromResult(item));
   };
 
+  // Cmd/Ctrl+Enter opens a result in a new tab, Shift+Enter in a background
+  // tab (the dialog stays open, so several can be queued).
+  const openInNewTab = (row: Row, background: boolean): boolean => {
+    if (row.type !== 'result') return false;
+    const item = row.result;
+    const path = item.ref ? detailPathForRef(item.ref) : item.path ?? '/';
+    useTabsStore.getState().openTab(path, { afterActive: true, activate: !background });
+    if (!background) {
+      void navigate(path);
+      closeAll();
+    }
+    return true;
+  };
+
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
@@ -192,10 +243,18 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === 'PageDown' || e.key === 'PageUp') {
+      e.preventDefault();
+      setActiveIndex((i) => (e.key === 'PageDown' ? Math.min(i + 8, rows.length - 1) : Math.max(i - 8, 0)));
     } else if (e.key === 'Enter') {
       e.preventDefault();
       const row = rows[activeIndex];
-      if (row) activate(row);
+      if (!row) return;
+      if ((e.metaKey || e.ctrlKey || e.shiftKey) && openInNewTab(row, e.shiftKey)) return;
+      activate(row);
+    } else if (e.key === 'ArrowLeft' && stage && query === '') {
+      e.preventDefault();
+      setStage(null);
     } else if ((e.key === 'Tab' || e.key === 'ArrowRight') && !stage) {
       const row = rows[activeIndex];
       if (row?.type === 'result' && row.result.ref) {
@@ -225,7 +284,7 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
       : query.trim().length > 1
         ? isFetching
           ? 'Searching…'
-          : `${rows.length} results — Tab for actions, > for commands`
+          : `${rows.length} results — Tab actions · ${HOTKEY_MOD_LABEL}↵ new tab · > commands`
         : favorites.length
           ? 'Favorites — type to search, > for commands'
           : 'Type to search, > for commands';

--- a/client/src/layout/TabsBar.tsx
+++ b/client/src/layout/TabsBar.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { layout } from '../theme.js';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
@@ -11,6 +11,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import { useLocation, useNavigate } from 'react-router';
 import { useTabsStore } from '../state/tabs.js';
 import { useClustersStore } from '../state/clusters.js';
+import { applySavedViewGridState } from '../state/saved-view.js';
 import { useApiResourcesForContexts } from '../api/queries.js';
 import { tabMeta } from './tab-meta.js';
 
@@ -26,12 +27,21 @@ export const TabsBar = memo(function TabsBar() {
   const location = useLocation();
   const navigate = useNavigate();
   const current = location.pathname + location.search;
+  const activeTab = tabs.find((tab) => tab.id === activeId);
 
   const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
   const [dragId, setDragId] = useState<string | null>(null);
   const dragIndexRef = useRef<number | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
+
+  // A background saved-view tab carries its snapshot without touching the
+  // visible page. Consume it exactly once when that tab becomes active.
+  useLayoutEffect(() => {
+    if (!activeId || !activeTab?.pendingSavedView) return;
+    applySavedViewGridState(activeTab.path, activeTab.pendingSavedView);
+    useTabsStore.getState().clearPendingSavedView(activeId);
+  }, [activeId, activeTab?.path, activeTab?.pendingSavedView]);
 
   // Router → store: the active tab always mirrors the current location, so
   // in-page navigation (filters, detail deep links, drill-downs) is captured.

--- a/client/src/layout/TabsBar.tsx
+++ b/client/src/layout/TabsBar.tsx
@@ -120,6 +120,24 @@ export const TabsBar = memo(function TabsBar() {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   act(() => useTabsStore.getState().setActive(tab.id));
+                  return;
+                }
+                if (e.key === 'Delete') {
+                  e.preventDefault();
+                  closeTab(tab.id);
+                  // The focused element is gone; keep keyboard flow on the strip.
+                  requestAnimationFrame(() => scrollRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]')?.focus());
+                  return;
+                }
+                // Roving focus per the ARIA tabs pattern: arrows move focus
+                // (with wrap-around), Enter/Space activates.
+                if (e.key === 'ArrowRight' || e.key === 'ArrowLeft' || e.key === 'Home' || e.key === 'End') {
+                  e.preventDefault();
+                  const els = [...(scrollRef.current?.querySelectorAll<HTMLElement>('[role="tab"]') ?? [])];
+                  const i = els.indexOf(e.currentTarget as HTMLElement);
+                  const to =
+                    e.key === 'Home' ? 0 : e.key === 'End' ? els.length - 1 : (i + (e.key === 'ArrowRight' ? 1 : -1) + els.length) % els.length;
+                  els[to]?.focus();
                 }
               }}
               onAuxClick={(e) => {

--- a/client/src/layout/TabsBar.tsx
+++ b/client/src/layout/TabsBar.tsx
@@ -1,4 +1,5 @@
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { layout } from '../theme.js';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
@@ -138,8 +139,8 @@ export const TabsBar = memo(function TabsBar() {
                 pl: 1.25,
                 pr: 0.75,
                 // Explicit width (not flex-basis) so the shrink-to-fit tablist
-                // sizes to n×190 and only squeezes tabs once the bar is full.
-                width: 190,
+                // sizes to n×tabWidth and only squeezes tabs once the bar is full.
+                width: layout.tabWidth,
                 minWidth: 100,
                 flexShrink: 1,
                 borderRight: 1,

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -3,6 +3,8 @@ import { layout } from '../theme.js';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import MenuIcon from '@mui/icons-material/Menu';
 import Stack from '@mui/material/Stack';
 import Toolbar from '@mui/material/Toolbar';
 import Tooltip from '@mui/material/Tooltip';
@@ -16,6 +18,8 @@ import SearchIcon from '@mui/icons-material/Search';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { useClustersStore } from '../state/clusters.js';
 import { useDockStore } from '../state/dock.js';
+import { NAV_OVERLAY_MEDIA_QUERY, useNavUiStore } from '../state/nav-ui.js';
+import { useUiPrefsStore } from '../state/prefs.js';
 import { isTextEntryTarget } from '../text-entry.js';
 import { ShortcutHelpDialog } from '../components/ShortcutHelpDialog.js';
 import { ClusterSwitcher } from './ClusterSwitcher.js';
@@ -37,6 +41,17 @@ export const TopBar = memo(function TopBar() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  // Wide viewports: toggle the pinned rail. Narrow: toggle the overlay.
+  const navOverlay = useMediaQuery(NAV_OVERLAY_MEDIA_QUERY);
+  const handleNavToggle = () => {
+    if (navOverlay) {
+      const nav = useNavUiStore.getState();
+      nav.setOverlayOpen(!nav.overlayOpen);
+    } else {
+      const prefs = useUiPrefsStore.getState();
+      prefs.set({ navCollapsed: !prefs.navCollapsed });
+    }
+  };
   // Mounted on first open, kept mounted after so close animations still play.
   const [searchMounted, setSearchMounted] = useState(false);
   const [settingsMounted, setSettingsMounted] = useState(false);
@@ -83,6 +98,11 @@ export const TopBar = memo(function TopBar() {
             },
           }}
         >
+          <Tooltip title="Toggle navigation">
+            <IconButton size="small" aria-label="Toggle navigation" onClick={handleNavToggle} sx={{ mr: 0.5 }}>
+              <MenuIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
           <Stack direction="row" spacing={1} sx={{ mr: 1.5, alignItems: 'center' }}>
             <Box
               component="img"

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -1,9 +1,8 @@
-import { lazy, memo, Suspense, useEffect, useState } from 'react';
+import { lazy, memo, Suspense, useState } from 'react';
 import { layout } from '../theme.js';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import MenuIcon from '@mui/icons-material/Menu';
 import Stack from '@mui/material/Stack';
 import Toolbar from '@mui/material/Toolbar';
@@ -18,9 +17,9 @@ import SearchIcon from '@mui/icons-material/Search';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import { useClustersStore } from '../state/clusters.js';
 import { useDockStore } from '../state/dock.js';
-import { NAV_OVERLAY_MEDIA_QUERY, useNavUiStore } from '../state/nav-ui.js';
-import { useUiPrefsStore } from '../state/prefs.js';
-import { isTextEntryTarget } from '../text-entry.js';
+import { useUiStore } from '../state/ui.js';
+import { HOTKEY_MOD_LABEL } from '../platform.js';
+import { toggleNavRail } from '../shortcuts.js';
 import { ShortcutHelpDialog } from '../components/ShortcutHelpDialog.js';
 import { ClusterSwitcher } from './ClusterSwitcher.js';
 import { NamespaceFilter } from './NamespaceFilter.js';
@@ -38,41 +37,19 @@ export const TopBar = memo(function TopBar() {
   const dockOpen = useDockStore((s) => s.open);
   const dockTabCount = useDockStore((s) => s.tabs.length);
   const setDockOpen = useDockStore((s) => s.setOpen);
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  // Wide viewports: toggle the pinned rail. Narrow: toggle the overlay.
-  const navOverlay = useMediaQuery(NAV_OVERLAY_MEDIA_QUERY);
-  const handleNavToggle = () => {
-    if (navOverlay) {
-      const nav = useNavUiStore.getState();
-      nav.setOverlayOpen(!nav.overlayOpen);
-    } else {
-      const prefs = useUiPrefsStore.getState();
-      prefs.set({ navCollapsed: !prefs.navCollapsed });
-    }
-  };
+  // Dialog open state lives in the ui store: the global shortcuts and the
+  // command palette drive the same dialogs.
+  const searchOpen = useUiStore((s) => s.searchOpen);
+  const setSearchOpen = useUiStore((s) => s.setSearchOpen);
+  const settingsOpen = useUiStore((s) => s.settingsOpen);
+  const setSettingsOpen = useUiStore((s) => s.setSettingsOpen);
+  const shortcutsOpen = useUiStore((s) => s.shortcutsOpen);
+  const setShortcutsOpen = useUiStore((s) => s.setShortcutsOpen);
   // Mounted on first open, kept mounted after so close animations still play.
   const [searchMounted, setSearchMounted] = useState(false);
   const [settingsMounted, setSettingsMounted] = useState(false);
   if (searchOpen && !searchMounted) setSearchMounted(true);
   if (settingsOpen && !settingsMounted) setSettingsMounted(true);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
-        e.preventDefault();
-        setSearchOpen(true);
-        return;
-      }
-      if (e.key === '?' && !e.metaKey && !e.ctrlKey && !e.altKey && !isTextEntryTarget(e.target)) {
-        e.preventDefault();
-        setShortcutsOpen(true);
-      }
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, []);
 
   return (
     <>
@@ -98,8 +75,8 @@ export const TopBar = memo(function TopBar() {
             },
           }}
         >
-          <Tooltip title="Toggle navigation">
-            <IconButton size="small" aria-label="Toggle navigation" onClick={handleNavToggle} sx={{ mr: 0.5 }}>
+          <Tooltip title={`Toggle navigation (${HOTKEY_MOD_LABEL}B)`}>
+            <IconButton size="small" aria-label="Toggle navigation" onClick={toggleNavRail} sx={{ mr: 0.5 }}>
               <MenuIcon fontSize="small" />
             </IconButton>
           </Tooltip>
@@ -123,13 +100,13 @@ export const TopBar = memo(function TopBar() {
           <ClusterSwitcher />
           <NamespaceFilter />
           <Box sx={{ flex: 1 }} />
-          <Tooltip title="Search (Ctrl+K)">
+          <Tooltip title={`Search (${HOTKEY_MOD_LABEL}K)`}>
             <IconButton size="small" onClick={() => setSearchOpen(true)} onMouseEnter={() => void loadSearchDialog()} onFocus={() => void loadSearchDialog()}>
               <SearchIcon fontSize="small" />
             </IconButton>
           </Tooltip>
           {dockTabCount > 0 && (
-            <Tooltip title={dockOpen ? 'Hide dock' : `Show dock (${dockTabCount} tabs)`}>
+            <Tooltip title={dockOpen ? `Hide dock (${HOTKEY_MOD_LABEL}J)` : `Show dock — ${dockTabCount} tabs (${HOTKEY_MOD_LABEL}J)`}>
               <IconButton size="small" onClick={() => setDockOpen(!dockOpen)} color={dockOpen ? 'primary' : 'default'}>
                 <TerminalIcon fontSize="small" />
               </IconButton>
@@ -145,7 +122,7 @@ export const TopBar = memo(function TopBar() {
               {mode === 'light' ? <DarkModeOutlinedIcon fontSize="small" /> : mode === 'dark' ? <BrightnessAutoOutlinedIcon fontSize="small" /> : <LightModeOutlinedIcon fontSize="small" />}
             </IconButton>
           </Tooltip>
-          <Tooltip title="Settings">
+          <Tooltip title={`Settings (${HOTKEY_MOD_LABEL},)`}>
             <IconButton size="small" onClick={() => setSettingsOpen(true)} onMouseEnter={() => void loadSettingsDialog()} onFocus={() => void loadSettingsDialog()}>
               <SettingsOutlinedIcon fontSize="small" />
             </IconButton>

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -1,4 +1,5 @@
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
+import { layout } from '../theme.js';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
@@ -70,7 +71,7 @@ export const TopBar = memo(function TopBar() {
           variant="dense"
           sx={{
             gap: 1.5,
-            minHeight: 52,
+            minHeight: layout.topBarHeight,
             WebkitAppRegion: 'drag',
             // double the specificity: MUI's responsive gutter rule wins otherwise
             '&&': {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router';
 import { ApiError, initAuthToken } from './api/http.js';
+import { isMutationErrorHandledLocally } from './api/mutation-errors.js';
 import { showToast } from './state/toast.js';
 import App from './App.js';
 
@@ -15,6 +16,7 @@ const queryClient = new QueryClient({
     // failures are excluded — the global status banner owns those.
     onError: (error, _variables, _context, mutation) => {
       if (mutation.options.onError) return;
+      if (isMutationErrorHandledLocally(mutation.meta)) return;
       if (error instanceof ApiError && (error.status === 0 || error.status === 401)) return;
       showToast('error', error instanceof Error ? error.message : String(error));
     },

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,13 +1,24 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router';
-import { initAuthToken } from './api/http.js';
+import { ApiError, initAuthToken } from './api/http.js';
+import { showToast } from './state/toast.js';
 import App from './App.js';
 
 initAuthToken();
 
 const queryClient = new QueryClient({
+  mutationCache: new MutationCache({
+    // Safety net so a failed action is never silent: mutations that handle
+    // their own errors keep doing so. Unreachable-backend and stale-token
+    // failures are excluded — the global status banner owns those.
+    onError: (error, _variables, _context, mutation) => {
+      if (mutation.options.onError) return;
+      if (error instanceof ApiError && (error.status === 0 || error.status === 401)) return;
+      showToast('error', error instanceof Error ? error.message : String(error));
+    },
+  }),
   defaultOptions: {
     // staleTime keeps remounts (tab switches, pane reveals) from refetching
     // data that a polled query refreshed moments ago; polling intervals are

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -1,27 +1,27 @@
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useDeferredValue, useMemo, useRef, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Stack from '@mui/material/Stack';
 import Switch from '@mui/material/Switch';
-import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import SearchIcon from '@mui/icons-material/Search';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { gvkForKind, type KubeObject } from '@kubus/shared';
 import { useApiResourcesForContexts, useWatchedList, type ClusterRow } from '../api/queries.js';
-import { useClustersStore } from '../state/clusters.js';
+import { matchesPlainText, matchesSmartFilter, parseSmartFilter } from '../smart-filter.js';
+import { namespaceVisible, useClustersStore } from '../state/clusters.js';
 import { useDetailStore } from '../state/detail.js';
 import { AgeCell } from '../components/AgeCell.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
+import { useQuickSearchShortcut } from '../components/quick-search.js';
+import { SmartFilterInput } from '../components/SmartFilterInput.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { NoClustersState } from '../components/NoClustersState.js';
 import { PageHeader } from '../components/PageHeader.js';
@@ -97,6 +97,8 @@ export function EventsPage() {
   const [kindFilter, setKindFilter] = useState('');
   const [text, setText] = useState('');
   const deferredText = useDeferredValue(text);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  useQuickSearchShortcut(searchInputRef);
 
   const kinds = useMemo(() => {
     const set = new Set<string>();
@@ -107,34 +109,40 @@ export function EventsPage() {
     return [...set].sort();
   }, [list.rows]);
 
+  // Same engine as the resource tables: plain words, or `/` clauses
+  // (reason:, message:, type:warning, ns:, cluster:, age>…).
+  const parsedFilter = useMemo(() => {
+    const query = deferredText.trim();
+    if (!query) return undefined;
+    if (query.startsWith('/')) {
+      const clauses = parseSmartFilter(query.slice(1));
+      return clauses.length ? { clauses } : undefined;
+    }
+    return { words: query.toLowerCase().split(/\s+/).filter(Boolean) };
+  }, [deferredText]);
+
   const deduped = useMemo(() => {
     let filtered = list.rows;
     if (namespaces.length > 0) {
-      const nsSet = new Set(namespaces);
-      filtered = filtered.filter((r) => !r.obj.metadata.namespace || nsSet.has(r.obj.metadata.namespace));
+      filtered = filtered.filter((r) => namespaceVisible(r.obj.metadata.namespace, namespaces));
+    }
+    if (parsedFilter?.clauses) {
+      const ctx = { kind: 'Event', nowMs: Date.now() };
+      filtered = filtered.filter((r) => matchesSmartFilter(r, parsedFilter.clauses, ctx));
+    } else if (parsedFilter?.words) {
+      filtered = filtered.filter((r) => matchesPlainText(r, parsedFilter.words, 'Event'));
     }
     return dedupe(filtered);
-  }, [list.rows, namespaces]);
+  }, [list.rows, namespaces, parsedFilter]);
 
   const rows = useMemo(() => {
-    const f = deferredText.trim().toLowerCase();
-    if (!warningsOnly && !kindFilter && !f) return deduped;
+    if (!warningsOnly && !kindFilter) return deduped;
     return deduped.filter((r) => {
       if (warningsOnly && r.ev.type !== 'Warning') return false;
       if (kindFilter && r.ev.involvedObject?.kind !== kindFilter) return false;
-      if (f) {
-        const o = r.ev.involvedObject;
-        return (
-          (r.ev.message ?? '').toLowerCase().includes(f) ||
-          (r.ev.reason ?? '').toLowerCase().includes(f) ||
-          `${o?.kind}/${o?.name}`.toLowerCase().includes(f) ||
-          (o?.namespace ?? '').toLowerCase().includes(f) ||
-          r.ctx.toLowerCase().includes(f)
-        );
-      }
       return true;
     });
-  }, [deduped, warningsOnly, kindFilter, deferredText]);
+  }, [deduped, warningsOnly, kindFilter]);
 
   const openInvolved = (row: EventRow) => {
     const o = row.ev.involvedObject;
@@ -217,21 +225,7 @@ export function EventsPage() {
         ))}
       </Box>
       <Stack direction="row" spacing={1} sx={{ px: 1.5, py: 1, flexShrink: 0, alignItems: 'center' }}>
-        <TextField
-          placeholder="Search message, reason, object…"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          sx={{ width: 280 }}
-          slotProps={{
-            input: {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon sx={{ fontSize: 18 }} />
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
+        <SmartFilterInput value={text} onChange={setText} kind="Event" rows={list.rows} inputRef={searchInputRef} />
         <FormControl size="small" sx={{ minWidth: 160 }}>
           <InputLabel id="events-kind">Kind</InputLabel>
           <Select labelId="events-kind" label="Kind" value={kindFilter} onChange={(e) => setKindFilter(e.target.value)}>

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -250,14 +250,20 @@ export function EventsPage() {
         density={grid.density}
         onColumnWidthChange={grid.onColumnWidthChange}
         onRowClick={(p) => openInvolved(p.row as EventRow)}
-        onCellKeyDown={handleCopyCellKeyDown}
+        onCellKeyDown={(params, event, details) => {
+          handleCopyCellKeyDown(params, event, details);
+          // Keyboard equivalent of clicking the row.
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            openInvolved(params.row as EventRow);
+          }
+        }}
         initialState={{ sorting: { sortModel: [{ field: 'lastSeen', sort: 'desc' }] } }}
         sx={{
           border: 0,
           flex: 1,
           minHeight: 0,
           '& .MuiDataGrid-row': { cursor: 'pointer' },
-          '& .MuiDataGrid-cell:focus, & .MuiDataGrid-columnHeader:focus': { outline: 'none' },
           ...copyCellGridSx,
         }}
       />

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -15,7 +15,7 @@ import type { GridColDef } from '@mui/x-data-grid';
 import { DataGrid } from '@mui/x-data-grid';
 import type { HelmReleaseSummary } from '@kubus/shared';
 import { useAppInfo, useHelmOperations, useHelmReleases, useHelmUpdates } from '../api/queries.js';
-import { useClustersStore } from '../state/clusters.js';
+import { namespaceVisible, useClustersStore } from '../state/clusters.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
@@ -44,8 +44,7 @@ export function HelmPage() {
   const rows = useMemo(() => {
     const all = data ?? [];
     if (!namespaces.length) return all;
-    const set = new Set(namespaces);
-    return all.filter((r) => set.has(r.release.namespace));
+    return all.filter((r) => namespaceVisible(r.release.namespace, namespaces));
   }, [data, namespaces]);
   const updateItems = useMemo(
     () =>

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -193,7 +193,16 @@ export function HelmPage() {
         density={grid.density}
         onColumnWidthChange={grid.onColumnWidthChange}
         onRowClick={(p) => navigate(`/helm/${encodeURIComponent(p.row.ctx)}/${encodeURIComponent(p.row.release.namespace)}/${encodeURIComponent(p.row.release.name)}`)}
-        onCellKeyDown={handleCopyCellKeyDown}
+        onCellKeyDown={(params, event, details) => {
+          handleCopyCellKeyDown(params, event, details);
+          // Keyboard equivalent of clicking the row.
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            void navigate(
+              `/helm/${encodeURIComponent(params.row.ctx)}/${encodeURIComponent(params.row.release.namespace)}/${encodeURIComponent(params.row.release.name)}`,
+            );
+          }
+        }}
         sx={{ flex: 1, minHeight: 0, border: 0, '& .MuiDataGrid-row': { cursor: 'pointer' }, ...copyCellGridSx }}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
       />

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -1,6 +1,9 @@
-import { useMemo } from 'react';
+import { lazy, Suspense, useMemo, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import CircularProgress from '@mui/material/CircularProgress';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
@@ -24,35 +27,110 @@ import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router';
-import { useNodeMetrics, useOverview } from '../api/queries.js';
+import { useContexts, useKubeconfigSettings, useNodeMetrics, useOverview } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { AgeCell } from '../components/AgeCell.js';
 import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
-import { EmptyState } from '../components/EmptyState.js';
 import { InstallMetricsServerButton } from '../components/MetricsServerControls.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { formatBytes, formatCpu } from '../components/format.js';
+
+// Adding a cluster pulls the settings chunk (js-yaml); keep it lazy here.
+const AddClusterDialog = lazy(() => import('../components/settings/AddClusterDialog.js').then((m) => ({ default: m.AddClusterDialog })));
+
+const HEALTH_COLOR: Record<string, string> = { connected: 'success.main', connecting: 'warning.main', error: 'error.main' };
+
+/**
+ * First-run path: instead of pointing at the cluster switcher, list the
+ * kubeconfig's contexts for one-click connect, or lead straight into the
+ * add-cluster flow when the kubeconfig is empty.
+ */
+function WelcomeState() {
+  // Selecting drives the ClusterSwitcher's keep-healthy effect, which owns
+  // connecting — no second connect path here.
+  const setSelected = useClustersStore((s) => s.setSelected);
+  const { data: contexts, isLoading } = useContexts();
+  const { data: kubeconfig } = useKubeconfigSettings();
+  const [addOpen, setAddOpen] = useState(false);
+  const shown = (contexts ?? []).slice(0, 8);
+
+  return (
+    <Stack sx={{ flex: 1, alignItems: 'center', justifyContent: 'center', p: 3, minHeight: '100%' }} spacing={2}>
+      <Box component="img" src="/kubus.svg" alt="" aria-hidden sx={{ width: 48, height: 54, objectFit: 'contain' }} />
+      <Typography variant="h5" sx={{ fontWeight: 700 }}>
+        Welcome to Kubus
+      </Typography>
+      {isLoading && <CircularProgress size={22} />}
+      {!isLoading && shown.length > 0 && (
+        <>
+          <Typography variant="body2" color="text.secondary">
+            Pick a cluster from your kubeconfig to get started.
+          </Typography>
+          <Stack spacing={1} sx={{ width: 'min(520px, 100%)' }}>
+            {shown.map((c) => (
+              <ButtonBase
+                key={c.name}
+                onClick={() => setSelected([c.name])}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1.25,
+                  px: 1.75,
+                  py: 1.25,
+                  border: 1,
+                  borderColor: 'divider',
+                  borderRadius: 1.5,
+                  textAlign: 'left',
+                  justifyContent: 'flex-start',
+                  '&:hover': { bgcolor: 'action.hover', borderColor: 'primary.main' },
+                }}
+              >
+                <Box sx={{ width: 9, height: 9, borderRadius: '50%', flexShrink: 0, bgcolor: HEALTH_COLOR[c.health] ?? 'text.disabled' }} />
+                <Box sx={{ minWidth: 0, flex: 1 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }} noWrap>
+                    {c.name}
+                  </Typography>
+                  {c.server && (
+                    <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+                      {c.server}
+                    </Typography>
+                  )}
+                </Box>
+                {c.current && <Chip label="current" size="small" variant="outlined" sx={{ flexShrink: 0 }} />}
+              </ButtonBase>
+            ))}
+            {(contexts?.length ?? 0) > shown.length && (
+              <Typography variant="caption" color="text.secondary" sx={{ textAlign: 'center' }}>
+                …and {(contexts?.length ?? 0) - shown.length} more in the cluster switcher above.
+              </Typography>
+            )}
+          </Stack>
+        </>
+      )}
+      {!isLoading && shown.length === 0 && (
+        <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 440, textAlign: 'center' }}>
+          No clusters found in your kubeconfig. Add one by pasting a kubeconfig or entering connection details.
+        </Typography>
+      )}
+      <Button variant={shown.length === 0 ? 'contained' : 'outlined'} startIcon={<AddIcon />} onClick={() => setAddOpen(true)}>
+        Add cluster
+      </Button>
+      {addOpen && (
+        <Suspense fallback={null}>
+          <AddClusterDialog primaryPath={kubeconfig?.primaryPath ?? null} onClose={() => setAddOpen(false)} />
+        </Suspense>
+      )}
+    </Stack>
+  );
+}
 
 export function OverviewPage() {
   const selected = useClustersStore((s) => s.selected);
 
   if (selected.length === 0) {
-    return (
-      <EmptyState
-        icon={
-          <Box
-            component="img"
-            src="/kubus.svg"
-            alt=""
-            aria-hidden
-            sx={{ width: 48, height: 54, objectFit: 'contain' }}
-          />
-        }
-        title="Welcome to Kubus"
-        subtitle="Select one or more clusters in the top bar to get started."
-      />
-    );
+    return <WelcomeState />;
   }
 
   return (

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -173,7 +173,15 @@ function EmbeddedResourceDetail() {
           e.stopPropagation();
           const page = asideRef.current?.closest('.kubus-resource-page');
           handleClose();
-          page?.querySelector<HTMLElement>('.MuiDataGrid-cell[tabindex="0"], .MuiDataGrid-columnHeader[tabindex="0"]')?.focus();
+          // Query after the close re-renders — the grid re-lays-out without
+          // the panel and may recreate cell nodes. Prefer the cell the grid
+          // last had focused, fall back to the first cell.
+          requestAnimationFrame(() => {
+            const cell =
+              page?.querySelector<HTMLElement>('.MuiDataGrid-cell[tabindex="0"], .MuiDataGrid-columnHeader[tabindex="0"]') ??
+              page?.querySelector<HTMLElement>('.MuiDataGrid-cell');
+            cell?.focus();
+          });
         }}
         sx={{
           position: 'relative',

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -18,6 +18,7 @@ import { useParams, useSearchParams } from 'react-router';
 import { columnsForKind, groupFromPath, groupToPath, gvkForResource, gvkLabel, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
 import { useApiResourcesForContexts, useCrdColumns, useCreateResource, useDryRunResource, useFilteredList, useResourceMetrics, useWatchedList, type ClusterRow } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
+import { useUiPrefsStore } from '../state/prefs.js';
 import { useDockStore, dockTabId } from '../state/dock.js';
 import { ResourceTable } from '../components/ResourceTable.js';
 import { ApiResourceDrawer } from '../components/ApiResourceDrawer.js';
@@ -448,12 +449,21 @@ export function ResourceListPage() {
     if (textFilter.trim()) params.set('q', textFilter.trim());
     if (labelSelector.trim()) params.set('label', labelSelector.trim());
     const path = `${kindPath}${params.toString() ? `?${params.toString()}` : ''}`;
+    // Snapshot the grid so restoring brings back the exact table, not just
+    // the query. tableId for this grid is kindPath.
+    const prefs = useUiPrefsStore.getState();
     addSavedView({
       id: `view:${path}`,
       title: `${resourceTitle}${textFilter || labelSelector ? ' view' : ''}`,
       path,
       textFilter: textFilter.trim() || undefined,
       labelSelector: labelSelector.trim() || undefined,
+      grid: {
+        namespaces: [...useClustersStore.getState().namespaces],
+        sort: prefs.sortModels[kindPath],
+        columnVisibility: prefs.columnVisibility[kindPath],
+        columnWidths: prefs.columnWidths[kindPath],
+      },
     });
   };
 

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -12,11 +12,13 @@ import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import SubjectIcon from '@mui/icons-material/Subject';
 import BookmarkAddOutlinedIcon from '@mui/icons-material/BookmarkAddOutlined';
 import { useParams, useSearchParams } from 'react-router';
 import { columnsForKind, groupFromPath, groupToPath, gvkForResource, gvkLabel, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
-import { useApiResourcesForContexts, useCrdColumns, useCreateResource, useDryRunResource, useFilteredList, useResourceMetrics, useWatchedList, type ClusterRow } from '../api/queries.js';
+import { useApiResourcesForContexts, useCrdColumns, useCreateResource, useDeleteResource, useDryRunResource, useFilteredList, useResourceMetrics, useRolloutRestart, useWatchedList, type ClusterRow } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { useDockStore, dockTabId } from '../state/dock.js';
@@ -27,7 +29,9 @@ import { ResourceDetailPanel, type ResourceSelection } from '../components/Resou
 import { clampDetailWidth, DEFAULT_DETAIL_WIDTH, useDetailStore } from '../state/detail.js';
 import { isLogTargetKind, RowActionMenu, RowActions, RowLogsButton, type RowActionTarget } from '../components/RowActions.js';
 import { YamlEditor } from '../components/YamlEditor.js';
+import { ConfirmDialog } from '../components/ConfirmDialog.js';
 import { NoClustersState } from '../components/NoClustersState.js';
+import { showToast } from '../state/toast.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { usePaneActive } from '../layout/pane-context.js';
 import { addLabelTerm } from '../label-selector.js';
@@ -281,6 +285,35 @@ export function ResourceListPage() {
   const create = useCreateResource();
   const dryRun = useDryRunResource();
   const addSavedView = useNavigationStore((s) => s.addSavedView);
+  const del = useDeleteResource();
+  const rolloutRestart = useRolloutRestart();
+  const [bulkDialog, setBulkDialog] = useState<'delete' | 'restart' | null>(null);
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const contextSettings = useClustersStore((s) => s.contextSettings);
+  const protectByDefault = useUiPrefsStore((s) => s.protectByDefault);
+  // This page instance is reused across kinds — a selection must not survive
+  // the switch to a different resource list.
+  useEffect(() => setSelectedRows([]), [group, version, plural]);
+
+  const bulkRestartable = kind === 'Deployment' || kind === 'StatefulSet' || kind === 'DaemonSet';
+  const bulkProtected = selectedRows.some((r) => contextSettings[r.ctx]?.protected ?? protectByDefault);
+  const runBulk = async (verb: string, run: (row: ClusterRow) => Promise<unknown>) => {
+    const rows = selectedRows;
+    setBulkBusy(true);
+    const results = await Promise.allSettled(rows.map((row) => run(row)));
+    setBulkBusy(false);
+    setBulkDialog(null);
+    const failures = results
+      .map((result, i) => ({ result, row: rows[i]! }))
+      .filter((f): f is { result: PromiseRejectedResult; row: ClusterRow } => f.result.status === 'rejected');
+    if (!failures.length) {
+      showToast('success', `${verb} ${rows.length} ${rows.length === 1 ? kind : resourceTitle}`);
+    } else {
+      const first = failures[0]!;
+      const message = first.result.reason instanceof Error ? first.result.reason.message : String(first.result.reason);
+      showToast('error', `${verb} failed for ${failures.length} of ${rows.length} — ${first.row.obj.metadata.name}: ${message}`);
+    }
+  };
 
   // Detail selection deep-linked via ?sel=ctx|namespace|name
   const sel: ResourceSelection | undefined = useMemo(() => {
@@ -535,8 +568,8 @@ export function ResourceListPage() {
           setContextAction({ target: rowActionTarget(row), mouseX: event.clientX + 2, mouseY: event.clientY - 6 });
           setContextMenuOpen(true);
         }}
-        checkboxSelection={kind === 'Pod'}
-        onSelectionChange={kind === 'Pod' ? setSelectedRows : undefined}
+        checkboxSelection
+        onSelectionChange={setSelectedRows}
         hiddenFields={hiddenFields}
         activeRowId={activeRowId}
         toolbar={
@@ -573,10 +606,62 @@ export function ResourceListPage() {
                 Logs ({selectedRows.length})
               </Button>
             )}
+            {selectedRows.length > 0 && bulkRestartable && (
+              <Button startIcon={<RestartAltIcon />} variant="outlined" onClick={() => setBulkDialog('restart')}>
+                Restart ({selectedRows.length})
+              </Button>
+            )}
+            {selectedRows.length > 0 && (
+              <Button startIcon={<DeleteOutlineIcon />} color="error" variant="outlined" onClick={() => setBulkDialog('delete')}>
+                Delete ({selectedRows.length})
+              </Button>
+            )}
             <Button startIcon={<AddIcon />} variant="outlined" onClick={() => setCreateOpen(true)}>
               Create
             </Button>
           </>
+        }
+      />
+      <ConfirmDialog
+        open={bulkDialog === 'delete'}
+        title={`Delete ${selectedRows.length} ${selectedRows.length === 1 ? kind : resourceTitle}`}
+        message={
+          <>
+            Delete the selected {selectedRows.length === 1 ? kind : `${selectedRows.length} ${resourceTitle}`}? This cannot be undone.
+            <BulkTargetList rows={selectedRows} />
+          </>
+        }
+        confirmLabel="Delete"
+        danger
+        busy={bulkBusy}
+        confirmText={bulkProtected ? `delete ${selectedRows.length}` : undefined}
+        onClose={() => setBulkDialog(null)}
+        onConfirm={() =>
+          void runBulk('Deleted', (row) =>
+            del.mutateAsync({ ctx: row.ctx, group, version, plural, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace }),
+          )
+        }
+      />
+      <ConfirmDialog
+        open={bulkDialog === 'restart'}
+        title={`Restart ${selectedRows.length} ${selectedRows.length === 1 ? kind : resourceTitle}`}
+        message={
+          <>
+            Trigger a rolling restart of the selected {selectedRows.length === 1 ? kind : `${selectedRows.length} ${resourceTitle}`}?
+            <BulkTargetList rows={selectedRows} />
+          </>
+        }
+        confirmLabel="Restart"
+        busy={bulkBusy}
+        confirmText={bulkProtected ? `restart ${selectedRows.length}` : undefined}
+        onClose={() => setBulkDialog(null)}
+        onConfirm={() =>
+          void runBulk('Restarted', (row) =>
+            rolloutRestart.mutateAsync({
+              ctx: row.ctx,
+              body: { kind: kind as 'Deployment', namespace: row.obj.metadata.namespace ?? '', name: row.obj.metadata.name },
+            }),
+          )
         }
       />
       {contextAction && (
@@ -619,6 +704,23 @@ export function ResourceListPage() {
       </Dialog>
       </Box>
       <EmbeddedResourceDetail />
+    </Box>
+  );
+}
+
+/** Compact cluster/namespace/name listing shown in bulk-action confirms. */
+function BulkTargetList({ rows }: { rows: ClusterRow[] }) {
+  const shown = rows.slice(0, 8);
+  const more = rows.length - shown.length;
+  return (
+    <Box component="ul" sx={{ my: 1, pl: 2.5, fontFamily: 'monospace', fontSize: 12 }}>
+      {shown.map((row) => (
+        <li key={row.obj.metadata.uid}>
+          {row.ctx}: {row.obj.metadata.namespace ? `${row.obj.metadata.namespace}/` : ''}
+          {row.obj.metadata.name}
+        </li>
+      ))}
+      {more > 0 && <li>… and {more} more</li>}
     </Box>
   );
 }

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -35,6 +35,7 @@ import { NoClustersState } from '../components/NoClustersState.js';
 import { showToast } from '../state/toast.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { usePaneActive } from '../layout/pane-context.js';
+import { isTextEntryTarget } from '../text-entry.js';
 import { addLabelTerm } from '../label-selector.js';
 
 /**
@@ -97,8 +98,14 @@ function EmbeddedResourceDetail() {
   const setCollapsed = useDetailStore((s) => s.setCollapsed);
   const width = useDetailStore((s) => s.width);
   const setWidth = useDetailStore((s) => s.setWidth);
+  const focusSeq = useDetailStore((s) => s.focusSeq);
   const [searchParams, setSearchParams] = useSearchParams();
   const asideRef = useRef<HTMLElement>(null);
+
+  // Keyboard row activation asks for focus here; Escape hands it back.
+  useEffect(() => {
+    if (focusSeq && paneActive) asideRef.current?.focus({ preventScroll: true });
+  }, [focusSeq, paneActive]);
 
   // Drag writes the width straight to the DOM; once the mouseup commit
   // re-renders with the same value, drop the inline override so sx takes
@@ -158,6 +165,16 @@ function EmbeddedResourceDetail() {
         component="aside"
         ref={asideRef}
         aria-label="Resource details"
+        tabIndex={-1}
+        onKeyDown={(e) => {
+          // Escape closes the panel and hands focus back to the grid — but
+          // never while typing (inputs, Monaco), where Escape has meaning.
+          if (e.key !== 'Escape' || isTextEntryTarget(e.target)) return;
+          e.stopPropagation();
+          const page = asideRef.current?.closest('.kubus-resource-page');
+          handleClose();
+          page?.querySelector<HTMLElement>('.MuiDataGrid-cell[tabindex="0"], .MuiDataGrid-columnHeader[tabindex="0"]')?.focus();
+        }}
         sx={{
           position: 'relative',
           flexShrink: 0,
@@ -168,6 +185,7 @@ function EmbeddedResourceDetail() {
           bgcolor: 'background.paper',
           borderLeft: 1,
           borderColor: 'divider',
+          outline: 'none',
         }}
       >
         {!collapsed && (
@@ -366,6 +384,7 @@ export function ResourceListPage() {
   const pushDetail = useDetailStore((s) => s.push);
   const openDetail = useDetailStore((s) => s.open);
   const setDetailCollapsed = useDetailStore((s) => s.setCollapsed);
+  const requestDetailFocus = useDetailStore((s) => s.requestFocus);
   const crdSelection: ResourceSelection | undefined =
     isCustomKind && resourceCtx && group
       ? {
@@ -478,6 +497,18 @@ export function ResourceListPage() {
   const multiLogs = kind === 'Pod' && selectedRows.length > 0;
   const kindPath = `/r/${groupToPath(group)}/${version}/${plural}`;
 
+  const openRow = (row: ClusterRow) => {
+    // Update immediately so the embedded panel responds in the same render
+    // cycle; the URL remains the deep-link source of truth. Picking a row is
+    // an explicit ask for details, so also undo a collapse.
+    openDetail({ ctx: row.ctx, group, version, plural, kind, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace, custom: isCustomKind });
+    setDetailCollapsed(false);
+    const next = new URLSearchParams(searchParams);
+    next.delete('field');
+    next.set('sel', `${row.ctx}|${row.obj.metadata.namespace ?? ''}|${row.obj.metadata.name}`);
+    setSearchParams(next);
+  };
+
   const saveCurrentView = () => {
     const params = new URLSearchParams();
     if (textFilter.trim()) params.set('q', textFilter.trim());
@@ -502,7 +533,7 @@ export function ResourceListPage() {
   };
 
   return (
-    <Box sx={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
+    <Box className="kubus-resource-page" sx={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
       <DetailUrlSync sel={sel} />
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, minHeight: 0 }}>
       <Box sx={{ px: 1.5, pt: 1.5 }}>
@@ -553,20 +584,15 @@ export function ResourceListPage() {
         labelSelector={labelSelector}
         onFilterChange={(value) => setQueryParam('q', value)}
         onLabelSelectorChange={(value) => setQueryParam('label', value)}
-        onRowClick={(row) => {
-          // Update immediately so the embedded panel responds in the same
-          // render cycle; the URL remains the deep-link source of truth.
-          // Picking a row is an explicit ask for details, so also undo a
-          // collapse.
-          openDetail({ ctx: row.ctx, group, version, plural, kind, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace, custom: isCustomKind });
-          setDetailCollapsed(false);
-          const next = new URLSearchParams(searchParams);
-          next.delete('field');
-          next.set('sel', `${row.ctx}|${row.obj.metadata.namespace ?? ''}|${row.obj.metadata.name}`);
-          setSearchParams(next);
+        onRowClick={openRow}
+        onRowActivate={(row) => {
+          // Keyboard activation also moves focus into the panel; Escape there
+          // returns it to the grid.
+          openRow(row);
+          requestDetailFocus();
         }}
-        onRowContextMenu={(row, event) => {
-          setContextAction({ target: rowActionTarget(row), mouseX: event.clientX + 2, mouseY: event.clientY - 6 });
+        onRowContextMenu={(row, position) => {
+          setContextAction({ target: rowActionTarget(row), mouseX: position.clientX + 2, mouseY: position.clientY - 6 });
           setContextMenuOpen(true);
         }}
         checkboxSelection

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -1,4 +1,5 @@
 import { Activity, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { layout } from '../theme.js';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -183,7 +184,7 @@ function EmbeddedResourceDetail() {
               bottom: 0,
               width: 8,
               cursor: 'col-resize',
-              zIndex: 71,
+              zIndex: layout.zDetailResizeHandle,
               '&:hover .drag-line, &:active .drag-line': { opacity: 1 },
             }}
           >
@@ -213,7 +214,7 @@ function EmbeddedResourceDetail() {
               left: collapsed ? 'auto' : 0,
               right: collapsed ? 0 : 'auto',
               transform: collapsed ? 'translateY(-50%)' : 'translate(-50%, -50%)',
-              zIndex: 72,
+              zIndex: layout.zDetailCollapseButton,
               width: 20,
               height: 52,
               borderRadius: '10px',

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -81,6 +81,26 @@ function DetailUrlSync({ sel }: { sel: ResourceSelection | undefined }) {
 }
 
 /**
+ * Renderless `c` shortcut: create a resource on the visible list page. Kept
+ * out of ResourceListPage so pane-activation flips re-render this stub only.
+ */
+function CreateShortcut({ onCreate }: { onCreate: () => void }) {
+  const paneActive = usePaneActive();
+  useEffect(() => {
+    if (!paneActive) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.defaultPrevented || e.key.toLowerCase() !== 'c' || e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      if (isTextEntryTarget(e.target)) return;
+      e.preventDefault();
+      onCreate();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [paneActive, onCreate]);
+  return null;
+}
+
+/**
  * Side-by-side detail view. Unlike the global overlay drawer it never blocks
  * the table (other rows stay clickable) and only closes explicitly — but it
  * also only takes space while a resource is selected. The divider drags to
@@ -304,6 +324,7 @@ export function ResourceListPage() {
   const nodeAllocation = useMemo(() => (behaviorKind === 'Node' ? makeNodeAllocationLookup(auxPods.rows) : undefined), [behaviorKind, auxPods.rows]);
 
   const [createOpen, setCreateOpen] = useState(false);
+  const openCreate = useCallback(() => setCreateOpen(true), []);
   const [apiResourceOpen, setApiResourceOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<ClusterRow[]>([]);
   const [contextAction, setContextAction] = useState<{ target: RowActionTarget; mouseX: number; mouseY: number } | null>(null);
@@ -543,6 +564,7 @@ export function ResourceListPage() {
   return (
     <Box className="kubus-resource-page" sx={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
       <DetailUrlSync sel={sel} />
+      <CreateShortcut onCreate={openCreate} />
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0, minHeight: 0 }}>
       <Box sx={{ px: 1.5, pt: 1.5 }}>
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -1,0 +1,351 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import { MOD_KEY_LABEL } from './platform.js';
+import { isEditorOrTerminalTarget, isTextEntryTarget } from './text-entry.js';
+import { NAV_OVERLAY_MEDIA_QUERY, useNavUiStore } from './state/nav-ui.js';
+import { useUiPrefsStore } from './state/prefs.js';
+import { useUiStore } from './state/ui.js';
+import { useTabsStore } from './state/tabs.js';
+import { useDockStore } from './state/dock.js';
+import { useDetailStore } from './state/detail.js';
+
+/** How long a pending `g` waits for its second key (the which-key panel shows meanwhile). */
+export const GO_TIMEOUT_MS = 3000;
+
+/** `g` sequences: press g, then one of these keys, to jump to a page. */
+export const GO_TARGETS: Array<{ key: string; path: string; label: string }> = [
+  { key: 'o', path: '/', label: 'Overview' },
+  { key: 'p', path: '/r/core/v1/pods', label: 'Pods' },
+  { key: 'd', path: '/r/apps/v1/deployments', label: 'Deployments' },
+  { key: 's', path: '/r/core/v1/services', label: 'Services' },
+  { key: 'n', path: '/r/core/v1/nodes', label: 'Nodes' },
+  { key: 'i', path: '/r/networking.k8s.io/v1/ingresses', label: 'Ingresses' },
+  { key: 'c', path: '/r/core/v1/configmaps', label: 'ConfigMaps' },
+  { key: 'k', path: '/r/core/v1/secrets', label: 'Secrets' },
+  { key: 'e', path: '/events', label: 'Events' },
+  { key: 'h', path: '/helm', label: 'Helm releases' },
+  { key: 't', path: '/topology', label: 'Topology' },
+  { key: 'm', path: '/metrics', label: 'Metrics' },
+  { key: 'w', path: '/network', label: 'Network' },
+  { key: 'f', path: '/forwards', label: 'Port forwards' },
+  { key: 'a', path: '/audit', label: 'Audit' },
+];
+
+/** Wide viewports toggle the pinned rail; narrow ones the overlay drawer. */
+export function toggleNavRail(): void {
+  if (window.matchMedia(NAV_OVERLAY_MEDIA_QUERY).matches) {
+    const nav = useNavUiStore.getState();
+    nav.setOverlayOpen(!nav.overlayOpen);
+  } else {
+    const prefs = useUiPrefsStore.getState();
+    prefs.set({ navCollapsed: !prefs.navCollapsed });
+  }
+}
+
+export interface ShortcutRowDef {
+  /** Alternative key combos, each an array of keys pressed together. */
+  combos: string[][];
+  description: string;
+  /** The combo's keys are pressed one after another (rendered "G then P"), not as a chord. */
+  sequence?: boolean;
+  /** Shown only in the desktop app (the chord needs the Electron main process). */
+  desktopOnly?: boolean;
+  /** Shown only in the browser (the desktop app has a native equivalent). */
+  webOnly?: boolean;
+}
+
+const MOD = MOD_KEY_LABEL;
+
+/** Single source of truth for the cheatsheet — every binding below is wired here or next to its owner. */
+export const SHORTCUT_SECTIONS: Array<{ title: string; shortcuts: ShortcutRowDef[] }> = [
+  {
+    title: 'Global',
+    shortcuts: [
+      { combos: [[MOD, 'K']], description: 'Command palette (toggle)' },
+      { combos: [['?']], description: 'Keyboard shortcuts (this dialog)' },
+      { combos: [[MOD, 'B']], description: 'Toggle the navigation rail' },
+      { combos: [[MOD, 'J']], description: 'Toggle the terminal / logs dock' },
+      { combos: [[MOD, ',']], description: 'Open settings' },
+      { combos: [[MOD, '1–9']], description: 'Open pinned favorite 1–9' },
+      { combos: [['Esc']], description: 'Close dialogs & menus · close the details panel · restore a maximized dock' },
+    ],
+  },
+  {
+    title: 'Tabs',
+    shortcuts: [
+      { combos: [['Alt', 'T']], description: 'New tab' },
+      { combos: [['Alt', 'W']], description: 'Close the focused dock or page tab' },
+      { combos: [[MOD, 'W']], description: 'Close the focused dock or page tab', desktopOnly: true },
+      { combos: [['Alt', 'Shift', 'T']], description: 'Reopen the last closed tab' },
+      { combos: [['Alt', '1–9']], description: 'Switch to tab 1–9 (9 = last tab)' },
+      { combos: [['Alt', 'PgUp'], ['Alt', 'PgDn']], description: 'Previous / next tab' },
+      { combos: [['Ctrl', 'Tab'], ['Ctrl', 'Shift', 'Tab']], description: 'Next / previous tab', desktopOnly: true },
+      { combos: [['←'], ['→'], ['Home'], ['End']], description: 'Move focus on the tab strip' },
+      { combos: [['Enter'], ['Delete']], description: 'Activate / close the focused tab' },
+      { combos: [[MOD, 'Click'], ['Middle-click']], description: 'Open a link in a background tab' },
+      { combos: [['Middle-click']], description: 'Close a tab (on the tab strip)' },
+    ],
+  },
+  {
+    title: 'Go to',
+    shortcuts: GO_TARGETS.map((t) => ({ combos: [['G', t.key.toUpperCase()]], sequence: true, description: t.label })),
+  },
+  {
+    title: 'Command palette',
+    shortcuts: [
+      { combos: [['↑'], ['↓']], description: 'Move selection' },
+      { combos: [['PgUp'], ['PgDn']], description: 'Move selection a page at a time' },
+      { combos: [['Enter']], description: 'Open the selected result' },
+      { combos: [[MOD, 'Enter']], description: 'Open in a new tab' },
+      { combos: [['Shift', 'Enter']], description: 'Open in a background tab' },
+      { combos: [['Tab'], ['→']], description: 'Show actions for the selected resource' },
+      { combos: [['Esc'], ['Backspace'], ['←']], description: 'Leave the actions list' },
+    ],
+  },
+  {
+    title: 'Resource lists',
+    shortcuts: [
+      { combos: [['S'], ['/'], [':']], description: 'Focus the filter input' },
+      { combos: [[MOD, 'F']], description: 'Focus the filter input' },
+      { combos: [['C']], description: 'Create a resource' },
+      { combos: [[MOD, 'C']], description: 'Copy the focused cell' },
+      { combos: [['Enter']], description: 'Open details for the focused row' },
+      { combos: [['Right-click'], ['Shift', 'F10']], description: 'Open the row actions menu' },
+      { combos: [['Esc']], description: 'In the filter: clear, then leave · elsewhere: close the details panel' },
+    ],
+  },
+  {
+    title: 'Details panel',
+    shortcuts: [
+      { combos: [['Esc']], description: 'Close the panel (focus returns to the list)' },
+      { combos: [['Alt', '←']], description: 'Back to the previous resource in the panel' },
+    ],
+  },
+  {
+    title: 'Logs',
+    shortcuts: [
+      { combos: [[MOD, 'F']], description: 'Focus find' },
+      { combos: [['Enter'], ['Shift', 'Enter']], description: 'Next / previous match' },
+      { combos: [['Esc']], description: 'Clear find / filter, then leave it' },
+    ],
+  },
+];
+
+/**
+ * The app-wide keyboard owner, mounted once in AppShell. Two window listeners:
+ *
+ * - capture phase: chords (mod-key, Alt tab chords) and `g` go-to sequences.
+ *   Capture lets them win over page-level listeners, which all check
+ *   `defaultPrevented`.
+ * - bubble phase: the Escape dismiss chain. Bubble so focused surfaces
+ *   (dialogs, menus, the palette's action stage, the details panel, editors,
+ *   terminals) always get first refusal — MUI modals stop propagation, text
+ *   surfaces are guarded explicitly.
+ *
+ * Also owns the desktop (Electron) tab chords: Cmd/Ctrl+W close and
+ * Ctrl+Tab cycling arrive over IPC and reuse the same tab helpers.
+ */
+export function GlobalShortcuts() {
+  const navigate = useNavigate();
+  const navRef = useRef(navigate);
+  navRef.current = navigate;
+
+  useEffect(() => {
+    // After any tab-store mutation, land the router on the (new) active tab —
+    // the same store→router sync TabsBar does for its mouse interactions.
+    // Compare against window.location, not useLocation: navigate() is
+    // transition-wrapped, so React's location lags — a second chord arriving
+    // mid-transition would otherwise see the stale URL and skip navigating.
+    const landOnActiveTab = () => {
+      const s = useTabsStore.getState();
+      const active = s.tabs.find((t) => t.id === s.activeId);
+      if (active && active.path !== window.location.pathname + window.location.search) void navRef.current(active.path);
+    };
+
+    const cycleTab = (delta: number) => {
+      const s = useTabsStore.getState();
+      if (s.tabs.length < 2) return;
+      const idx = Math.max(0, s.tabs.findIndex((t) => t.id === s.activeId));
+      s.setActive(s.tabs[(idx + delta + s.tabs.length) % s.tabs.length]!.id);
+      landOnActiveTab();
+    };
+
+    const activateTab = (digit: number) => {
+      const s = useTabsStore.getState();
+      const tab = digit === 9 ? s.tabs.at(-1) : s.tabs[digit - 1];
+      if (!tab) return;
+      s.setActive(tab.id);
+      landOnActiveTab();
+    };
+
+    const reopenTab = () => {
+      const before = useTabsStore.getState().activeId;
+      useTabsStore.getState().reopenTab();
+      if (useTabsStore.getState().activeId !== before) landOnActiveTab();
+    };
+
+    // Same semantics as the desktop Cmd/Ctrl+W chord: a dock tab first, then
+    // the active page tab — but never the last remaining page tab.
+    const closeActiveTab = () => {
+      const dock = useDockStore.getState();
+      if (dock.open && dock.activeId) {
+        dock.closeTab(dock.activeId);
+        return;
+      }
+      const pages = useTabsStore.getState();
+      if (pages.tabs.length > 1 && pages.activeId) {
+        pages.closeTab(pages.activeId);
+        landOnActiveTab();
+      }
+    };
+
+    const onCapture = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      const mod = e.metaKey || e.ctrlKey;
+      const key = e.key.toLowerCase();
+
+      if (mod && !e.altKey && !e.shiftKey) {
+        if (key === 'k') {
+          e.preventDefault();
+          const ui = useUiStore.getState();
+          ui.setSearchOpen(!ui.searchOpen);
+          return;
+        }
+        if (key === 'b') {
+          e.preventDefault();
+          toggleNavRail();
+          return;
+        }
+        // Guarded: in a shell Ctrl+J is a real control character (linefeed).
+        if (key === 'j' && !isTextEntryTarget(e.target)) {
+          e.preventDefault();
+          const dock = useDockStore.getState();
+          if (dock.tabs.length) dock.setOpen(!dock.open);
+          return;
+        }
+        if (e.key === ',' && !isTextEntryTarget(e.target)) {
+          e.preventDefault();
+          useUiStore.getState().setSettingsOpen(true);
+        }
+        return;
+      }
+
+      // Alt is the tab namespace. Never with Ctrl/Meta (AltGr reports
+      // ctrl+alt on Windows), and never while a terminal/editor owns Alt
+      // sequences (Alt+digit is an escape sequence in shells).
+      if (e.altKey && !e.ctrlKey && !e.metaKey && !isEditorOrTerminalTarget(e.target)) {
+        const digit = e.shiftKey ? undefined : /^Digit([1-9])$/.exec(e.code)?.[1];
+        if (digit) {
+          e.preventDefault();
+          activateTab(Number(digit));
+          return;
+        }
+        if (!e.shiftKey && e.code === 'PageDown') {
+          e.preventDefault();
+          cycleTab(1);
+          return;
+        }
+        if (!e.shiftKey && e.code === 'PageUp') {
+          e.preventDefault();
+          cycleTab(-1);
+          return;
+        }
+        if (e.code === 'KeyT') {
+          e.preventDefault();
+          if (e.shiftKey) {
+            reopenTab();
+          } else {
+            useTabsStore.getState().openTab('/');
+            landOnActiveTab();
+          }
+          return;
+        }
+        if (!e.shiftKey && e.code === 'KeyW') {
+          e.preventDefault();
+          closeActiveTab();
+        }
+        return;
+      }
+
+      if (mod || e.altKey) return;
+
+      if (isTextEntryTarget(e.target)) return;
+
+      // `g` go-to sequences (pending state lives in the ui store so the
+      // which-key panel can render it). An unmatched second key cancels and
+      // falls through to whoever else wants it (e.g. `?` or `s`).
+      const ui = useUiStore.getState();
+      if (ui.goPendingSince && Date.now() - ui.goPendingSince < GO_TIMEOUT_MS) {
+        ui.clearGoPending();
+        const target = e.shiftKey ? undefined : GO_TARGETS.find((t) => t.key === key);
+        if (target) {
+          e.preventDefault();
+          e.stopPropagation();
+          void navRef.current(target.path);
+          return;
+        }
+      }
+
+      if (e.key === '?') {
+        e.preventDefault();
+        useUiStore.getState().setShortcutsOpen(true);
+        return;
+      }
+
+      if (key === 'g' && !e.shiftKey) useUiStore.getState().startGoPending();
+    };
+
+    const onBubble = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      useUiStore.getState().clearGoPending();
+      if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      // Inputs, dialogs, menus, editors, and terminals own their Escape.
+      if (isTextEntryTarget(e.target)) return;
+
+      // Dismiss chain, topmost surface first.
+      const navUi = useNavUiStore.getState();
+      if (navUi.overlayOpen) {
+        navUi.setOverlayOpen(false);
+        return;
+      }
+      const dock = useDockStore.getState();
+      if (dock.maximized) {
+        dock.setMaximized(false);
+        return;
+      }
+      const detail = useDetailStore.getState();
+      if (detail.stack.length) {
+        detail.close();
+        // Drop the ?sel deep link so the tab doesn't reopen the selection.
+        const { pathname, search } = window.location;
+        const params = new URLSearchParams(search);
+        if (params.has('sel')) {
+          params.delete('sel');
+          void navRef.current({ pathname, search: params.toString() }, { replace: true });
+        }
+        // Hand focus to the visible list's grid so arrow keys keep working.
+        requestAnimationFrame(() => {
+          const page = [...document.querySelectorAll<HTMLElement>('.kubus-resource-page')].find((el) => !el.closest('[aria-hidden="true"]'));
+          const cell =
+            page?.querySelector<HTMLElement>('.MuiDataGrid-cell[tabindex="0"], .MuiDataGrid-columnHeader[tabindex="0"]') ??
+            page?.querySelector<HTMLElement>('.MuiDataGrid-cell');
+          cell?.focus();
+        });
+      }
+    };
+
+    window.addEventListener('keydown', onCapture, true);
+    window.addEventListener('keydown', onBubble);
+    const desktop = window.kubusDesktop;
+    const offClose = desktop?.onCloseTab?.(closeActiveTab);
+    const offCycle = desktop?.onCycleTab?.((backwards) => cycleTab(backwards ? -1 : 1));
+    return () => {
+      window.removeEventListener('keydown', onCapture, true);
+      window.removeEventListener('keydown', onBubble);
+      offClose?.();
+      offCycle?.();
+    };
+  }, []);
+
+  return null;
+}

--- a/client/src/state/backend.ts
+++ b/client/src/state/backend.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+interface BackendState {
+  /** The local Kubus server did not answer a fetch at all. */
+  unreachable: boolean;
+  /** The server answered 401 — the session token is no longer valid. */
+  authInvalid: boolean;
+}
+
+export const useBackendStore = create<BackendState>()(() => ({
+  unreachable: false,
+  authInvalid: false,
+}));
+
+export function reportBackendDown(): void {
+  if (!useBackendStore.getState().unreachable) useBackendStore.setState({ unreachable: true });
+}
+
+export function reportBackendUp(): void {
+  if (useBackendStore.getState().unreachable) useBackendStore.setState({ unreachable: false });
+}
+
+export function reportAuthInvalid(): void {
+  if (!useBackendStore.getState().authInvalid) useBackendStore.setState({ authInvalid: true });
+}

--- a/client/src/state/clusters.ts
+++ b/client/src/state/clusters.ts
@@ -68,3 +68,12 @@ export function useIsProtected(ctx: string): boolean {
   const protectByDefault = useUiPrefsStore((s) => s.protectByDefault);
   return explicit ?? protectByDefault;
 }
+
+/**
+ * The one definition of what the global namespace filter means: an empty
+ * selection shows everything, and cluster-scoped items (no namespace)
+ * are always visible.
+ */
+export function namespaceVisible(namespace: string | undefined, selected: string[]): boolean {
+  return selected.length === 0 || !namespace || selected.includes(namespace);
+}

--- a/client/src/state/detail.ts
+++ b/client/src/state/detail.ts
@@ -12,12 +12,15 @@ interface DetailState {
   collapsed: boolean;
   /** Embedded panel width in px; user-resizable via the divider. */
   width: number;
+  /** Bumped when keyboard flows want focus moved into the panel. */
+  focusSeq: number;
   open: (sel: ResourceSelection) => void;
   push: (sel: ResourceSelection) => void;
   back: () => void;
   close: () => void;
   setCollapsed: (collapsed: boolean) => void;
   setWidth: (width: number) => void;
+  requestFocus: () => void;
 }
 
 export const DEFAULT_DETAIL_WIDTH = 640;
@@ -30,6 +33,7 @@ export const useDetailStore = create<DetailState>((set) => ({
   stack: [],
   collapsed: false,
   width: DEFAULT_DETAIL_WIDTH,
+  focusSeq: 0,
   open: (sel) => set({ stack: [sel] }),
   // Pushes can come from outside the panel (e.g. the API-resource drawer's
   // CRD link), so surface the result even if the panel was collapsed.
@@ -40,4 +44,5 @@ export const useDetailStore = create<DetailState>((set) => ({
   close: () => set((s) => (s.stack.length ? { stack: [] } : s)),
   setCollapsed: (collapsed) => set({ collapsed }),
   setWidth: (width) => set({ width: clampDetailWidth(width) }),
+  requestFocus: () => set((s) => ({ focusSeq: s.focusSeq + 1, collapsed: false })),
 }));

--- a/client/src/state/nav-ui.ts
+++ b/client/src/state/nav-ui.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+
+/** Transient nav-overlay state (narrow viewports); deliberately not persisted. */
+export const useNavUiStore = create<{ overlayOpen: boolean; setOverlayOpen: (open: boolean) => void }>()((set) => ({
+  overlayOpen: false,
+  setOverlayOpen: (overlayOpen) => set({ overlayOpen }),
+}));
+
+/** Below this width the pinned nav rail becomes an on-demand overlay. */
+export const NAV_OVERLAY_MEDIA_QUERY = '(max-width: 900px)';

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -33,7 +33,7 @@ interface UiPrefsState {
   setColumnWidth: (tableId: string, field: string, width: number) => void;
   setColumnVisibility: (tableId: string, model: Record<string, boolean>) => void;
   setSortModel: (tableId: string, model: TableSortModel) => void;
-  /** Bulk-apply a saved view's grid snapshot; absent parts are left untouched. */
+  /** Replace a table with a saved snapshot; absent parts restore implicit defaults. */
   applyTableState: (
     tableId: string,
     state: { columnWidths?: Record<string, number>; columnVisibility?: Record<string, boolean>; sort?: TableSortModel },
@@ -41,6 +41,13 @@ interface UiPrefsState {
 }
 
 export type TableSortModel = ReadonlyArray<{ field: string; sort: 'asc' | 'desc' | null | undefined }>;
+
+function replaceTableValue<T>(values: Record<string, T>, tableId: string, value: T | undefined): Record<string, T> {
+  const next = { ...values };
+  if (value === undefined) delete next[tableId];
+  else next[tableId] = value;
+  return next;
+}
 
 export const useUiPrefsStore = create<UiPrefsState>()(
   persist(
@@ -70,9 +77,9 @@ export const useUiPrefsStore = create<UiPrefsState>()(
         })),
       applyTableState: (tableId, state) =>
         set((s) => ({
-          columnWidths: state.columnWidths ? { ...s.columnWidths, [tableId]: state.columnWidths } : s.columnWidths,
-          columnVisibility: state.columnVisibility ? { ...s.columnVisibility, [tableId]: state.columnVisibility } : s.columnVisibility,
-          sortModels: state.sort ? { ...s.sortModels, [tableId]: state.sort } : s.sortModels,
+          columnWidths: replaceTableValue(s.columnWidths, tableId, state.columnWidths),
+          columnVisibility: replaceTableValue(s.columnVisibility, tableId, state.columnVisibility),
+          sortModels: replaceTableValue(s.sortModels, tableId, state.sort),
         })),
     }),
     { name: 'kubus-prefs', version: 0, storage: createJSONStorage(() => kubusStateStorage) },

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -25,10 +25,20 @@ interface UiPrefsState {
   columnWidths: Record<string, Record<string, number>>;
   /** User-toggled column visibility models, keyed by table id then column field. */
   columnVisibility: Record<string, Record<string, boolean>>;
+  /** User-chosen sort, keyed by table id. */
+  sortModels: Record<string, TableSortModel>;
   set: (patch: Partial<Omit<UiPrefsState, 'set'>>) => void;
   setColumnWidth: (tableId: string, field: string, width: number) => void;
   setColumnVisibility: (tableId: string, model: Record<string, boolean>) => void;
+  setSortModel: (tableId: string, model: TableSortModel) => void;
+  /** Bulk-apply a saved view's grid snapshot; absent parts are left untouched. */
+  applyTableState: (
+    tableId: string,
+    state: { columnWidths?: Record<string, number>; columnVisibility?: Record<string, boolean>; sort?: TableSortModel },
+  ) => void;
 }
+
+export type TableSortModel = ReadonlyArray<{ field: string; sort: 'asc' | 'desc' | null | undefined }>;
 
 export const useUiPrefsStore = create<UiPrefsState>()(
   persist(
@@ -41,6 +51,7 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       protectByDefault: false,
       columnWidths: {},
       columnVisibility: {},
+      sortModels: {},
       set: (patch) => set(patch),
       setColumnWidth: (tableId, field, width) =>
         set((state) => ({
@@ -49,6 +60,16 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       setColumnVisibility: (tableId, model) =>
         set((state) => ({
           columnVisibility: { ...state.columnVisibility, [tableId]: model },
+        })),
+      setSortModel: (tableId, model) =>
+        set((state) => ({
+          sortModels: { ...state.sortModels, [tableId]: model },
+        })),
+      applyTableState: (tableId, state) =>
+        set((s) => ({
+          columnWidths: state.columnWidths ? { ...s.columnWidths, [tableId]: state.columnWidths } : s.columnWidths,
+          columnVisibility: state.columnVisibility ? { ...s.columnVisibility, [tableId]: state.columnVisibility } : s.columnVisibility,
+          sortModels: state.sort ? { ...s.sortModels, [tableId]: state.sort } : s.sortModels,
         })),
     }),
     { name: 'kubus-prefs', version: 0, storage: createJSONStorage(() => kubusStateStorage) },

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -21,6 +21,8 @@ interface UiPrefsState {
   defaultShell: string;
   /** Treat contexts without an explicit protected flag as protected. */
   protectByDefault: boolean;
+  /** Nav rail collapsed to reclaim width (wide viewports only). */
+  navCollapsed: boolean;
   /** User-resized column widths, keyed by table id then column field. */
   columnWidths: Record<string, Record<string, number>>;
   /** User-toggled column visibility models, keyed by table id then column field. */
@@ -49,6 +51,7 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       defaultTailLines: 500,
       defaultShell: 'auto',
       protectByDefault: false,
+      navCollapsed: false,
       columnWidths: {},
       columnVisibility: {},
       sortModels: {},

--- a/client/src/state/saved-view.ts
+++ b/client/src/state/saved-view.ts
@@ -1,0 +1,10 @@
+import type { SavedViewGridState } from '@kubus/shared';
+import { useClustersStore } from './clusters.js';
+import { useUiPrefsStore } from './prefs.js';
+
+/** Apply one saved-view snapshot as a complete grid state, including defaults. */
+export function applySavedViewGridState(path: string, grid: SavedViewGridState): void {
+  useClustersStore.getState().setNamespaces(grid.namespaces ?? []);
+  const tableId = path.split('?')[0] || path;
+  useUiPrefsStore.getState().applyTableState(tableId, grid);
+}

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -1,12 +1,15 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import type { StateStorage } from 'zustand/middleware';
+import type { SavedViewGridState } from '@kubus/shared';
 import { kubusStateStorage } from './persist-storage.js';
 
 export interface PageTab {
   id: string;
   /** In-app location the tab shows: pathname + search (e.g. '/r/core/v1/pods?q=web'). */
   path: string;
+  /** Saved-view state waiting to be applied the first time this tab is activated. */
+  pendingSavedView?: SavedViewGridState;
 }
 
 interface TabsState {
@@ -14,7 +17,8 @@ interface TabsState {
   activeId?: string;
   /** Paths of recently closed tabs, oldest first; feeds "reopen closed tab". */
   closedPaths: string[];
-  openTab: (path: string, opts?: { activate?: boolean; afterActive?: boolean }) => void;
+  openTab: (path: string, opts?: { activate?: boolean; afterActive?: boolean; pendingSavedView?: SavedViewGridState }) => void;
+  clearPendingSavedView: (id: string) => void;
   closeTab: (id: string) => void;
   closeOthers: (id: string) => void;
   closeRight: (id: string) => void;
@@ -62,8 +66,8 @@ function debouncedStorage(base: StateStorage, ms: number): StateStorage {
   };
 }
 
-function freshTab(path: string): PageTab {
-  return { id: pageTabId(), path };
+function freshTab(path: string, pendingSavedView?: SavedViewGridState): PageTab {
+  return { id: pageTabId(), path, pendingSavedView };
 }
 
 function recordClosed(closedPaths: string[], ...paths: string[]): string[] {
@@ -80,13 +84,23 @@ export const useTabsStore = create<TabsState>()(
       closedPaths: [],
       openTab: (path, opts) =>
         set((s) => {
-          const tab = freshTab(path);
+          const tab = freshTab(path, opts?.pendingSavedView);
           const activeIdx = s.tabs.findIndex((t) => t.id === s.activeId);
           const at = opts?.afterActive && activeIdx >= 0 ? activeIdx + 1 : s.tabs.length;
           return {
             tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)],
             activeId: opts?.activate === false ? s.activeId : tab.id,
           };
+        }),
+      clearPendingSavedView: (id) =>
+        set((s) => {
+          const idx = s.tabs.findIndex((tab) => tab.id === id);
+          if (idx < 0 || !s.tabs[idx]!.pendingSavedView) return s;
+          const tabs = [...s.tabs];
+          const tab = { ...tabs[idx]! };
+          delete tab.pendingSavedView;
+          tabs[idx] = tab;
+          return { tabs };
         }),
       closeTab: (id) =>
         set((s) => {
@@ -136,7 +150,8 @@ export const useTabsStore = create<TabsState>()(
         set((s) => {
           const idx = s.tabs.findIndex((t) => t.id === id);
           if (idx < 0) return s;
-          const tab = freshTab(s.tabs[idx]!.path);
+          const source = s.tabs[idx]!;
+          const tab = freshTab(source.path, source.pendingSavedView);
           return { tabs: [...s.tabs.slice(0, idx + 1), tab, ...s.tabs.slice(idx + 1)], activeId: tab.id };
         }),
       setActive: (id) => set({ activeId: id }),

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -12,11 +12,15 @@ export interface PageTab {
 interface TabsState {
   tabs: PageTab[];
   activeId?: string;
+  /** Paths of recently closed tabs, oldest first; feeds "reopen closed tab". */
+  closedPaths: string[];
   openTab: (path: string, opts?: { activate?: boolean; afterActive?: boolean }) => void;
   closeTab: (id: string) => void;
   closeOthers: (id: string) => void;
   closeRight: (id: string) => void;
   duplicateTab: (id: string) => void;
+  /** Restore the most recently closed tab (after the active one) and activate it. */
+  reopenTab: () => void;
   setActive: (id: string) => void;
   moveTab: (from: number, to: number) => void;
   /** Mirror the router location into the active tab (creates the first tab). */
@@ -62,6 +66,10 @@ function freshTab(path: string): PageTab {
   return { id: pageTabId(), path };
 }
 
+function recordClosed(closedPaths: string[], ...paths: string[]): string[] {
+  return [...closedPaths, ...paths].slice(-10);
+}
+
 const initialTab = freshTab('/');
 
 export const useTabsStore = create<TabsState>()(
@@ -69,6 +77,7 @@ export const useTabsStore = create<TabsState>()(
     (set) => ({
       tabs: [initialTab],
       activeId: initialTab.id,
+      closedPaths: [],
       openTab: (path, opts) =>
         set((s) => {
           const tab = freshTab(path);
@@ -83,28 +92,45 @@ export const useTabsStore = create<TabsState>()(
         set((s) => {
           const idx = s.tabs.findIndex((t) => t.id === id);
           if (idx < 0) return s;
+          const closedPaths = recordClosed(s.closedPaths, s.tabs[idx]!.path);
           const tabs = s.tabs.filter((t) => t.id !== id);
           // The bar always shows at least one tab; closing the last one resets it.
           if (tabs.length === 0) {
             const tab = freshTab('/');
-            return { tabs: [tab], activeId: tab.id };
+            return { tabs: [tab], activeId: tab.id, closedPaths };
           }
           // Like browsers: closing the active tab activates its right neighbor.
           const activeId = s.activeId === id ? tabs[Math.min(idx, tabs.length - 1)]!.id : s.activeId;
-          return { tabs, activeId };
+          return { tabs, activeId, closedPaths };
         }),
       closeOthers: (id) =>
         set((s) => {
           const tab = s.tabs.find((t) => t.id === id);
-          return tab ? { tabs: [tab], activeId: id } : s;
+          if (!tab) return s;
+          const closedPaths = recordClosed(s.closedPaths, ...s.tabs.filter((t) => t.id !== id).map((t) => t.path));
+          return { tabs: [tab], activeId: id, closedPaths };
         }),
       closeRight: (id) =>
         set((s) => {
           const idx = s.tabs.findIndex((t) => t.id === id);
           if (idx < 0) return s;
+          const closedPaths = recordClosed(s.closedPaths, ...s.tabs.slice(idx + 1).map((t) => t.path));
           const tabs = s.tabs.slice(0, idx + 1);
           const activeId = tabs.some((t) => t.id === s.activeId) ? s.activeId : id;
-          return { tabs, activeId };
+          return { tabs, activeId, closedPaths };
+        }),
+      reopenTab: () =>
+        set((s) => {
+          const path = s.closedPaths.at(-1);
+          if (path === undefined) return s;
+          const tab = freshTab(path);
+          const activeIdx = s.tabs.findIndex((t) => t.id === s.activeId);
+          const at = activeIdx >= 0 ? activeIdx + 1 : s.tabs.length;
+          return {
+            closedPaths: s.closedPaths.slice(0, -1),
+            tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)],
+            activeId: tab.id,
+          };
         }),
       duplicateTab: (id) =>
         set((s) => {

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+/**
+ * Transient top-level dialog state (command palette, settings, shortcut
+ * cheatsheet) — shared so the top-bar buttons, the command palette, and the
+ * global keyboard shortcuts all drive the same dialogs.
+ */
+interface UiState {
+  searchOpen: boolean;
+  settingsOpen: boolean;
+  shortcutsOpen: boolean;
+  /** When a `g` go-to sequence is pending: its Date.now() start; 0 = none. Drives the which-key panel. */
+  goPendingSince: number;
+  setSearchOpen: (open: boolean) => void;
+  setSettingsOpen: (open: boolean) => void;
+  setShortcutsOpen: (open: boolean) => void;
+  startGoPending: () => void;
+  clearGoPending: () => void;
+}
+
+export const useUiStore = create<UiState>((set) => ({
+  searchOpen: false,
+  settingsOpen: false,
+  shortcutsOpen: false,
+  goPendingSince: 0,
+  setSearchOpen: (searchOpen) => set({ searchOpen }),
+  setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
+  setShortcutsOpen: (shortcutsOpen) => set({ shortcutsOpen }),
+  startGoPending: () => set({ goPendingSince: Date.now() }),
+  clearGoPending: () => set((s) => (s.goPendingSince ? { goPendingSince: 0 } : s)),
+}));

--- a/client/src/text-entry.ts
+++ b/client/src/text-entry.ts
@@ -1,12 +1,17 @@
+/** Input types that don't consume typing — a focused checkbox must not block shortcuts. */
+const NON_TEXT_INPUT_TYPES = new Set(['checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'file', 'color']);
+
 /** True when a key event targets a surface that consumes typing (inputs, editors, menus, dialogs). */
 export function isTextEntryTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   const tag = target.tagName;
+  if (tag === 'INPUT' && !NON_TEXT_INPUT_TYPES.has((target as HTMLInputElement).type)) return true;
   return (
     target.isContentEditable ||
-    tag === 'INPUT' ||
     tag === 'TEXTAREA' ||
     tag === 'SELECT' ||
+    // Non-text inputs (grid checkboxes) don't consume typing themselves, but
+    // anything inside a dialog/menu/editor still blocks global shortcuts.
     !!target.closest('[contenteditable="true"], [role="textbox"], [role="dialog"], [role="menu"], [role="listbox"], .monaco-editor')
   );
 }

--- a/client/src/text-entry.ts
+++ b/client/src/text-entry.ts
@@ -15,3 +15,13 @@ export function isTextEntryTarget(target: EventTarget | null): boolean {
     !!target.closest('[contenteditable="true"], [role="textbox"], [role="dialog"], [role="menu"], [role="listbox"], .monaco-editor')
   );
 }
+
+/**
+ * True when the target sits inside a surface that owns the whole keyboard
+ * (terminals, code editors). Stricter than isTextEntryTarget: plain filter
+ * inputs still allow e.g. Alt tab-switching chords, but a shell or editor
+ * must receive every Alt sequence unmodified.
+ */
+export function isEditorOrTerminalTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && !!target.closest('.xterm, .monaco-editor');
+}

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -269,6 +269,13 @@ export function buildTheme(mode: 'light' | 'dark', options: { modalBackdrop?: El
               color: c.textSecondary,
             },
             '& .MuiDataGrid-columnSeparator': { color: 'transparent' },
+            // No outline for mouse focus, but keyboard navigation must show
+            // which cell is focused (source order: focus-visible wins).
+            '& .MuiDataGrid-cell:focus, & .MuiDataGrid-columnHeader:focus': { outline: 'none' },
+            '& .MuiDataGrid-cell:focus-visible, & .MuiDataGrid-columnHeader:focus-visible': {
+              outline: `2px solid ${alpha(c.primary, 0.8)}`,
+              outlineOffset: '-2px',
+            },
             '& .MuiDataGrid-row:hover': { backgroundColor: dark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)' },
             '& .MuiDataGrid-row.Mui-selected': {
               backgroundColor: c.selectedPill,

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -2,6 +2,29 @@ import type { ElementType } from 'react';
 import { alpha, createTheme, type Theme } from '@mui/material/styles';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
+/**
+ * Shared layout dimensions. Several of these are cross-file contracts:
+ * anything that changes one side must keep the other in sync, so both sides
+ * read the same token instead of repeating the number.
+ */
+export const layout = {
+  /** TopBar toolbar height; drawers/panels below it offset by the same value. */
+  topBarHeight: 52,
+  navDrawerWidth: 228,
+  /** Fixed tab width so the shrink-to-fit tablist sizes to n×tabs. */
+  tabWidth: 190,
+  /** Themed scrollbar thickness; grids reserve the same explicit gutter. */
+  scrollbarSize: 10,
+  /**
+   * The embedded detail panel's resize handle and collapse button overhang
+   * the grid, whose floating scrollbars are MUI-internal zIndex 60 (70 on
+   * hover) in the same stacking context — these must stay above both, and
+   * the button above the handle.
+   */
+  zDetailResizeHandle: 71,
+  zDetailCollapseButton: 72,
+} as const;
+
 const modalBackdropAlpha = 0.5;
 
 const darkColors = {
@@ -114,7 +137,7 @@ export function buildTheme(mode: 'light' | 'dark', options: { modalBackdrop?: El
             scrollbarWidth: 'thin',
             scrollbarColor: `${c.scrollThumb} transparent`,
           },
-          '*::-webkit-scrollbar': { width: 10, height: 10 },
+          '*::-webkit-scrollbar': { width: layout.scrollbarSize, height: layout.scrollbarSize },
           '*::-webkit-scrollbar-track': { background: 'transparent' },
           '*::-webkit-scrollbar-thumb': {
             backgroundColor: c.scrollThumb,

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -25,7 +25,7 @@ The home for managing the clusters in your kubeconfig:
 
 - **Add cluster** — paste or fill in a new cluster.
 - **Edit** (:material-pencil:) — change a cluster's API server, credentials, TLS, and
-  proxy settings. See [Adding & editing clusters](clusters.md#adding-editing-clusters) and
+  proxy settings. See [Adding, editing & removing clusters](clusters.md#adding-editing-removing-clusters) and
   [Reaching clusters behind a proxy or bastion](clusters.md#reaching-clusters-behind-a-proxy-or-bastion).
 - **Protect** (:material-shield:) — mark a cluster as protected, or set **protect by
   default** so every cluster is guarded until you say otherwise. See

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -288,11 +288,24 @@ function createWindow(url: string): void {
   // whole window when nothing is docked. preventDefault() stops the native menu
   // accelerator from firing (and keeps the key out of the page).
   mainWindow.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown' || input.key.toLowerCase() !== 'w' || input.alt || input.shift) return;
-    const closeChord = isMac ? input.meta && !input.control : input.control && !input.meta;
-    if (!closeChord) return;
-    event.preventDefault();
-    mainWindow?.webContents.send('kubus:close-tab');
+    if (input.type !== 'keyDown') return;
+    const key = input.key.toLowerCase();
+    // Cmd/Ctrl+W closes the focused dock/page tab — never the window.
+    if (key === 'w' && !input.alt && !input.shift && (isMac ? input.meta && !input.control : input.control && !input.meta)) {
+      event.preventDefault();
+      mainWindow?.webContents.send('kubus:close-tab');
+      return;
+    }
+    // Browser-style page-tab cycling; the payload is true to cycle backwards.
+    if (input.control && !input.meta && !input.alt && (key === 'tab' || key === 'pageup' || key === 'pagedown')) {
+      event.preventDefault();
+      mainWindow?.webContents.send('kubus:cycle-tab', key === 'tab' ? input.shift : key === 'pageup');
+      return;
+    }
+    if (isMac && input.meta && input.shift && !input.control && !input.alt && (input.code === 'BracketLeft' || input.code === 'BracketRight')) {
+      event.preventDefault();
+      mainWindow?.webContents.send('kubus:cycle-tab', input.code === 'BracketLeft');
+    }
   });
   void mainWindow.loadURL(url);
 }

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -31,6 +31,13 @@ contextBridge.exposeInMainWorld('kubusDesktop', {
     ipcRenderer.on('kubus:close-tab', listener);
     return () => ipcRenderer.removeListener('kubus:close-tab', listener);
   },
+  // Fires on the tab-cycling chords (Ctrl+Tab, Ctrl+PgUp/PgDn, macOS
+  // Cmd+Shift+[/]); backwards=true cycles left. Returns an unsubscribe.
+  onCycleTab(callback: (backwards: boolean) => void): () => void {
+    const listener = (_event: unknown, backwards: unknown): void => callback(backwards === true);
+    ipcRenderer.on('kubus:cycle-tab', listener);
+    return () => ipcRenderer.removeListener('kubus:cycle-tab', listener);
+  },
   closeWindow(): void {
     ipcRenderer.send('kubus:close-window');
   },

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -241,12 +241,23 @@ export interface FavoriteItem {
   ref?: ResourceRef;
 }
 
+/** Grid state snapshotted with a saved view so restoring brings back the exact table. */
+export interface SavedViewGridState {
+  /** Global namespace filter at save time (empty = all namespaces). */
+  namespaces?: string[];
+  sort?: ReadonlyArray<{ field: string; sort: 'asc' | 'desc' | null | undefined }>;
+  columnVisibility?: Record<string, boolean>;
+  columnWidths?: Record<string, number>;
+}
+
 export interface SavedView {
   id: string;
   title: string;
   path: string;
   textFilter?: string;
   labelSelector?: string;
+  /** Absent on views saved before grid capture existed — those restore the query only. */
+  grid?: SavedViewGridState;
 }
 
 // ---- Topology graph ----


### PR DESCRIPTION
## Keyboard support

A central shortcut system (`client/src/shortcuts.ts`) replaces the ad-hoc key listeners: capture-phase handling for chords and `g` go-to sequences, a bubble-phase Escape dismiss chain, and a single definition table that renders the help dialog so the cheatsheet cannot drift from the real bindings.

- **Esc everywhere**: dismisses the topmost surface in priority order — menus/dialogs, nav overlay, maximized dock, then the details panel (from anywhere on the page, with `?sel` cleanup and focus returned to the grid). Filter inputs clear first, then blur. A maximized dock no longer steals Esc from a focused terminal (vim stays usable).
- **Go-to navigation**: `g` then a key jumps to any major page (Pods, Deployments, Services, Nodes, Events, Helm, …). Pausing after `g` shows a which-key panel listing every destination; items are clickable, and Esc/outside-click/timeout dismiss it.
- **Tabs**: `Alt+T/W/Shift+T` (new / close / reopen with closed-tab history), `Alt+1–9`, `Alt+PgUp/PgDn`; the desktop app adds native `Ctrl+Tab`, `Ctrl+PgUp/PgDn`, `Cmd+Shift+[/]` via IPC. The tab strip follows the ARIA tabs pattern (arrows/Home/End move focus, Enter activates, Delete closes).
- **Panels & palette**: `Ctrl+B` nav rail, `Ctrl+J` dock, `Ctrl+,` settings, `Ctrl+K` palette toggle; palette gains `Ctrl+Enter`/`Shift+Enter` open-in-new/background-tab, paging, and new commands. `c` opens Create on list pages; Enter activates rows on the Events and Helm grids; keyboard cell focus is visible via `:focus-visible`; a skip-to-content link is the first tab stop.
- **Searchable cheatsheet** (`?`): filter across all sections, keycaps right-aligned, sequences rendered as "G then P", desktop-only rows filtered per platform.
- Fixed a race where rapid tab-switch chords skipped navigation: tab sync now compares against `window.location` instead of the transition-lagged router location.

## List & shell UX

- First-run onboarding: connect a cluster straight from the welcome screen.
- Collapsible nav rail, with a narrow-viewport overlay mode.
- Bulk delete and rolling restart from resource lists, with protected-cluster confirmations.
- Saved views capture and restore the full grid state (columns, widths, sort, namespaces).
- Unified filtering across Events and resource tables; shared layout dimensions moved into theme tokens.
- Pod detail surfaces why a pod is not ready; centralized backend error handling; grid quick-search focuses synchronously so fast typing is not dropped.

## Verification

Built and driven end-to-end with Playwright against a kind cluster: 35 keyboard-flow checks plus 19 shortcut-UI checks pass (Esc chain, sequences, tab chords, palette, cheatsheet search, which-key panel). `pnpm -r typecheck` and `pnpm lint` are clean.