### PR TITLE
Improve log viewer reliability and controls

### DIFF
--- a/client/src/actions/resource-actions.ts
+++ b/client/src/actions/resource-actions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { gvkForResource, type KubeObject, type ResourceRef } from '@kubus/shared';
+import { gvkForResource, type KubeObject, type LogTargetKind, type ResourceRef } from '@kubus/shared';
 import {
   resolveLogTargetPods,
   useCordon,
@@ -53,7 +53,7 @@ export function actionsForRef(ref: ResourceRef): PaletteAction[] {
     case 'CronJob':
       return [OPEN, TRIGGER, SUSPEND, MORE];
     case 'Job':
-      return [OPEN, RERUN, MORE];
+      return [OPEN, LOGS, RERUN, MORE];
     case 'Node':
       return [OPEN, CORDON, MORE];
     default:
@@ -76,15 +76,17 @@ export function usePaletteRunner(): (action: PaletteAction, ref: ResourceRef) =>
       const fetchObj = () => apiFetch<KubeObject>(resourceUrl(ref.ctx, ref.group, ref.version, ref.plural, ref.name, ref.namespace));
       switch (action.id) {
         case 'logs': {
-          const { pods } = await resolveLogTargetPods({ ctx: ref.ctx, group: ref.group, version: ref.version, plural: ref.plural, kind: ref.kind as 'Pod', namespace, name: ref.name });
+          const logKind = ref.kind as LogTargetKind;
+          const { pods } = await resolveLogTargetPods({ ctx: ref.ctx, group: ref.group, version: ref.version, plural: ref.plural, kind: logKind, namespace, name: ref.name });
           if (!pods.length) throw new Error(`No pods found for ${ref.kind} ${namespace}/${ref.name}`);
-          const byNamespace = new Map<string, string[]>();
+          const byNamespace = new Map<string, typeof pods>();
           for (const pod of pods) {
-            const names = byNamespace.get(pod.namespace);
-            if (names) names.push(pod.name);
-            else byNamespace.set(pod.namespace, [pod.name]);
+            const namespacePods = byNamespace.get(pod.namespace);
+            if (namespacePods) namespacePods.push(pod);
+            else byNamespace.set(pod.namespace, [pod]);
           }
-          for (const [ns, podNames] of byNamespace) {
+          for (const [ns, namespacePods] of byNamespace) {
+            const podNames = namespacePods.map((pod) => pod.name);
             addTab({
               kind: 'logs',
               id: dockTabId(),
@@ -92,6 +94,8 @@ export function usePaletteRunner(): (action: PaletteAction, ref: ResourceRef) =>
               ctx: ref.ctx,
               namespace: ns,
               pods: podNames,
+              sources: namespacePods.map((pod) => ({ pod: pod.name, containers: pod.containers })),
+              target: { kind: logKind, name: ref.name },
               follow: true,
             });
           }

--- a/client/src/components/LogViewer.tsx
+++ b/client/src/components/LogViewer.tsx
@@ -1,7 +1,14 @@
 import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
 import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
+import ListItemText from '@mui/material/ListItemText';
+import ListSubheader from '@mui/material/ListSubheader';
+import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
@@ -19,15 +26,23 @@ import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import type { LogServerMessage } from '@kubus/shared';
+import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import FlagOutlinedIcon from '@mui/icons-material/FlagOutlined';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import TuneIcon from '@mui/icons-material/Tune';
+import { LOG_SOCKET_COMPLETE_CODE, LOG_SOCKET_NO_STREAMS_CODE, type LogServerMessage } from '@kubus/shared';
 import { wsUrl } from '../api/http.js';
 import { useDockStore, type LogsTab } from '../state/dock.js';
 import { copyToClipboard } from '../clipboard.js';
 import { useLogPrefsStore, type TsMode } from '../state/log-prefs.js';
 import { useUiPrefsStore } from '../state/prefs.js';
+import { isTextEntryTarget } from '../text-entry.js';
 import { detectLevel, LOG_LEVELS, markSegs, parseLine, stripAnsi, type LogLevel, type Seg } from './log-format.js';
 
 interface LogLine {
+  kind: 'line';
   pod: string;
   container: string;
   ts?: string;
@@ -35,20 +50,46 @@ interface LogLine {
   receivedAt: number;
 }
 
+interface LogMarker {
+  kind: 'marker';
+  label: string;
+  tone: 'manual' | 'warning' | 'success';
+  receivedAt: number;
+}
+
+type LogEntry = LogLine | LogMarker;
+type LogConnectionState = 'connecting' | 'streaming' | 'reconnecting' | 'complete' | 'disconnected';
+
+interface LogSource {
+  pod: string;
+  containers: string[];
+}
+
+interface LogBuffer {
+  entries: LogEntry[];
+  markerCount: number;
+}
+
 const POD_COLORS = ['#7aa2f7', '#9ece6a', '#e0af68', '#f7768e', '#bb9af7', '#7dcfff', '#ff9e64', '#73daca'];
-const MAX_LINES = 20_000;
+const MAX_ENTRIES = 20_000;
+const MAX_RECONNECT_ATTEMPTS = 8;
+const RECONNECT_BASE_MS = 500;
+const RECONNECT_MAX_MS = 8_000;
+const RECONNECT_STABLE_MS = 10_000;
 /** Virtualized row height for the default 12px mono font; scales with it. */
 function rowHeightFor(fontSize: number): number {
   return fontSize + 8;
 }
-type LogTimeMode = 'live' | '10m' | '1h' | '6h' | '24h' | 'terminated';
+type LogTimeMode = 'live' | '10m' | '1h' | '6h' | '24h' | '30d' | 'last20k' | 'terminated';
 
-const TIME_OPTIONS: Array<{ value: LogTimeMode; label: string; params: { follow: boolean; tail?: boolean; sinceSeconds?: number; previous?: boolean } }> = [
+const TIME_OPTIONS: Array<{ value: LogTimeMode; label: string; params: { follow: boolean; tail?: boolean; tailLines?: number; sinceSeconds?: number; previous?: boolean } }> = [
   { value: 'live', label: 'Live tail', params: { follow: true, tail: true } },
   { value: '10m', label: '10m ago', params: { follow: false, sinceSeconds: 10 * 60 } },
   { value: '1h', label: '1h ago', params: { follow: false, sinceSeconds: 60 * 60 } },
   { value: '6h', label: '6h ago', params: { follow: false, sinceSeconds: 6 * 60 * 60 } },
   { value: '24h', label: '24h ago', params: { follow: false, sinceSeconds: 24 * 60 * 60 } },
+  { value: '30d', label: '30d ago', params: { follow: false, sinceSeconds: 30 * 24 * 60 * 60 } },
+  { value: 'last20k', label: 'Last 20k', params: { follow: false, tailLines: MAX_ENTRIES } },
   { value: 'terminated', label: 'Terminated', params: { follow: false, tail: true, previous: true } },
 ];
 
@@ -117,6 +158,8 @@ function initialTimeMode(tab: LogsTab): LogTimeMode {
   if (tab.sinceSeconds === 60 * 60) return '1h';
   if (tab.sinceSeconds === 6 * 60 * 60) return '6h';
   if (tab.sinceSeconds === 24 * 60 * 60) return '24h';
+  if (tab.sinceSeconds === 30 * 24 * 60 * 60) return '30d';
+  if (tab.follow === false && tab.sinceSeconds === undefined && (tab.tailLines === undefined || tab.tailLines === MAX_ENTRIES)) return 'last20k';
   return 'live';
 }
 
@@ -124,16 +167,209 @@ function paramsForMode(mode: LogTimeMode): (typeof TIME_OPTIONS)[number]['params
   return TIME_OPTIONS.find((opt) => opt.value === mode)?.params ?? TIME_OPTIONS[0]!.params;
 }
 
+function appendEntries(state: LogBuffer, fresh: LogEntry[]): LogBuffer {
+  if (!fresh.length) return state;
+  const combined = [...state.entries, ...fresh];
+  const overflow = Math.max(0, combined.length - MAX_ENTRIES);
+  let markerCount = state.markerCount;
+  for (const entry of fresh) {
+    if (entry.kind === 'marker') markerCount++;
+  }
+  for (let index = 0; index < overflow; index++) {
+    if (combined[index]?.kind === 'marker') markerCount--;
+  }
+  return {
+    entries: overflow ? combined.slice(overflow) : combined,
+    markerCount,
+  };
+}
+
+function reconnectDelay(attempt: number): number {
+  return Math.min(RECONNECT_BASE_MS * 2 ** Math.max(0, attempt - 1), RECONNECT_MAX_MS);
+}
+
+function workloadPreferenceKey(ctx: string, namespace: string, kind: NonNullable<LogsTab['target']>['kind'] | undefined, name: string | undefined): string | undefined {
+  if (!kind || !name) return undefined;
+  return [ctx, namespace, kind, name].map(encodeURIComponent).join('/');
+}
+
+function sourceKey(pod: string, container: string): string {
+  return `${pod}/${container}`;
+}
+
+function setsEqual<T>(left: ReadonlySet<T>, right: ReadonlySet<T>): boolean {
+  if (left.size !== right.size) return false;
+  for (const value of left) {
+    if (!right.has(value)) return false;
+  }
+  return true;
+}
+
+interface LogSourceSelectorProps {
+  sources: readonly LogSource[];
+  containerNames: readonly string[];
+  enabledPods: ReadonlySet<string>;
+  enabledContainers: ReadonlySet<string>;
+  onApply: (pods: ReadonlySet<string>, containers: ReadonlySet<string>) => void;
+}
+
+const LogSourceSelector = memo(function LogSourceSelector({
+  sources,
+  containerNames,
+  enabledPods,
+  enabledContainers,
+  onApply,
+}: LogSourceSelectorProps) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const [draftPods, setDraftPods] = useState<ReadonlySet<string>>(() => new Set(enabledPods));
+  const [draftContainers, setDraftContainers] = useState<ReadonlySet<string>>(() => new Set(enabledContainers));
+  const podCountByContainer = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const source of sources) {
+      for (const container of source.containers) {
+        counts.set(container, (counts.get(container) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [sources]);
+
+  const openSelector = (target: HTMLElement) => {
+    setDraftPods(new Set(enabledPods));
+    setDraftContainers(new Set(enabledContainers));
+    setAnchor(target);
+  };
+
+  const togglePod = (pod: string) => {
+    setDraftPods((current) => {
+      if (current.has(pod) && current.size === 1) return current;
+      const next = new Set(current);
+      if (next.has(pod)) next.delete(pod);
+      else next.add(pod);
+      return next;
+    });
+  };
+
+  const toggleContainer = (container: string) => {
+    setDraftContainers((current) => {
+      if (current.has(container) && current.size === 1) return current;
+      const next = new Set(current);
+      if (next.has(container)) next.delete(container);
+      else next.add(container);
+      return next;
+    });
+  };
+
+  const selectionChanged = !setsEqual(draftPods, enabledPods) || !setsEqual(draftContainers, enabledContainers);
+
+  return (
+    <>
+      <Button
+        size="small"
+        variant="outlined"
+        startIcon={<TuneIcon fontSize="small" />}
+        onClick={(event) => openSelector(event.currentTarget)}
+        aria-label="Select log pods and containers"
+        aria-haspopup="menu"
+        aria-expanded={anchor ? 'true' : undefined}
+        sx={{ whiteSpace: 'nowrap' }}
+      >
+        {enabledPods.size}/{sources.length} pods · {containerNames.length ? `${enabledContainers.size}/${containerNames.length} containers` : 'all containers'}
+      </Button>
+      <Menu anchorEl={anchor} open={!!anchor} onClose={() => setAnchor(null)} slotProps={{ paper: { sx: { minWidth: 300, maxHeight: 480 } } }}>
+        {anchor ? (
+          <>
+            <ListSubheader disableSticky>Pods</ListSubheader>
+            {sources.map((source) => {
+              const checked = draftPods.has(source.pod);
+              return (
+                <MenuItem key={source.pod} dense disabled={checked && draftPods.size === 1} onClick={() => togglePod(source.pod)}>
+                  <Checkbox size="small" checked={checked} />
+                  <ListItemText primary={source.pod} secondary={source.containers.join(', ') || 'Containers discovered by server'} />
+                </MenuItem>
+              );
+            })}
+            {containerNames.length ? <Divider /> : null}
+            {containerNames.length ? <ListSubheader disableSticky>Containers</ListSubheader> : null}
+            {containerNames.map((container) => {
+              const checked = draftContainers.has(container);
+              const podCount = podCountByContainer.get(container) ?? 0;
+              return (
+                <MenuItem key={container} dense disabled={checked && draftContainers.size === 1} onClick={() => toggleContainer(container)}>
+                  <Checkbox size="small" checked={checked} />
+                  <ListItemText primary={container} secondary={`Available in ${podCount} ${podCount === 1 ? 'pod' : 'pods'}`} />
+                </MenuItem>
+              );
+            })}
+            <Divider />
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, px: 1.5, py: 1 }}>
+              <Button size="small" onClick={() => setAnchor(null)}>
+                Cancel
+              </Button>
+              <Button
+                size="small"
+                variant="contained"
+                disabled={!selectionChanged}
+                onClick={() => {
+                  onApply(draftPods, draftContainers);
+                  setAnchor(null);
+                }}
+              >
+                Apply
+              </Button>
+            </Box>
+          </>
+        ) : null}
+      </Menu>
+    </>
+  );
+});
+
 export function LogViewer({ tab }: { tab: LogsTab }) {
-  const [lines, setLines] = useState<LogLine[]>([]);
+  const initialMode = initialTimeMode(tab);
+  const sources = useMemo(
+    () =>
+      tab.sources?.length
+        ? tab.sources
+        : tab.pods.map((pod) => ({
+            pod,
+            containers: tab.container ? [tab.container] : [],
+          })),
+    [tab.container, tab.pods, tab.sources],
+  );
+  const allContainerNames = useMemo(() => {
+    const seen = new Set<string>();
+    for (const source of sources) {
+      for (const container of source.containers) seen.add(container);
+    }
+    return [...seen];
+  }, [sources]);
+  const preferenceKey = useMemo(
+    () => workloadPreferenceKey(tab.ctx, tab.namespace, tab.target?.kind, tab.target?.name),
+    [tab.ctx, tab.namespace, tab.target?.kind, tab.target?.name],
+  );
+
+  const [logBuffer, setLogBuffer] = useState<LogBuffer>({ entries: [], markerCount: 0 });
+  const entries = logBuffer.entries;
+  const totalLineCount = entries.length - logBuffer.markerCount;
   const [filter, setFilter] = useState('');
   const [levelFilter, setLevelFilter] = useState<ReadonlySet<LogLevel>>(new Set());
   const [find, setFind] = useState('');
   const [cursor, setCursor] = useState(0);
-  const [follow, setFollow] = useState(true);
-  const [timeMode, setTimeMode] = useState<LogTimeMode>(() => initialTimeMode(tab));
-  const [statusText, setStatusText] = useState('connecting…');
+  const [follow, setFollow] = useState(() => paramsForMode(initialMode).follow);
+  const [timeMode, setTimeMode] = useState<LogTimeMode>(initialMode);
+  const [connectionState, setConnectionState] = useState<LogConnectionState>('connecting');
+  const [retryAttempt, setRetryAttempt] = useState(0);
+  const [reconnectToken, setReconnectToken] = useState(0);
+  const [enabledPods, setEnabledPods] = useState<ReadonlySet<string>>(() => new Set(tab.pods));
+  const [enabledContainers, setEnabledContainers] = useState<ReadonlySet<string>>(() => {
+    if (tab.container) return new Set([tab.container]);
+    const remembered = preferenceKey ? useLogPrefsStore.getState().enabledContainersByWorkload[preferenceKey] : undefined;
+    const available = remembered?.filter((container) => allContainerNames.includes(container)) ?? [];
+    return new Set(available.length ? available : allContainerNames);
+  });
   const bufferRef = useRef<LogLine[]>([]);
+  const lastTimestampBySourceRef = useRef(new Map<string, string>());
+  const lastFrameBySourceRef = useRef(new Map<string, { ts: string; line: string }>());
   const scrollRef = useRef<HTMLDivElement>(null);
   const findRef = useRef<HTMLInputElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
@@ -145,6 +381,7 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
   const setWrap = useLogPrefsStore((s) => s.setWrap);
   const cycleTsMode = useLogPrefsStore((s) => s.cycleTsMode);
   const setHighlight = useLogPrefsStore((s) => s.setHighlight);
+  const rememberEnabledContainers = useLogPrefsStore((s) => s.rememberEnabledContainers);
   const monoFontSize = useUiPrefsStore((s) => s.monoFontSize);
   const defaultTailLines = useUiPrefsStore((s) => s.defaultTailLines);
   const rowHeight = rowHeightFor(monoFontSize);
@@ -157,69 +394,156 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
     return map;
   }, [tab.pods]);
 
+  const enabledPodsParam = useMemo(() => tab.pods.filter((pod) => enabledPods.has(pod)).join(','), [enabledPods, tab.pods]);
+  const enabledContainersParam = useMemo(
+    () => allContainerNames.filter((container) => enabledContainers.has(container)).join(','),
+    [allContainerNames, enabledContainers],
+  );
+  const selectedSourceCount = Math.max(1, enabledPods.size * Math.max(1, enabledContainers.size));
+
+  const flushBuffered = useCallback(() => {
+    if (!bufferRef.current.length) return;
+    const fresh = bufferRef.current;
+    bufferRef.current = [];
+    setLogBuffer((current) => appendEntries(current, fresh));
+  }, []);
+
+  const appendMarker = useCallback((label: string, tone: LogMarker['tone']) => {
+    const fresh = bufferRef.current;
+    bufferRef.current = [];
+    const marker: LogMarker = { kind: 'marker', label, tone, receivedAt: Date.now() };
+    setLogBuffer((current) => appendEntries(current, [...fresh, marker]));
+  }, []);
+
+  // Batch incoming lines into 120ms renders independently of socket retries.
+  useEffect(() => {
+    const flush = window.setInterval(flushBuffered, 120);
+    return () => window.clearInterval(flush);
+  }, [flushBuffered]);
+
   useEffect(() => {
     const modeParams = paramsForMode(timeMode);
-    setLines([]);
-    bufferRef.current = [];
-    setFollow(modeParams.follow);
-    setStatusText('connecting…');
-    const ws = new WebSocket(
-      wsUrl('/ws/logs', {
+    let disposed = false;
+    let socket: WebSocket | undefined;
+    let retryTimer: number | undefined;
+    let stableTimer: number | undefined;
+    let failures = 0;
+
+    const connect = () => {
+      if (disposed) return;
+      const resumeAt = Object.fromEntries(lastTimestampBySourceRef.current);
+      const requestedTailLines =
+        modeParams.tailLines !== undefined
+          ? Math.max(1, Math.floor(modeParams.tailLines / selectedSourceCount))
+          : modeParams.tail
+            ? (tab.tailLines ?? defaultTailLines)
+            : undefined;
+      socket = new WebSocket(wsUrl('/ws/logs', {
         ctx: tab.ctx,
         namespace: tab.namespace,
-        pods: tab.pods.join(','),
-        container: tab.container ?? '',
+        pods: enabledPodsParam,
+        containers: allContainerNames.length ? enabledContainersParam : undefined,
         previous: modeParams.previous ?? false,
         follow: modeParams.follow,
-        tailLines: modeParams.tail ? (tab.tailLines ?? defaultTailLines) : tab.tailLines,
-        sinceSeconds: modeParams.sinceSeconds ?? tab.sinceSeconds,
-      }),
-    );
-    // Batch incoming lines into 120ms renders.
-    const flush = window.setInterval(() => {
-      if (!bufferRef.current.length) return;
-      const fresh = bufferRef.current;
-      bufferRef.current = [];
-      setLines((prev) => {
-        const next = [...prev, ...fresh];
-        return next.length > MAX_LINES ? next.slice(next.length - MAX_LINES) : next;
-      });
-    }, 120);
+        tailLines: requestedTailLines,
+        sinceSeconds: modeParams.tailLines !== undefined ? undefined : (modeParams.sinceSeconds ?? tab.sinceSeconds),
+        resumeAt: Object.keys(resumeAt).length ? JSON.stringify(resumeAt) : undefined,
+      }));
+      let opened = false;
 
-    ws.onopen = () => setStatusText('streaming');
-    ws.onmessage = (ev) => {
-      try {
-        const msg = JSON.parse(ev.data as string) as LogServerMessage;
-        if (msg.op === 'line') {
-          bufferRef.current.push({ pod: msg.pod, container: msg.container, ts: msg.ts, line: msg.line, receivedAt: Date.now() });
-        } else if (msg.op === 'pod-status' && msg.state === 'error') {
-          bufferRef.current.push({ pod: msg.pod, container: msg.container, line: `⚠ ${msg.message ?? 'stream error'}`, receivedAt: Date.now() });
+      socket.onopen = () => {
+        opened = true;
+        if (failures > 0) appendMarker(`Reconnected after ${failures} ${failures === 1 ? 'attempt' : 'attempts'}`, 'success');
+        setConnectionState('streaming');
+        window.clearTimeout(stableTimer);
+        stableTimer = window.setTimeout(() => {
+          failures = 0;
+          setRetryAttempt(0);
+        }, RECONNECT_STABLE_MS);
+      };
+      socket.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data as string) as LogServerMessage;
+          if (msg.op === 'line') {
+            const key = sourceKey(msg.pod, msg.container);
+            const lastFrame = lastFrameBySourceRef.current.get(key);
+            if (msg.ts && lastFrame?.ts === msg.ts && lastFrame.line === msg.line) return;
+            if (msg.ts) {
+              lastTimestampBySourceRef.current.set(key, msg.ts);
+              lastFrameBySourceRef.current.set(key, { ts: msg.ts, line: msg.line });
+            }
+            bufferRef.current.push({ kind: 'line', pod: msg.pod, container: msg.container, ts: msg.ts, line: msg.line, receivedAt: Date.now() });
+          } else if (msg.op === 'pod-status' && msg.state === 'error') {
+            bufferRef.current.push({ kind: 'line', pod: msg.pod, container: msg.container, line: `⚠ ${msg.message ?? 'stream error'}`, receivedAt: Date.now() });
+          }
+        } catch {
+          /* ignore malformed frames */
         }
-      } catch {
-        /* ignore malformed frames */
-      }
+      };
+      socket.onclose = (event) => {
+        if (disposed) return;
+        window.clearTimeout(stableTimer);
+        if (event.code === LOG_SOCKET_COMPLETE_CODE) {
+          setConnectionState('complete');
+          setRetryAttempt(0);
+          return;
+        }
+        if (event.code === LOG_SOCKET_NO_STREAMS_CODE) {
+          setConnectionState('disconnected');
+          setRetryAttempt(0);
+          return;
+        }
+        if (opened) appendMarker('Connection interrupted', 'warning');
+        if (failures >= MAX_RECONNECT_ATTEMPTS) {
+          setConnectionState('disconnected');
+          setRetryAttempt(MAX_RECONNECT_ATTEMPTS);
+          return;
+        }
+        failures += 1;
+        setRetryAttempt(failures);
+        setConnectionState('reconnecting');
+        retryTimer = window.setTimeout(connect, reconnectDelay(failures));
+      };
     };
-    ws.onclose = () => setStatusText('disconnected');
+
+    setConnectionState('connecting');
+    setRetryAttempt(0);
+    connect();
     return () => {
-      window.clearInterval(flush);
-      ws.close();
+      disposed = true;
+      window.clearTimeout(retryTimer);
+      window.clearTimeout(stableTimer);
+      socket?.close(1000, 'log session changed');
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab.id, timeMode]);
+  }, [
+    allContainerNames.length,
+    appendMarker,
+    defaultTailLines,
+    enabledContainersParam,
+    enabledPodsParam,
+    reconnectToken,
+    selectedSourceCount,
+    tab.ctx,
+    tab.namespace,
+    tab.sinceSeconds,
+    tab.tailLines,
+    timeMode,
+  ]);
 
   // Status-bar stats may lag slightly: one O(n) pass over the deferred buffer keeps flushes cheap.
-  const deferredLines = useDeferredValue(lines);
+  const deferredEntries = useDeferredValue(entries);
   const { levelCounts, recentRate } = useMemo(() => {
     const counts: Record<LogLevel, number> = { error: 0, warn: 0, info: 0, debug: 0, trace: 0 };
     const cutoff = Date.now() - 10_000;
     let recent = 0;
-    for (const l of deferredLines) {
-      const level = levelOf(l);
+    for (const entry of deferredEntries) {
+      if (entry.kind === 'marker') continue;
+      const level = levelOf(entry);
       if (level) counts[level] += 1;
-      if (l.receivedAt >= cutoff) recent++;
+      if (entry.receivedAt >= cutoff) recent++;
     }
     return { levelCounts: counts, recentRate: recent / 10 };
-  }, [deferredLines]);
+  }, [deferredEntries]);
 
   const toggleLevel = (level: LogLevel) => {
     setLevelFilter((prev) => {
@@ -231,30 +555,45 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
   };
 
   const deferredFilter = useDeferredValue(filter);
-  const visible = useMemo(() => {
-    let out = lines;
-    if (levelFilter.size) {
-      out = out.filter((l) => {
-        const level = levelOf(l);
-        return level !== undefined && levelFilter.has(level);
-      });
+  const { visible, visibleLineCount } = useMemo(() => {
+    if (!levelFilter.size && !deferredFilter) {
+      return { visible: entries, visibleLineCount: totalLineCount };
     }
-    if (!deferredFilter) return out;
+
+    let matchesText: (entry: LogLine) => boolean;
     try {
       const re = new RegExp(deferredFilter, 'i');
-      return out.filter((l) => re.test(strippedOf(l)) || re.test(l.pod));
+      matchesText = deferredFilter ? (entry) => re.test(strippedOf(entry)) || re.test(entry.pod) || re.test(entry.container) : () => true;
     } catch {
       const f = deferredFilter.toLowerCase();
-      return out.filter((l) => strippedOf(l).toLowerCase().includes(f) || l.pod.toLowerCase().includes(f));
+      matchesText = (entry) => strippedOf(entry).toLowerCase().includes(f) || entry.pod.toLowerCase().includes(f) || entry.container.toLowerCase().includes(f);
     }
-  }, [lines, deferredFilter, levelFilter]);
+
+    const nextVisible: LogEntry[] = [];
+    let nextLineCount = 0;
+    for (const entry of entries) {
+      if (entry.kind === 'marker') {
+        nextVisible.push(entry);
+        continue;
+      }
+      if (levelFilter.size) {
+        const level = levelOf(entry);
+        if (level === undefined || !levelFilter.has(level)) continue;
+      }
+      if (!matchesText(entry)) continue;
+      nextVisible.push(entry);
+      nextLineCount++;
+    }
+    return { visible: nextVisible, visibleLineCount: nextLineCount };
+  }, [entries, deferredFilter, levelFilter, totalLineCount]);
 
   const matches = useMemo(() => {
     if (!find) return [];
     const q = find.toLowerCase();
     const idx: number[] = [];
     for (let i = 0; i < visible.length; i++) {
-      if (strippedOf(visible[i]!).toLowerCase().includes(q)) idx.push(i);
+      const entry = visible[i]!;
+      if (entry.kind === 'line' && strippedOf(entry).toLowerCase().includes(q)) idx.push(i);
     }
     return idx;
   }, [visible, find]);
@@ -306,8 +645,13 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
     if (!atBottom && follow) setFollow(false);
   }, [follow, wrap]);
 
+  const entryText = (entry: LogEntry): string =>
+    entry.kind === 'marker'
+      ? `--- ${entry.label} ---`
+      : `${entry.ts ?? ''} [${entry.pod}/${entry.container}] ${strippedOf(entry)}`;
+
   const download = () => {
-    const text = visible.map((l) => `${l.ts ?? ''} [${l.pod}/${l.container}] ${strippedOf(l)}`).join('\n');
+    const text = visible.map(entryText).join('\n');
     const blob = new Blob([text], { type: 'text/plain' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
@@ -317,15 +661,55 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
   };
 
   const copyVisible = async () => {
-    const text = visible.map((l) => `${l.ts ?? ''} [${l.pod}/${l.container}] ${strippedOf(l)}`).join('\n');
+    const text = visible.map(entryText).join('\n');
     await copyToClipboard(text);
   };
+
+  const changeTimeMode = (next: LogTimeMode) => {
+    bufferRef.current = [];
+    lastTimestampBySourceRef.current.clear();
+    lastFrameBySourceRef.current.clear();
+    setLogBuffer({ entries: [], markerCount: 0 });
+    setFollow(paramsForMode(next).follow);
+    setTimeMode(next);
+  };
+
+  const addVisualMarker = useCallback(() => {
+    appendMarker(`Marker · ${new Date().toLocaleTimeString()}`, 'manual');
+  }, [appendMarker]);
+
+  const clearEntries = () => {
+    bufferRef.current = [];
+    setLogBuffer({ entries: [], markerCount: 0 });
+  };
+
+  const applySourceSelection = useCallback(
+    (pods: ReadonlySet<string>, containers: ReadonlySet<string>) => {
+      setEnabledPods(new Set(pods));
+      setEnabledContainers(new Set(containers));
+      if (preferenceKey) {
+        rememberEnabledContainers(preferenceKey, allContainerNames.filter((name) => containers.has(name)));
+      }
+    },
+    [allContainerNames, preferenceKey, rememberEnabledContainers],
+  );
 
   // Simple windowed rendering (nowrap) — only rows near the viewport mount.
   const start = wrap ? 0 : Math.max(0, Math.floor(scrollTop / rowHeight) - 20);
   const end = wrap ? visible.length : Math.min(visible.length, Math.ceil((scrollTop + viewHeight) / rowHeight) + 20);
   const currentMatch = matches.length ? matches[cursor] : undefined;
   const showPod = tab.pods.length > 1;
+  const showSource = showPod || allContainerNames.length > 1;
+  const connectionTooltip =
+    connectionState === 'reconnecting'
+      ? `Reconnect attempt ${retryAttempt} of ${MAX_RECONNECT_ATTEMPTS}`
+      : connectionState === 'disconnected'
+        ? retryAttempt
+          ? `Stopped after ${MAX_RECONNECT_ATTEMPTS} reconnect attempts`
+          : 'No log streams are available'
+        : connectionState === 'complete'
+          ? 'Log session complete'
+        : connectionState;
 
   return (
     <Box
@@ -335,17 +719,37 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
           e.preventDefault();
           findRef.current?.focus();
           findRef.current?.select();
+          return;
+        }
+        const target = e.target instanceof HTMLElement ? e.target : null;
+        if (
+          e.key === ' ' &&
+          !e.ctrlKey &&
+          !e.metaKey &&
+          !e.altKey &&
+          !isTextEntryTarget(e.target) &&
+          !target?.closest('button, [role="button"]')
+        ) {
+          e.preventDefault();
+          addVisualMarker();
         }
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1, py: 0.5, borderBottom: 1, borderColor: 'divider', flexShrink: 0, flexWrap: 'wrap' }}>
-        <Select size="small" value={timeMode} onChange={(e) => setTimeMode(e.target.value as LogTimeMode)} sx={{ width: 124 }}>
+        <Select size="small" value={timeMode} onChange={(e) => changeTimeMode(e.target.value as LogTimeMode)} sx={{ width: 124 }}>
           {TIME_OPTIONS.map((opt) => (
             <MenuItem key={opt.value} value={opt.value}>
               {opt.label}
             </MenuItem>
           ))}
         </Select>
+        <LogSourceSelector
+          sources={sources}
+          containerNames={allContainerNames}
+          enabledPods={enabledPods}
+          enabledContainers={enabledContainers}
+          onApply={applySourceSelection}
+        />
         <TextField
           placeholder="Filter (regex)…"
           value={filter}
@@ -420,34 +824,76 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
             </Tooltip>
           );
         })}
-        <Chip label={`${visible.length}/${lines.length} lines`} variant="outlined" />
+        <Chip label={`${visibleLineCount}/${totalLineCount} lines`} variant="outlined" />
         <Chip label={`${recentRate >= 10 ? recentRate.toFixed(0) : recentRate.toFixed(1)}/s`} variant="outlined" />
-        <Typography variant="caption" color="text.secondary">
-          {statusText}
-        </Typography>
+        <Tooltip title={connectionTooltip}>
+          <Chip
+            size="small"
+            label={connectionState}
+            color={connectionState === 'streaming' || connectionState === 'complete' ? 'success' : connectionState === 'reconnecting' ? 'warning' : connectionState === 'disconnected' ? 'error' : 'info'}
+            variant="outlined"
+            icon={
+              connectionState === 'connecting' || connectionState === 'reconnecting' ? (
+                <CircularProgress size={12} color="inherit" />
+              ) : connectionState === 'streaming' ? (
+                <FiberManualRecordIcon />
+              ) : connectionState === 'complete' ? (
+                <CheckCircleOutlinedIcon />
+              ) : (
+                <LinkOffIcon />
+              )
+            }
+          />
+        </Tooltip>
+        {connectionState === 'disconnected' && (
+          <Tooltip title="Reconnect now">
+            <IconButton
+              size="small"
+              aria-label="Reconnect log stream"
+              onClick={() => {
+                setConnectionState('connecting');
+                setReconnectToken((token) => token + 1);
+              }}
+            >
+              <RefreshIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
         <Box sx={{ flex: 1 }} />
         <Tooltip title={highlight ? 'Disable syntax highlighting' : 'Enable syntax highlighting (ANSI / JSON / logfmt)'}>
-          <ToggleButton value="highlight" selected={highlight} size="small" onChange={() => setHighlight(!highlight)} sx={{ p: 0.5, fontSize: 12, lineHeight: 1, width: 28 }}>
+          <ToggleButton
+            value="highlight"
+            selected={highlight}
+            size="small"
+            aria-label={highlight ? 'Disable syntax highlighting' : 'Enable syntax highlighting'}
+            onChange={() => setHighlight(!highlight)}
+            sx={{ p: 0.5, fontSize: 12, lineHeight: 1, width: 28 }}
+          >
             Aa
           </ToggleButton>
         </Tooltip>
         <Tooltip title={wrap ? 'Disable line wrap' : 'Wrap long lines'}>
-          <ToggleButton value="wrap" selected={wrap} size="small" onChange={() => setWrap(!wrap)} sx={{ p: 0.5 }}>
+          <ToggleButton value="wrap" selected={wrap} size="small" aria-label={wrap ? 'Disable line wrap' : 'Wrap long lines'} onChange={() => setWrap(!wrap)} sx={{ p: 0.5 }}>
             <WrapTextIcon fontSize="small" />
           </ToggleButton>
         </Tooltip>
         <Tooltip title={`Timestamps: ${tsMode}`}>
-          <ToggleButton value="ts" selected={tsMode !== 'off'} size="small" onChange={cycleTsMode} sx={{ p: 0.5 }}>
+          <ToggleButton value="ts" selected={tsMode !== 'off'} size="small" aria-label={`Timestamps: ${tsMode}`} onChange={cycleTsMode} sx={{ p: 0.5 }}>
             <AccessTimeIcon fontSize="small" />
           </ToggleButton>
         </Tooltip>
         <Tooltip title={follow ? 'Pause auto-scroll' : 'Resume auto-scroll'}>
-          <ToggleButton value="follow" selected={follow} size="small" onChange={() => setFollow(!follow)} sx={{ p: 0.5 }}>
+          <ToggleButton value="follow" selected={follow} size="small" aria-label={follow ? 'Pause auto-scroll' : 'Resume auto-scroll'} onChange={() => setFollow(!follow)} sx={{ p: 0.5 }}>
             {follow ? <PauseIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
           </ToggleButton>
         </Tooltip>
+        <Tooltip title="Add visual marker (Space)">
+          <IconButton size="small" aria-label="Add visual log marker" onClick={addVisualMarker}>
+            <FlagOutlinedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
         <Tooltip title="Clear">
-          <IconButton size="small" onClick={() => setLines([])}>
+          <IconButton size="small" onClick={clearEntries}>
             <DeleteSweepIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -469,8 +915,11 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
       </Box>
       <Box sx={{ flex: 1, minHeight: 0, p: 1, pt: 0.75 }}>
         <Box
+          component="section"
           ref={scrollRef}
           onScroll={onScroll}
+          tabIndex={0}
+          aria-label="Log output"
           sx={{
             height: '100%',
             overflow: 'auto',
@@ -493,7 +942,8 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
                   idx={idx}
                   wrap={wrap}
                   showPod={showPod}
-                  podColor={showPod ? (podColor.get(l.pod) ?? '#888') : undefined}
+                  showSource={showSource}
+                  podColor={l.kind === 'line' && showSource ? (podColor.get(l.pod) ?? '#888') : undefined}
                   tsMode={tsMode}
                   highlight={highlight}
                   find={find}
@@ -510,10 +960,11 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
 }
 
 interface LineRowProps {
-  line: LogLine;
+  line: LogEntry;
   idx: number;
   wrap: boolean;
   showPod: boolean;
+  showSource: boolean;
   podColor?: string;
   tsMode: TsMode;
   highlight: boolean;
@@ -522,11 +973,33 @@ interface LineRowProps {
   rowHeight: number;
 }
 
-const LineRow = memo(function LineRow({ line, idx, wrap, showPod, podColor, tsMode, highlight, find, isCurrent, rowHeight }: LineRowProps) {
+const LineRow = memo(function LineRow({ line, idx, wrap, showPod, showSource, podColor, tsMode, highlight, find, isCurrent, rowHeight }: LineRowProps) {
+  if (line.kind === 'marker') {
+    const color = line.tone === 'warning' ? '#e0af68' : line.tone === 'success' ? '#9ece6a' : '#bb9af7';
+    return (
+      <Box
+        data-idx={idx}
+        sx={
+          wrap
+            ? { minHeight: rowHeight, px: 1, display: 'flex', alignItems: 'center', gap: 1, color, contentVisibility: 'auto', containIntrinsicSize: `auto ${rowHeight}px` }
+            : { position: 'absolute', top: idx * rowHeight, left: 0, right: 0, height: rowHeight, px: 1, display: 'flex', alignItems: 'center', gap: 1, color }
+        }
+      >
+        <Divider sx={{ flex: 1, borderColor: color, opacity: 0.55 }} />
+        <FlagOutlinedIcon sx={{ fontSize: 14 }} />
+        <Box component="span" sx={{ fontSize: '0.9em', fontWeight: 600, whiteSpace: 'nowrap' }}>
+          {line.label}
+        </Box>
+        <Divider sx={{ flex: 1, borderColor: color, opacity: 0.55 }} />
+      </Box>
+    );
+  }
+
   const segs = highlight ? segsOf(line) : [{ text: strippedOf(line) }];
   const marked = find ? markSegs(segs, find) : segs;
   const level = levelOf(line);
   const tint = level ? LEVEL_ROW_TINT[level] : undefined;
+  const sourceLabel = showPod ? [line.pod, line.container].filter(Boolean).join('/') : line.container;
   return (
     <Box
       data-idx={idx}
@@ -536,9 +1009,9 @@ const LineRow = memo(function LineRow({ line, idx, wrap, showPod, podColor, tsMo
           : { position: 'absolute', top: idx * rowHeight, left: 0, right: 0, height: rowHeight, px: 1, whiteSpace: 'pre', display: 'flex', gap: 1, bgcolor: tint, '&:hover': { bgcolor: 'rgba(255,255,255,0.04)' } }
       }
     >
-      {showPod && (
+      {showSource && (
         <Box component="span" sx={{ color: podColor, flexShrink: 0, ...(wrap ? { mr: 1 } : {}) }}>
-          {line.pod}
+          {sourceLabel}
         </Box>
       )}
       {tsMode !== 'off' && (

--- a/client/src/components/LogViewer.tsx
+++ b/client/src/components/LogViewer.tsx
@@ -70,6 +70,11 @@ interface LogBuffer {
   markerCount: number;
 }
 
+interface SourceResumeCursor {
+  timestamp: string;
+  frameCounts: Map<string, number>;
+}
+
 const POD_COLORS = ['#7aa2f7', '#9ece6a', '#e0af68', '#f7768e', '#bb9af7', '#7dcfff', '#ff9e64', '#73daca'];
 const MAX_ENTRIES = 20_000;
 const MAX_RECONNECT_ATTEMPTS = 8;
@@ -195,6 +200,40 @@ function workloadPreferenceKey(ctx: string, namespace: string, kind: NonNullable
 
 function sourceKey(pod: string, container: string): string {
   return `${pod}/${container}`;
+}
+
+function consumeReplayFrame(
+  replayCursors: Map<string, SourceResumeCursor>,
+  source: string,
+  timestamp: string,
+  line: string,
+): boolean {
+  const cursor = replayCursors.get(source);
+  if (!cursor) return false;
+  if (cursor.timestamp !== timestamp) {
+    replayCursors.delete(source);
+    return false;
+  }
+  const remaining = cursor.frameCounts.get(line) ?? 0;
+  if (!remaining) return false;
+  if (remaining === 1) cursor.frameCounts.delete(line);
+  else cursor.frameCounts.set(line, remaining - 1);
+  if (!cursor.frameCounts.size) replayCursors.delete(source);
+  return true;
+}
+
+function recordResumeFrame(
+  cursors: Map<string, SourceResumeCursor>,
+  source: string,
+  timestamp: string,
+  line: string,
+): void {
+  const cursor = cursors.get(source);
+  if (cursor?.timestamp === timestamp) {
+    cursor.frameCounts.set(line, (cursor.frameCounts.get(line) ?? 0) + 1);
+    return;
+  }
+  cursors.set(source, { timestamp, frameCounts: new Map([[line, 1]]) });
 }
 
 function setsEqual<T>(left: ReadonlySet<T>, right: ReadonlySet<T>): boolean {
@@ -368,8 +407,7 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
     return new Set(available.length ? available : allContainerNames);
   });
   const bufferRef = useRef<LogLine[]>([]);
-  const lastTimestampBySourceRef = useRef(new Map<string, string>());
-  const lastFrameBySourceRef = useRef(new Map<string, { ts: string; line: string }>());
+  const resumeCursorBySourceRef = useRef(new Map<string, SourceResumeCursor>());
   const scrollRef = useRef<HTMLDivElement>(null);
   const findRef = useRef<HTMLInputElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
@@ -399,7 +437,17 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
     () => allContainerNames.filter((container) => enabledContainers.has(container)).join(','),
     [allContainerNames, enabledContainers],
   );
-  const selectedSourceCount = Math.max(1, enabledPods.size * Math.max(1, enabledContainers.size));
+  const selectedSourceCount = useMemo(() => {
+    if (!allContainerNames.length) return Math.max(1, enabledPods.size);
+    let count = 0;
+    for (const source of sources) {
+      if (!enabledPods.has(source.pod)) continue;
+      for (const container of source.containers) {
+        if (enabledContainers.has(container)) count++;
+      }
+    }
+    return Math.max(1, count);
+  }, [allContainerNames.length, enabledContainers, enabledPods, sources]);
 
   const flushBuffered = useCallback(() => {
     if (!bufferRef.current.length) return;
@@ -431,10 +479,22 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
 
     const connect = () => {
       if (disposed) return;
-      const resumeAt = Object.fromEntries(lastTimestampBySourceRef.current);
+      const resumeAt = Object.fromEntries(
+        [...resumeCursorBySourceRef.current].map(([key, cursor]) => [key, cursor.timestamp]),
+      );
+      const replayCursors = new Map(
+        [...resumeCursorBySourceRef.current].map(([key, cursor]) => [
+          key,
+          { timestamp: cursor.timestamp, frameCounts: new Map(cursor.frameCounts) },
+        ]),
+      );
+      const requestedSinceSeconds =
+        modeParams.tailLines !== undefined ? undefined : (modeParams.sinceSeconds ?? tab.sinceSeconds);
+      const combinedTailLines =
+        modeParams.tailLines ?? (requestedSinceSeconds !== undefined ? MAX_ENTRIES : undefined);
       const requestedTailLines =
-        modeParams.tailLines !== undefined
-          ? Math.max(1, Math.floor(modeParams.tailLines / selectedSourceCount))
+        combinedTailLines !== undefined
+          ? Math.max(1, Math.floor(combinedTailLines / selectedSourceCount))
           : modeParams.tail
             ? (tab.tailLines ?? defaultTailLines)
             : undefined;
@@ -446,7 +506,7 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
         previous: modeParams.previous ?? false,
         follow: modeParams.follow,
         tailLines: requestedTailLines,
-        sinceSeconds: modeParams.tailLines !== undefined ? undefined : (modeParams.sinceSeconds ?? tab.sinceSeconds),
+        sinceSeconds: requestedSinceSeconds,
         resumeAt: Object.keys(resumeAt).length ? JSON.stringify(resumeAt) : undefined,
       }));
       let opened = false;
@@ -466,11 +526,9 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
           const msg = JSON.parse(ev.data as string) as LogServerMessage;
           if (msg.op === 'line') {
             const key = sourceKey(msg.pod, msg.container);
-            const lastFrame = lastFrameBySourceRef.current.get(key);
-            if (msg.ts && lastFrame?.ts === msg.ts && lastFrame.line === msg.line) return;
             if (msg.ts) {
-              lastTimestampBySourceRef.current.set(key, msg.ts);
-              lastFrameBySourceRef.current.set(key, { ts: msg.ts, line: msg.line });
+              if (consumeReplayFrame(replayCursors, key, msg.ts, msg.line)) return;
+              recordResumeFrame(resumeCursorBySourceRef.current, key, msg.ts, msg.line);
             }
             bufferRef.current.push({ kind: 'line', pod: msg.pod, container: msg.container, ts: msg.ts, line: msg.line, receivedAt: Date.now() });
           } else if (msg.op === 'pod-status' && msg.state === 'error') {
@@ -667,8 +725,7 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
 
   const changeTimeMode = (next: LogTimeMode) => {
     bufferRef.current = [];
-    lastTimestampBySourceRef.current.clear();
-    lastFrameBySourceRef.current.clear();
+    resumeCursorBySourceRef.current.clear();
     setLogBuffer({ entries: [], markerCount: 0 });
     setFollow(paramsForMode(next).follow);
     setTimeMode(next);

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -76,7 +76,7 @@ export interface RowActionMenuProps {
   onClose: () => void;
 }
 
-const LOG_TARGET_KINDS = new Set<string>(['Pod', 'Deployment', 'ReplicaSet', 'StatefulSet', 'DaemonSet', 'Service']);
+const LOG_TARGET_KINDS = new Set<string>(['Pod', 'Deployment', 'ReplicaSet', 'StatefulSet', 'DaemonSet', 'Service', 'Job']);
 
 export function isLogTargetKind(kind: string): kind is LogTargetKind {
   return LOG_TARGET_KINDS.has(kind);
@@ -92,13 +92,14 @@ async function openLogsForTarget(target: RowActionTarget, addTab: (tab: DockTab)
   if (!namespace) throw new Error(`${kind} has no namespace`);
   const { pods } = await resolveLogTargetPods({ ctx, group: target.group, version: target.version, plural: target.plural, kind: actionKind, namespace, name });
   if (!pods.length) throw new Error(`No pods found for ${actionKind} ${namespace}/${name}`);
-  const byNamespace = new Map<string, string[]>();
+  const byNamespace = new Map<string, typeof pods>();
   for (const pod of pods) {
-    const names = byNamespace.get(pod.namespace);
-    if (names) names.push(pod.name);
-    else byNamespace.set(pod.namespace, [pod.name]);
+    const namespacePods = byNamespace.get(pod.namespace);
+    if (namespacePods) namespacePods.push(pod);
+    else byNamespace.set(pod.namespace, [pod]);
   }
-  for (const [ns, podNames] of byNamespace) {
+  for (const [ns, namespacePods] of byNamespace) {
+    const podNames = namespacePods.map((pod) => pod.name);
     addTab({
       kind: 'logs',
       id: dockTabId(),
@@ -106,6 +107,8 @@ async function openLogsForTarget(target: RowActionTarget, addTab: (tab: DockTab)
       ctx,
       namespace: ns,
       pods: podNames,
+      sources: namespacePods.map((pod) => ({ pod: pod.name, containers: pod.containers })),
+      target: { kind: actionKind, name },
       follow: true,
     });
   }

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -37,6 +37,7 @@ import { useNavigationStore } from '../state/navigation.js';
 import { usePaneActive } from '../layout/pane-context.js';
 import { isTextEntryTarget } from '../text-entry.js';
 import { addLabelTerm } from '../label-selector.js';
+import { podContainerNames } from '../kube-display.js';
 
 /**
  * Renderless bridge between this page's URL params and the shared detail
@@ -654,6 +655,7 @@ export function ResourceListPage() {
                       ctx: ctx!,
                       namespace: namespace ?? '',
                       pods: rows.map((r) => r.obj.metadata.name),
+                      sources: rows.map((r) => ({ pod: r.obj.metadata.name, containers: podContainerNames(r.obj) })),
                       follow: true,
                       tailLines: 500,
                     });

--- a/client/src/state/dock.ts
+++ b/client/src/state/dock.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { LogTargetKind } from '@kubus/shared';
 import { useDetailStore } from './detail.js';
 
 export interface TerminalTab {
@@ -26,6 +27,8 @@ export interface LogsTab {
   ctx: string;
   namespace: string;
   pods: string[];
+  sources?: Array<{ pod: string; containers: string[] }>;
+  target?: { kind: LogTargetKind; name: string };
   container?: string;
   follow?: boolean;
   tailLines?: number;

--- a/client/src/state/log-prefs.ts
+++ b/client/src/state/log-prefs.ts
@@ -8,10 +8,12 @@ interface LogPrefsState {
   wrap: boolean;
   tsMode: TsMode;
   highlight: boolean;
+  enabledContainersByWorkload: Record<string, string[]>;
   setWrap: (wrap: boolean) => void;
   cycleTsMode: () => void;
   setTsMode: (tsMode: TsMode) => void;
   setHighlight: (highlight: boolean) => void;
+  rememberEnabledContainers: (workloadKey: string, containers: string[]) => void;
 }
 
 const TS_CYCLE: Record<TsMode, TsMode> = { off: 'local', local: 'utc', utc: 'off' };
@@ -22,11 +24,28 @@ export const useLogPrefsStore = create<LogPrefsState>()(
       wrap: false,
       tsMode: 'off',
       highlight: true,
+      enabledContainersByWorkload: {},
       setWrap: (wrap) => set({ wrap }),
       cycleTsMode: () => set((s) => ({ tsMode: TS_CYCLE[s.tsMode] })),
       setTsMode: (tsMode) => set({ tsMode }),
       setHighlight: (highlight) => set({ highlight }),
+      rememberEnabledContainers: (workloadKey, containers) =>
+        set((s) => ({
+          enabledContainersByWorkload: {
+            ...s.enabledContainersByWorkload,
+            [workloadKey]: containers,
+          },
+        })),
     }),
-    { name: 'kubus-log-prefs', version: 0, storage: createJSONStorage(() => kubusStateStorage) },
+    {
+      name: 'kubus-log-prefs',
+      version: 1,
+      storage: createJSONStorage(() => kubusStateStorage),
+      migrate: (persisted, version) => {
+        const state = persisted as Partial<LogPrefsState>;
+        if (version === 0) return { ...state, enabledContainersByWorkload: {} };
+        return state;
+      },
+    },
   ),
 );

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "KUBUS_DEV=1 tsx watch --clear-screen=false src/index.ts",
     "build": "tsc",
-    "test": "node --test test/helm-regressions.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "typecheck": "tsc --noEmit",
     "start": "node dist/index.js"
   },

--- a/server/src/routes/detail.ts
+++ b/server/src/routes/detail.ts
@@ -50,6 +50,10 @@ async function resolveLogTargetPods(handle: ClusterHandle, target: KubeObject, k
   }
 
   const selector = selectorToString((target.spec as { selector?: LabelSelector } | undefined)?.selector);
+  if (kind === 'Job') {
+    const pods = await listPods(handle, namespace, selector);
+    return pods.filter((pod) => owns(pod, target.metadata.uid));
+  }
   if (!selector) return [];
 
   if (kind === 'Deployment') {

--- a/server/src/ws/logs-socket.ts
+++ b/server/src/ws/logs-socket.ts
@@ -1,13 +1,29 @@
 import { Writable } from 'node:stream';
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { WebSocket } from 'ws';
-import type { LogServerMessage } from '@kubus/shared';
+import { LOG_SOCKET_COMPLETE_CODE, LOG_SOCKET_NO_STREAMS_CODE, type LogServerMessage } from '@kubus/shared';
 import type { AppContext } from '../app.js';
 import { podContainers } from '../kube/actions.js';
 
+type StreamResult = 'ended' | 'error';
+
+function containerHasTerminated(pod: unknown, container: string): boolean {
+  const status = (pod as {
+    status?: {
+      containerStatuses?: Array<{ name?: string; state?: { terminated?: unknown } }>;
+      initContainerStatuses?: Array<{ name?: string; state?: { terminated?: unknown } }>;
+    };
+  } | undefined)?.status;
+  return [...(status?.containerStatuses ?? []), ...(status?.initContainerStatuses ?? [])].some(
+    (entry) => entry.name === container && entry.state?.terminated !== undefined,
+  );
+}
+
 /**
  * One socket per log session. Query params:
- *   ctx, namespace, pods (comma-separated), container ('' = all containers),
+ *   ctx, namespace, pods (comma-separated), containers (comma-separated),
+ *   container (legacy singular selection; '' = all containers), resumeAt
+ *   (JSON object keyed by "pod/container" with RFC3339 timestamps),
  *   follow, tailLines, sinceSeconds, previous, timestamps are parsed per session.
  * The server fans IN multiple pod/container streams and forwards each line
  * as a JSON frame tagged with its origin.
@@ -19,88 +35,170 @@ export function registerLogsSocket(app: FastifyInstance, ctx: AppContext): void 
     const namespace = q.namespace ?? '';
     const pods = (q.pods ?? '').split(',').filter(Boolean);
     const container = q.container || undefined;
+    const selectedContainers = q.containers !== undefined
+      ? new Set(q.containers.split(',').filter(Boolean))
+      : container
+        ? new Set([container])
+        : undefined;
     const follow = q.follow !== 'false';
     const tailLines = q.tailLines !== undefined ? Number(q.tailLines) : undefined;
     const sinceSeconds = q.sinceSeconds ? Number(q.sinceSeconds) : undefined;
     const previous = q.previous === 'true';
+    const resumeAt: Record<string, string> = {};
+    if (q.resumeAt) {
+      try {
+        const parsed = JSON.parse(q.resumeAt) as unknown;
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          for (const [key, value] of Object.entries(parsed)) {
+            if (typeof value === 'string' && Number.isFinite(Date.parse(value))) resumeAt[key] = value;
+          }
+        }
+      } catch {
+        // A malformed cursor should not prevent a fresh stream.
+      }
+    }
 
     const send = (msg: LogServerMessage) => {
       if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(msg));
     };
 
     const aborts: AbortController[] = [];
+    const sinks = new Set<Writable>();
     let closed = false;
+    let closing = false;
 
-    const streamOne = async (pod: string, containerName: string) => {
+    const closeSocket = (code: number, reason: string) => {
+      if (closed || closing || socket.readyState !== socket.OPEN) return;
+      closing = true;
+      socket.close(code, reason);
+    };
+
+    const streamOne = async (pod: string, containerName: string): Promise<StreamResult> => {
       // Line-splitter writable that forwards tagged frames.
       let buffer = '';
-      const sink = new Writable({
+      let settled = false;
+      let settle!: (result: StreamResult) => void;
+      const completion = new Promise<StreamResult>((resolve) => {
+        settle = resolve;
+      });
+      let sink: Writable;
+      const complete = (result: StreamResult) => {
+        if (settled) return;
+        settled = true;
+        sinks.delete(sink);
+        settle(result);
+      };
+      const forwardLine = (raw: string) => {
+        if (!raw) return;
+        // With timestamps: "2026-01-02T03:04:05.000000000Z the line"
+        const space = raw.indexOf(' ');
+        const ts = space > 0 ? raw.slice(0, space) : undefined;
+        const line = space > 0 ? raw.slice(space + 1) : raw;
+        send({ op: 'line', pod, container: containerName, ts, line });
+      };
+      sink = new Writable({
         write(chunk: Buffer, _enc, cb) {
           buffer += chunk.toString('utf8');
           let nl: number;
           while ((nl = buffer.indexOf('\n')) >= 0) {
             const raw = buffer.slice(0, nl);
             buffer = buffer.slice(nl + 1);
-            if (!raw) continue;
-            // With timestamps: "2026-01-02T03:04:05.000000000Z the line"
-            const space = raw.indexOf(' ');
-            const ts = space > 0 ? raw.slice(0, space) : undefined;
-            const line = space > 0 ? raw.slice(space + 1) : raw;
-            send({ op: 'line', pod, container: containerName, ts, line });
+            forwardLine(raw);
           }
           cb();
         },
         final(cb) {
-          if (buffer) send({ op: 'line', pod, container: containerName, line: buffer });
+          forwardLine(buffer);
           send({ op: 'pod-status', pod, container: containerName, state: 'ended' });
+          complete('ended');
           cb();
         },
+        destroy(_err, cb) {
+          complete('ended');
+          cb();
+        },
+      });
+      sinks.add(sink);
+      sink.on('unpipe', () => {
+        queueMicrotask(() => {
+          if (settled || closed) return;
+          send({ op: 'pod-status', pod, container: containerName, state: 'error', message: 'Upstream log stream closed before completion' });
+          complete('error');
+        });
       });
 
       try {
         const handle = ctx.clusters.get(ctxName);
+        const sinceTime = resumeAt[`${pod}/${containerName}`];
         send({ op: 'pod-status', pod, container: containerName, state: 'streaming' });
         const abort = await handle.makeLog().log(namespace, pod, containerName, sink, {
           follow,
-          tailLines: tailLines !== undefined && Number.isFinite(tailLines) ? tailLines : undefined,
-          sinceSeconds: sinceSeconds !== undefined && Number.isFinite(sinceSeconds) ? sinceSeconds : undefined,
+          tailLines: !sinceTime && tailLines !== undefined && Number.isFinite(tailLines) ? tailLines : undefined,
+          sinceSeconds: !sinceTime && sinceSeconds !== undefined && Number.isFinite(sinceSeconds) ? sinceSeconds : undefined,
+          sinceTime,
           previous,
           timestamps: true,
         });
-        aborts.push(abort);
+        if (closed) abort.abort();
+        else aborts.push(abort);
+        return await completion;
       } catch (err) {
         send({ op: 'pod-status', pod, container: containerName, state: 'error', message: err instanceof Error ? err.message : String(err) });
+        sink.destroy();
+        return 'error';
       }
     };
 
     void (async () => {
       try {
         const handle = ctx.clusters.get(ctxName);
+        const streams: Array<Promise<StreamResult>> = [];
         await Promise.all(pods.map(async (pod) => {
-          if (closed) return;
-          let containers: string[];
-          if (container) {
-            containers = [container];
-          } else {
-            // Resolve all containers from the pod spec.
-            const podObj = await handle.core.readNamespacedPod({ name: pod, namespace }).catch(() => undefined);
-            if (closed) return;
-            containers = podObj ? podContainers(podObj as never) : [''];
-            if (!containers.length) containers = [''];
+          if (closed || closing) return;
+          // Resolve the pod spec even for a multi-container selection so names
+          // that do not exist on this particular replica are ignored.
+          const podObj = await handle.core.readNamespacedPod({ name: pod, namespace }).catch(() => undefined);
+          if (closed || closing) return;
+          let containers = podObj ? podContainers(podObj as never) : selectedContainers ? [...selectedContainers] : [''];
+          if (selectedContainers) containers = containers.filter((name) => selectedContainers.has(name));
+          if (!containers.length) {
+            send({ op: 'pod-status', pod, container: '', state: 'error', message: 'No selected containers are available in this pod' });
+            return;
           }
           for (const c of containers) {
-            void streamOne(pod, c || '');
+            const containerName = c || '';
+            const retryOnFinish = follow && !containerHasTerminated(podObj, containerName);
+            streams.push(
+              streamOne(pod, containerName).then((result) => {
+                if (retryOnFinish) {
+                  closeSocket(1011, result === 'error' ? 'upstream log stream failed' : 'upstream log stream ended');
+                }
+                return result;
+              }),
+            );
           }
         }));
+        if (!streams.length) {
+          closeSocket(LOG_SOCKET_NO_STREAMS_CODE, 'no log streams available');
+          return;
+        }
+        const results = await Promise.all(streams);
+        if (results.every((result) => result === 'error')) {
+          closeSocket(LOG_SOCKET_NO_STREAMS_CODE, 'all log streams failed');
+        } else {
+          closeSocket(LOG_SOCKET_COMPLETE_CODE, 'log session complete');
+        }
       } catch (err) {
         send({ op: 'pod-status', pod: '', container: '', state: 'error', message: err instanceof Error ? err.message : String(err) });
-        socket.close();
+        closeSocket(1011, 'log session failed');
       }
     })();
 
     socket.on('close', () => {
       closed = true;
       for (const abort of aborts) abort.abort();
+      for (const sink of sinks) sink.destroy();
+      sinks.clear();
     });
   });
 }

--- a/server/test/logs.test.mjs
+++ b/server/test/logs.test.mjs
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import { LOG_SOCKET_COMPLETE_CODE } from '@kubus/shared';
+import { registerDetailRoutes } from '../dist/routes/detail.js';
+import { registerLogsSocket } from '../dist/ws/logs-socket.js';
+
+function routeCollector() {
+  const routes = new Map();
+  return {
+    routes,
+    app: {
+      get(path, optionsOrHandler, handler) {
+        routes.set(path, handler ?? optionsOrHandler);
+      },
+    },
+  };
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('timed out waiting for asynchronous log setup');
+}
+
+void test('Job log targets contain only Pods directly owned by the Job', async () => {
+  const { app, routes } = routeCollector();
+  const target = {
+    apiVersion: 'batch/v1',
+    kind: 'Job',
+    metadata: { name: 'report', namespace: 'ops', uid: 'job-uid' },
+    spec: { selector: { matchLabels: { 'batch.kubernetes.io/controller-uid': 'job-uid' } } },
+  };
+  const ownedPod = {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'report-abc',
+      namespace: 'ops',
+      ownerReferences: [{ apiVersion: 'batch/v1', kind: 'Job', name: 'report', uid: 'job-uid', controller: true }],
+    },
+    spec: { containers: [{ name: 'worker' }], initContainers: [{ name: 'setup' }] },
+  };
+  const unrelatedPod = {
+    ...ownedPod,
+    metadata: {
+      ...ownedPod.metadata,
+      name: 'other-abc',
+      ownerReferences: [{ apiVersion: 'batch/v1', kind: 'Job', name: 'other', uid: 'other-uid', controller: true }],
+    },
+  };
+  const jsonCalls = [];
+  const handle = {
+    raw: {
+      async json(path) {
+        jsonCalls.push(path);
+        return jsonCalls.length === 1 ? target : { items: [unrelatedPod, ownedPod] };
+      },
+    },
+  };
+  registerDetailRoutes(app, { clusters: { get: () => handle } });
+
+  const handler = routes.get('/api/contexts/:ctx/detail/log-target-pods');
+  const response = await handler(
+    {
+      params: { ctx: 'dev' },
+      query: { group: 'batch', version: 'v1', plural: 'jobs', kind: 'Job', namespace: 'ops', name: 'report' },
+    },
+    {},
+  );
+
+  assert.deepEqual(response, {
+    pods: [{ name: 'report-abc', namespace: 'ops', containers: ['worker', 'setup'] }],
+  });
+  assert.match(jsonCalls[1], /labelSelector=batch\.kubernetes\.io%2Fcontroller-uid%3Djob-uid/);
+});
+
+class FakeSocket extends EventEmitter {
+  OPEN = 1;
+  readyState = this.OPEN;
+  sent = [];
+  closeCalls = [];
+
+  send(frame) {
+    this.sent.push(JSON.parse(frame));
+  }
+
+  close(code = 1000, reason = '') {
+    if (this.readyState !== this.OPEN) return;
+    this.closeCalls.push({ code, reason });
+    this.readyState = 3;
+    this.emit('close', code, Buffer.from(reason));
+  }
+}
+
+void test('log sockets stream selected containers and resume each source from its timestamp', async () => {
+  const { app, routes } = routeCollector();
+  const calls = [];
+  const controllers = [];
+  const handle = {
+    core: {
+      async readNamespacedPod() {
+        return { spec: { containers: [{ name: 'app' }, { name: 'sidecar' }] } };
+      },
+    },
+    makeLog() {
+      return {
+        async log(namespace, pod, container, sink, options) {
+          calls.push({ namespace, pod, container, options });
+          // No trailing newline exercises the stream finalizer's timestamp parser.
+          sink.end(Buffer.from('2026-01-02T03:04:06.000000000Z resumed line'));
+          const controller = new AbortController();
+          controllers.push(controller);
+          return controller;
+        },
+      };
+    },
+  };
+  registerLogsSocket(app, { clusters: { get: () => handle } });
+
+  const socket = new FakeSocket();
+  const handler = routes.get('/ws/logs');
+  handler(socket, {
+    query: {
+      ctx: 'dev',
+      namespace: 'ops',
+      pods: 'api-0',
+      containers: 'app',
+      follow: 'true',
+      tailLines: '500',
+      sinceSeconds: '600',
+      resumeAt: JSON.stringify({ 'api-0/app': '2026-01-02T03:04:05.000000000Z' }),
+    },
+  });
+  await waitFor(() => calls.length === 1 && socket.sent.some((message) => message.op === 'line') && socket.closeCalls.length === 1);
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], {
+    namespace: 'ops',
+    pod: 'api-0',
+    container: 'app',
+    options: {
+      follow: true,
+      tailLines: undefined,
+      sinceSeconds: undefined,
+      sinceTime: '2026-01-02T03:04:05.000000000Z',
+      previous: false,
+      timestamps: true,
+    },
+  });
+  assert.deepEqual(socket.sent.find((message) => message.op === 'line'), {
+    op: 'line',
+    pod: 'api-0',
+    container: 'app',
+    ts: '2026-01-02T03:04:06.000000000Z',
+    line: 'resumed line',
+  });
+
+  assert.deepEqual(socket.closeCalls, [{ code: 1011, reason: 'upstream log stream ended' }]);
+  assert.equal(controllers[0].signal.aborted, true);
+});
+
+void test('completed containers close a follow session without requesting a retry', async () => {
+  const { app, routes } = routeCollector();
+  const controllers = [];
+  const handle = {
+    core: {
+      async readNamespacedPod() {
+        return {
+          spec: { containers: [{ name: 'worker' }] },
+          status: {
+            containerStatuses: [{ name: 'worker', state: { terminated: { exitCode: 0 } } }],
+          },
+        };
+      },
+    },
+    makeLog() {
+      return {
+        async log(_namespace, _pod, _container, sink) {
+          sink.end(Buffer.from('2026-01-02T03:04:06.000000000Z complete'));
+          const controller = new AbortController();
+          controllers.push(controller);
+          return controller;
+        },
+      };
+    },
+  };
+  registerLogsSocket(app, { clusters: { get: () => handle } });
+
+  const socket = new FakeSocket();
+  routes.get('/ws/logs')(socket, {
+    query: {
+      ctx: 'dev',
+      namespace: 'ops',
+      pods: 'job-abc',
+      containers: 'worker',
+      follow: 'true',
+    },
+  });
+  await waitFor(() => socket.closeCalls.length === 1);
+
+  assert.deepEqual(socket.closeCalls, [{ code: LOG_SOCKET_COMPLETE_CODE, reason: 'log session complete' }]);
+  assert.equal(controllers[0].signal.aborted, true);
+});
+
+void test('an interrupted live upstream stream closes the socket for retry', async () => {
+  const { app, routes } = routeCollector();
+  const handle = {
+    core: {
+      async readNamespacedPod() {
+        return {
+          spec: { containers: [{ name: 'app' }] },
+          status: {
+            containerStatuses: [{ name: 'app', state: { running: { startedAt: '2026-01-02T03:04:05Z' } } }],
+          },
+        };
+      },
+    },
+    makeLog() {
+      return {
+        async log(_namespace, _pod, _container, sink) {
+          queueMicrotask(() => sink.emit('unpipe'));
+          return new AbortController();
+        },
+      };
+    },
+  };
+  registerLogsSocket(app, { clusters: { get: () => handle } });
+
+  const socket = new FakeSocket();
+  routes.get('/ws/logs')(socket, {
+    query: {
+      ctx: 'dev',
+      namespace: 'ops',
+      pods: 'api-0',
+      containers: 'app',
+      follow: 'true',
+    },
+  });
+  await waitFor(() => socket.closeCalls.length === 1);
+
+  assert.deepEqual(socket.closeCalls, [{ code: 1011, reason: 'upstream log stream failed' }]);
+  assert.equal(socket.sent.some((message) => message.op === 'pod-status' && message.state === 'error'), true);
+});

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -470,7 +470,11 @@ export interface SecretTlsResponse {
 
 // ---- Logs ----
 
-export type LogTargetKind = 'Pod' | 'Deployment' | 'ReplicaSet' | 'StatefulSet' | 'DaemonSet' | 'Service';
+/** Application close codes used by the logs WebSocket. */
+export const LOG_SOCKET_COMPLETE_CODE = 4000;
+export const LOG_SOCKET_NO_STREAMS_CODE = 4001;
+
+export type LogTargetKind = 'Pod' | 'Deployment' | 'ReplicaSet' | 'StatefulSet' | 'DaemonSet' | 'Service' | 'Job';
 
 export interface LogTargetPod {
   name: string;


### PR DESCRIPTION
## Summary

- add Job log actions and source-aware pod/container selection
- recover live streams after unexpected upstream interruption
- treat completed containers and historical sessions as finished
- bound historical sessions to a combined last 20,000 entries
- batch selector changes behind Apply and reduce hot-path rendering work
- persist container choices per workload

## Why

The log viewer could stop while still reporting an active connection, unbounded history could transfer far more data than the UI retained, and every selector click restarted the full workload stream.

## Impact

Log sessions now recover from unexpected upstream interruption, completed and historical sessions report completion accurately, source changes create one replacement session, and large workloads avoid unnecessary transfer and rendering work.