### PR TITLE
Namespace-aware overview with unified workload health and certificate expiry

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -17,6 +17,8 @@ import type {
   MetricsServerStatus,
   MetricsServerUninstallResult,
   MetricsSnapshot,
+  NamespaceOverview,
+  PodResourcesResponse,
   ClusterNetworkSummary,
   NetworkAgentInstallResult,
   NetworkAgentStatus,
@@ -873,6 +875,31 @@ export function useOverview(ctx: string) {
     queryKey: ['overview', ctx],
     queryFn: () => apiFetch<ClusterOverview>(`/api/contexts/${encodeURIComponent(ctx)}/overview`),
     refetchInterval: useRefetchInterval(10_000),
+  });
+}
+
+/** Live pod usage joined with requests/limits — thresholds are applied client-side. */
+export function usePodResources(ctx: string, namespace?: string) {
+  return useQuery({
+    queryKey: ['pod-resources', ctx, namespace ?? ''],
+    queryFn: () => {
+      const q = namespace ? `?namespace=${encodeURIComponent(namespace)}` : '';
+      return apiFetch<PodResourcesResponse>(`/api/contexts/${encodeURIComponent(ctx)}/overview/pod-resources${q}`);
+    },
+    refetchInterval: useRefetchInterval(20_000),
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** Namespace-scoped overview for the global namespace selection. */
+export function useNamespaceOverview(ctx: string, namespaces: string[]) {
+  const key = [...namespaces].sort().join(',');
+  return useQuery({
+    queryKey: ['namespace-overview', ctx, key],
+    queryFn: () => apiFetch<NamespaceOverview>(`/api/contexts/${encodeURIComponent(ctx)}/namespace-overview?namespaces=${encodeURIComponent(key)}`),
+    enabled: !!ctx && namespaces.length > 0,
+    refetchInterval: useRefetchInterval(10_000),
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/client/src/components/AgeCell.tsx
+++ b/client/src/components/AgeCell.tsx
@@ -25,10 +25,7 @@ function getTick(): number {
   return tickCount;
 }
 
-export function formatAge(timestamp: string | undefined): string {
-  if (!timestamp) return '';
-  const ms = Date.now() - Date.parse(timestamp);
-  if (Number.isNaN(ms) || ms < 0) return '0s';
+function formatDuration(ms: number): string {
   const s = Math.floor(ms / 1000);
   if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);
@@ -41,6 +38,24 @@ export function formatAge(timestamp: string | undefined): string {
   return y >= 1 ? `${y}y${Math.floor((d % 365) / 30)}mo` : `${Math.floor(d / 30)}mo`;
 }
 
+export function formatAge(timestamp: string | undefined): string {
+  if (!timestamp) return '';
+  const ms = Date.now() - Date.parse(timestamp);
+  if (Number.isNaN(ms)) return '0s';
+  // Future timestamps (expiry dates in CRD columns) used to clamp to "0s".
+  if (ms < -30_000) return `in ${formatDuration(-ms)}`;
+  return formatDuration(Math.max(0, ms));
+}
+
+/** Direction-aware relative time: "5d ago" for the past, "in 47d" for the future. */
+export function formatRelative(timestamp: string | undefined): string {
+  if (!timestamp) return '';
+  const diff = Date.parse(timestamp) - Date.now();
+  if (Number.isNaN(diff)) return '';
+  if (Math.abs(diff) < 30_000) return 'now';
+  return diff > 0 ? `in ${formatDuration(diff)}` : `${formatDuration(-diff)} ago`;
+}
+
 /** Live-ticking relative age. */
 export function AgeCell({ timestamp, variant = 'body2' }: { timestamp?: string; variant?: TypographyProps['variant'] }) {
   useSyncExternalStore(subscribeTick, getTick);
@@ -49,6 +64,22 @@ export function AgeCell({ timestamp, variant = 'body2' }: { timestamp?: string; 
     <Tooltip title={new Date(timestamp).toLocaleString()}>
       <Typography variant={variant} component="span">
         {formatAge(timestamp)}
+      </Typography>
+    </Tooltip>
+  );
+}
+
+/**
+ * Live-ticking relative time that handles future timestamps (certificate
+ * expiry, renewal times) — includes the "ago"/"in" direction itself.
+ */
+export function RelativeTimeCell({ timestamp, variant = 'body2' }: { timestamp?: string; variant?: TypographyProps['variant'] }) {
+  useSyncExternalStore(subscribeTick, getTick);
+  if (!timestamp) return null;
+  return (
+    <Tooltip title={new Date(timestamp).toLocaleString()}>
+      <Typography variant={variant} component="span">
+        {formatRelative(timestamp)}
       </Typography>
     </Tooltip>
   );

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -28,6 +28,7 @@ import { PodDetail } from './detail/PodDetail.js';
 import { NodeDetail } from './detail/NodeDetail.js';
 import { ServiceDetail } from './detail/ServiceDetail.js';
 import { SecretDetail } from './detail/SecretDetail.js';
+import { CertificateDetail } from './detail/CertificateDetail.js';
 import { CrdDetail, CrdSchemaDetail, crdVersions } from './detail/CrdDetail.js';
 import { CustomResourceDetail } from './detail/CustomResourceDetail.js';
 import { RolloutHistory } from './detail/RolloutHistory.js';
@@ -331,6 +332,11 @@ function OverviewForKind({ kind, obj, ctx, crd, version }: { kind: string | unde
     case 'CustomResourceDefinition':
       return <CrdDetail obj={obj} ctx={ctx} />;
     default:
+      // cert-manager Certificates get an expiry/renewal headline the printer
+      // columns don't surface.
+      if (crd?.metadata.name === 'certificates.cert-manager.io') {
+        return <CertificateDetail obj={obj} ctx={ctx} crd={crd} version={version} />;
+      }
       // Custom resources with their backing CRD loaded get a status-aware
       // overview driven by the CRD's printer columns.
       return crd ? <CustomResourceDetail obj={obj} ctx={ctx} crd={crd} version={version} /> : <GenericDetail obj={obj} ctx={ctx} />;

--- a/client/src/components/detail/CertificateDetail.tsx
+++ b/client/src/components/detail/CertificateDetail.tsx
@@ -1,0 +1,55 @@
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import type { KubeObject } from '@kubus/shared';
+import { RelativeTimeCell } from '../AgeCell.js';
+import { CustomResourceDetail } from './CustomResourceDetail.js';
+
+const WARN_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+interface CertStatus {
+  notAfter?: string;
+  renewalTime?: string;
+  conditions?: Array<{ type?: string; status?: string }>;
+}
+
+/**
+ * cert-manager Certificate overview: the expiry/renewal headline the printer
+ * columns don't surface, on top of the generic CR detail.
+ */
+export function CertificateDetail({ obj, ctx, crd, version }: { obj: KubeObject; ctx: string; crd: KubeObject; version: string }) {
+  const status = (obj.status ?? {}) as CertStatus;
+  const now = Date.now();
+  const notAfter = status.notAfter ? Date.parse(status.notAfter) : Number.NaN;
+  const renewal = status.renewalTime ? Date.parse(status.renewalTime) : Number.NaN;
+  const expired = !Number.isNaN(notAfter) && notAfter <= now;
+  const expiringSoon = !Number.isNaN(notAfter) && !expired && notAfter - now < WARN_WINDOW_MS;
+  const renewalOverdue = !Number.isNaN(renewal) && renewal <= now && !expired;
+  const severity = expired ? 'error' : expiringSoon || renewalOverdue ? 'warning' : 'success';
+
+  return (
+    <>
+      {status.notAfter && (
+        <Box sx={{ px: 2, pt: 2 }}>
+          <Alert severity={severity} variant="outlined" sx={{ alignItems: 'center' }}>
+            <Typography variant="body2" component="span" sx={{ fontWeight: 600 }}>
+              {expired ? 'Expired ' : 'Expires '}
+              <RelativeTimeCell timestamp={status.notAfter} />
+            </Typography>{' '}
+            <Typography variant="body2" component="span" color="text.secondary">
+              ({new Date(status.notAfter).toLocaleString()})
+            </Typography>
+            {status.renewalTime && !expired && (
+              <Typography variant="body2" component="span" sx={{ display: 'block' }}>
+                {renewalOverdue ? 'Renewal was due ' : 'Renews '}
+                <RelativeTimeCell timestamp={status.renewalTime} />
+                {renewalOverdue && ' — check the issuer, cert-manager has not renewed on schedule.'}
+              </Typography>
+            )}
+          </Alert>
+        </Box>
+      )}
+      <CustomResourceDetail obj={obj} ctx={ctx} crd={crd} version={version} />
+    </>
+  );
+}

--- a/client/src/components/detail/CustomResourceDetail.tsx
+++ b/client/src/components/detail/CustomResourceDetail.tsx
@@ -8,7 +8,7 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import type { KubeObject } from '@kubus/shared';
 import { evalPrinterColumnPath } from '@kubus/shared';
-import { AgeCell } from '../AgeCell.js';
+import { RelativeTimeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
 import { statusLikeName } from '../../kube-display.js';
 import { ConditionsTable, KeyValueSection, MetadataSection } from './GenericDetail.js';
@@ -113,11 +113,9 @@ function StatusRowValue({ row }: { row: StatusRow }) {
     );
   }
   if ((row.date || ISO_TIMESTAMP_RE.test(row.value)) && ISO_TIMESTAMP_RE.test(row.value)) {
-    return (
-      <>
-        <AgeCell timestamp={row.value} /> ago
-      </>
-    );
+    // Direction-aware: expiry/renewal fields are future timestamps and used
+    // to collapse into a meaningless "0s ago".
+    return <RelativeTimeCell timestamp={row.value} />;
   }
   if (statusLikeName(row.label)) return <StatusChip status={row.value} />;
   return <Typography variant="body2">{row.value}</Typography>;

--- a/client/src/components/overview/CertExpiryCard.tsx
+++ b/client/src/components/overview/CertExpiryCard.tsx
@@ -1,0 +1,84 @@
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router';
+import type { OverviewCertificates } from '@kubus/shared';
+import { RelativeTimeCell } from '../AgeCell.js';
+import { ProblemCard, kindListPath } from './cards.js';
+
+const API_SERVER_WARN_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Certificates that are expired or expire within 30 days (cert-manager
+ * Certificates + standalone TLS Secrets), plus the API server serving cert
+ * when it enters the window.
+ */
+export function CertExpiryCard({ ctx, certificates, hideNamespace }: { ctx: string; certificates: OverviewCertificates; hideNamespace?: boolean }) {
+  const navigate = useNavigate();
+  const apiServerSoon =
+    !!certificates.apiServerNotAfter && Date.parse(certificates.apiServerNotAfter) - Date.now() < API_SERVER_WARN_MS;
+  if (certificates.expiring.length === 0 && !apiServerSoon) return null;
+
+  return (
+    <ProblemCard title="Certificates expiring soon">
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Certificate</TableCell>
+            <TableCell>Kind</TableCell>
+            <TableCell>Expires</TableCell>
+            <TableCell>Date</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {apiServerSoon && certificates.apiServerNotAfter && (
+            <TableRow>
+              <TableCell>API server serving certificate</TableCell>
+              <TableCell>—</TableCell>
+              <TableCell>
+                <ExpiryCell notAfter={certificates.apiServerNotAfter} />
+              </TableCell>
+              <TableCell>{new Date(certificates.apiServerNotAfter).toLocaleDateString()}</TableCell>
+            </TableRow>
+          )}
+          {certificates.expiring.map((c) => (
+            <TableRow
+              key={`${c.plural}/${c.namespace}/${c.name}`}
+              hover
+              sx={{ cursor: 'pointer' }}
+              onClick={() => navigate(kindListPath(c, { sel: { ctx, namespace: c.namespace || undefined, name: c.name } }))}
+            >
+              <TableCell>
+                {c.namespace && !hideNamespace ? `${c.namespace}/` : ''}
+                {c.name}
+              </TableCell>
+              <TableCell>{c.source === 'cert-manager' ? 'Certificate' : 'TLS Secret'}</TableCell>
+              <TableCell>
+                <ExpiryCell notAfter={c.notAfter} />
+              </TableCell>
+              <TableCell>{new Date(c.notAfter).toLocaleDateString()}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {!apiServerSoon && certificates.apiServerNotAfter && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          API server certificate expires <RelativeTimeCell timestamp={certificates.apiServerNotAfter} variant="caption" />.
+        </Typography>
+      )}
+    </ProblemCard>
+  );
+}
+
+function ExpiryCell({ notAfter }: { notAfter: string }) {
+  const expired = Date.parse(notAfter) <= Date.now();
+  return (
+    <Typography variant="body2" component="span" sx={{ fontWeight: 600, color: expired ? 'error.main' : 'warning.main' }}>
+      {expired ? 'expired ' : ''}
+      <RelativeTimeCell timestamp={notAfter} />
+    </Typography>
+  );
+}

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -1,0 +1,181 @@
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import LinearProgress from '@mui/material/LinearProgress';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router';
+import { pluralLabel, type NamespaceInventoryEntry, type NamespaceQuotaStatus } from '@kubus/shared';
+import { useNamespaceOverview } from '../../api/queries.js';
+import { StatusChip } from '../StatusChip.js';
+import { usageColor } from '../UsageMeter.js';
+import { FailingPodsCard, ProblemCard, WarningEventsCard, kindListPath } from './cards.js';
+import { OperatorSection } from './OperatorSection.js';
+import { PodUsagePanels } from './PodUsagePanels.js';
+import { WorkloadHealthSection } from './WorkloadHealthSection.js';
+
+/**
+ * The overview body while the global namespace filter is active: a
+ * `kubectl get all -n`-style inventory (builtins + installed popular CRDs),
+ * unified workload health, operator rollups, quota usage, pod usage panels,
+ * failing pods and warning events — all scoped to the selected namespaces.
+ * List links inherit the same global filter.
+ */
+export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; namespaces: string[] }) {
+  const { data, isLoading, error } = useNamespaceOverview(ctx, namespaces);
+  const single = namespaces.length === 1;
+
+  return (
+    <>
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1.5 }}>
+        <Typography variant="body2" color="text.secondary">
+          Scoped to {single ? 'namespace' : 'namespaces'}{' '}
+          <Typography component="span" variant="body2" sx={{ fontWeight: 600, color: 'text.primary' }}>
+            {namespaces.join(', ')}
+          </Typography>
+        </Typography>
+        {data?.status && <StatusChip status={data.status} />}
+      </Stack>
+
+      {isLoading && !data && (
+        <Stack spacing={1.5}>
+          <Skeleton variant="rounded" height={110} />
+          <Skeleton variant="rounded" height={180} />
+        </Stack>
+      )}
+      {error && <Alert severity="error">{error.message}</Alert>}
+
+      {data && (
+        <>
+          <InventoryCard inventory={data.inventory} />
+
+          <WorkloadHealthSection ctx={ctx} health={data.workloadHealth} issues={data.issues} scoped hideNamespace={single} />
+
+          <OperatorSection ctx={ctx} operators={data.operators} scoped />
+
+          {data.quotas.length > 0 && <QuotasCard quotas={data.quotas} />}
+
+          <PodUsagePanels ctx={ctx} namespaces={namespaces} />
+
+          <FailingPodsCard ctx={ctx} pods={data.failingPods} hideNamespace={single} />
+
+          <WarningEventsCard events={data.warningEvents} />
+
+          {data.issues.length === 0 && data.failingPods.length === 0 && data.warningEvents.length === 0 && (
+            <Alert severity="success" variant="outlined">
+              No problems detected in {single ? 'this namespace' : 'these namespaces'}.
+            </Alert>
+          )}
+        </>
+      )}
+    </>
+  );
+}
+
+function InventoryCard({ inventory }: { inventory: NamespaceInventoryEntry[] }) {
+  const navigate = useNavigate();
+  const builtin = inventory.filter((e) => !e.custom);
+  const custom = inventory.filter((e) => e.custom);
+  return (
+    <ProblemCard title="Inventory">
+      <InventoryTiles entries={builtin} onOpen={(e) => navigate(kindListPath(e))} />
+      {custom.length > 0 && (
+        <>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1.25, mb: 0.5 }}>
+            Custom resources
+          </Typography>
+          <InventoryTiles entries={custom} onOpen={(e) => navigate(kindListPath(e))} />
+        </>
+      )}
+    </ProblemCard>
+  );
+}
+
+function InventoryTiles({ entries, onOpen }: { entries: NamespaceInventoryEntry[]; onOpen: (e: NamespaceInventoryEntry) => void }) {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+      {entries.map((e) => {
+        const warn = (e.unhealthy ?? 0) > 0;
+        return (
+          <ButtonBase
+            key={`${e.group}/${e.plural}`}
+            onClick={() => onOpen(e)}
+            title={e.group ? `${e.group}/${e.version}` : e.version}
+            sx={{
+              px: 1.25,
+              py: 0.75,
+              border: 1,
+              borderColor: warn ? 'warning.main' : 'divider',
+              borderRadius: 1.5,
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 0.75,
+              opacity: e.total === 0 && !warn ? 0.65 : 1,
+              '&:hover': { bgcolor: 'action.hover', borderColor: warn ? 'warning.main' : 'primary.main', opacity: 1 },
+            }}
+          >
+            <Typography variant="caption" color="text.secondary">
+              {pluralLabel(e.kind)}
+            </Typography>
+            {e.unavailable ? (
+              <Typography variant="body2" color="text.disabled" title="Resource API unavailable on this cluster">
+                —
+              </Typography>
+            ) : (
+              <>
+                <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                  {e.total}
+                </Typography>
+                {warn && (
+                  <Typography variant="body2" sx={{ fontWeight: 700, color: 'warning.main' }}>
+                    {e.unhealthy} unhealthy
+                  </Typography>
+                )}
+              </>
+            )}
+          </ButtonBase>
+        );
+      })}
+    </Box>
+  );
+}
+
+function QuotasCard({ quotas }: { quotas: NamespaceQuotaStatus[] }) {
+  return (
+    <ProblemCard title="Resource quotas">
+      <Stack spacing={1.5}>
+        {quotas.map((q) => (
+          <Box key={q.name}>
+            <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+              {q.name}
+            </Typography>
+            <Stack spacing={0.5}>
+              {q.resources.map((r) => (
+                <Box key={r.resource} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <Typography variant="caption" sx={{ width: 220, flexShrink: 0 }} noWrap title={r.resource}>
+                    {r.resource}
+                  </Typography>
+                  {r.pct !== undefined ? (
+                    <LinearProgress
+                      variant="determinate"
+                      value={Math.min(100, r.pct)}
+                      color={usageColor(r.pct)}
+                      sx={{ flex: 1, height: 6, borderRadius: 3 }}
+                    />
+                  ) : (
+                    <Box sx={{ flex: 1 }} />
+                  )}
+                  <Typography variant="caption" color="text.secondary" sx={{ width: 150, textAlign: 'right' }} noWrap>
+                    {r.used} / {r.hard}
+                    {r.pct !== undefined ? ` (${r.pct.toFixed(0)}%)` : ''}
+                  </Typography>
+                </Box>
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    </ProblemCard>
+  );
+}

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -26,6 +26,14 @@ import { WorkloadHealthSection } from './WorkloadHealthSection.js';
 export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; namespaces: string[] }) {
   const { data, isLoading, error } = useNamespaceOverview(ctx, namespaces);
   const single = namespaces.length === 1;
+  // The success alert must agree with every problem card above it.
+  const healthy =
+    !!data &&
+    data.issues.length === 0 &&
+    data.failingPods.length === 0 &&
+    data.warningEvents.length === 0 &&
+    data.certificates.expiring.length === 0 &&
+    data.operators.every((op) => op.resources.every((r) => r.issues.length === 0 && r.ready >= r.total));
 
   return (
     <>
@@ -65,7 +73,7 @@ export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; nam
 
           <WarningEventsCard events={data.warningEvents} />
 
-          {data.issues.length === 0 && data.failingPods.length === 0 && data.warningEvents.length === 0 && (
+          {healthy && (
             <Alert severity="success" variant="outlined">
               No problems detected in {single ? 'this namespace' : 'these namespaces'}.
             </Alert>

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -10,6 +10,7 @@ import { pluralLabel, type NamespaceInventoryEntry, type NamespaceQuotaStatus } 
 import { useNamespaceOverview } from '../../api/queries.js';
 import { StatusChip } from '../StatusChip.js';
 import { usageColor } from '../UsageMeter.js';
+import { CertExpiryCard } from './CertExpiryCard.js';
 import { FailingPodsCard, ProblemCard, WarningEventsCard, kindListPath } from './cards.js';
 import { OperatorSection } from './OperatorSection.js';
 import { PodUsagePanels } from './PodUsagePanels.js';
@@ -53,6 +54,8 @@ export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; nam
           <WorkloadHealthSection ctx={ctx} health={data.workloadHealth} issues={data.issues} scoped hideNamespace={single} />
 
           <OperatorSection ctx={ctx} operators={data.operators} scoped />
+
+          <CertExpiryCard ctx={ctx} certificates={data.certificates} hideNamespace={single} />
 
           {data.quotas.length > 0 && <QuotasCard quotas={data.quotas} />}
 

--- a/client/src/components/overview/OperatorSection.tsx
+++ b/client/src/components/overview/OperatorSection.tsx
@@ -13,7 +13,7 @@ import { ProblemCard, kindListPath } from './cards.js';
  */
 export function OperatorSection({ ctx, operators, scoped }: { ctx: string; operators: OperatorRollup[]; scoped?: boolean }) {
   const navigate = useNavigate();
-  const shown = scoped ? operators.filter((op) => op.resources.some((r) => r.total > 0)) : operators;
+  const shown = scoped ? operators.filter((op) => op.resources.some((r) => r.total > 0 || r.unavailable)) : operators;
   if (shown.length === 0) return null;
 
   return (
@@ -26,11 +26,12 @@ export function OperatorSection({ ctx, operators, scoped }: { ctx: string; opera
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, flex: 1, minWidth: 0 }}>
               {op.resources.map((r) => {
-                const degraded = r.ready < r.total;
+                const degraded = !r.unavailable && r.ready < r.total;
                 return (
                   <ButtonBase
                     key={r.plural}
                     onClick={() => navigate(kindListPath(r))}
+                    title={r.unavailable ? 'Resource API unavailable on this cluster' : undefined}
                     sx={{
                       px: 1,
                       py: 0.5,
@@ -44,8 +45,8 @@ export function OperatorSection({ ctx, operators, scoped }: { ctx: string; opera
                     <Typography variant="caption" color="text.secondary">
                       {pluralLabel(r.kind)}
                     </Typography>
-                    <Typography variant="caption" sx={{ fontWeight: 700, color: degraded ? 'warning.main' : undefined }}>
-                      {r.ready}/{r.total}
+                    <Typography variant="caption" sx={{ fontWeight: 700, color: degraded ? 'warning.main' : r.unavailable ? 'text.disabled' : undefined }}>
+                      {r.unavailable ? 'unavailable' : `${r.ready}/${r.total}`}
                     </Typography>
                   </ButtonBase>
                 );

--- a/client/src/components/overview/OperatorSection.tsx
+++ b/client/src/components/overview/OperatorSection.tsx
@@ -1,0 +1,72 @@
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router';
+import { pluralLabel, type OperatorRollup } from '@kubus/shared';
+import { ProblemCard, kindListPath } from './cards.js';
+
+/**
+ * Installed-operator rollups (cert-manager, Argo, Flux, KEDA, Karpenter):
+ * ready/total per resource kind, with the not-ready instances as chips.
+ */
+export function OperatorSection({ ctx, operators, scoped }: { ctx: string; operators: OperatorRollup[]; scoped?: boolean }) {
+  const navigate = useNavigate();
+  const shown = scoped ? operators.filter((op) => op.resources.some((r) => r.total > 0)) : operators;
+  if (shown.length === 0) return null;
+
+  return (
+    <ProblemCard title="Operators">
+      <Stack spacing={1}>
+        {shown.map((op) => (
+          <Box key={op.id} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, flexWrap: 'wrap' }}>
+            <Typography variant="body2" sx={{ fontWeight: 600, width: 110, flexShrink: 0, pt: 0.5 }}>
+              {op.name}
+            </Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75, flex: 1, minWidth: 0 }}>
+              {op.resources.map((r) => {
+                const degraded = r.ready < r.total;
+                return (
+                  <ButtonBase
+                    key={r.plural}
+                    onClick={() => navigate(kindListPath(r))}
+                    sx={{
+                      px: 1,
+                      py: 0.5,
+                      border: 1,
+                      borderColor: degraded ? 'warning.main' : 'divider',
+                      borderRadius: 1.5,
+                      gap: 0.5,
+                      '&:hover': { bgcolor: 'action.hover', borderColor: degraded ? 'warning.main' : 'primary.main' },
+                    }}
+                  >
+                    <Typography variant="caption" color="text.secondary">
+                      {pluralLabel(r.kind)}
+                    </Typography>
+                    <Typography variant="caption" sx={{ fontWeight: 700, color: degraded ? 'warning.main' : undefined }}>
+                      {r.ready}/{r.total}
+                    </Typography>
+                  </ButtonBase>
+                );
+              })}
+              {op.resources.flatMap((r) =>
+                r.issues.map((issue) => (
+                  <Chip
+                    key={`${r.plural}/${issue.namespace}/${issue.name}`}
+                    size="small"
+                    color="warning"
+                    variant="outlined"
+                    label={`${issue.namespace ? `${issue.namespace}/` : ''}${issue.name}: ${issue.reason ?? 'NotReady'}`}
+                    title={issue.message}
+                    onClick={() => navigate(kindListPath(r, { sel: { ctx, namespace: issue.namespace || undefined, name: issue.name } }))}
+                  />
+                )),
+              )}
+            </Box>
+          </Box>
+        ))}
+      </Stack>
+    </ProblemCard>
+  );
+}

--- a/client/src/components/overview/PodUsagePanels.tsx
+++ b/client/src/components/overview/PodUsagePanels.tsx
@@ -1,0 +1,204 @@
+import { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router';
+import type { PodResourceUsage } from '@kubus/shared';
+import { usePodResources } from '../../api/queries.js';
+import { useUiPrefsStore } from '../../state/prefs.js';
+import { UsageMeter } from '../UsageMeter.js';
+import { formatBytes, formatCpu } from '../format.js';
+import { ProblemCard, kindListPath } from './cards.js';
+
+const HIGH_USAGE_OPTIONS = [70, 80, 90];
+const UNDER_REQUESTED_OPTIONS = [1.5, 2, 3];
+const MAX_ROWS = 12;
+// Ignore near-idle pods so tiny absolute overshoots don't flood the panels.
+const CPU_FLOOR_MILLI = 20;
+const MEM_FLOOR_BYTES = 32 * 1024 * 1024;
+
+function highUsageScore(p: PodResourceUsage, pct: number): number {
+  const cpu = p.cpuLimitMilli > 0 ? (p.cpuUsageMilli / p.cpuLimitMilli) * 100 : 0;
+  const mem = p.memLimitBytes > 0 ? (p.memUsageBytes / p.memLimitBytes) * 100 : 0;
+  const score = Math.max(cpu, mem);
+  return score >= pct ? score : 0;
+}
+
+function underRequestedScore(p: PodResourceUsage, factor: number): number {
+  const cpu = p.cpuRequestMilli > 0 && p.cpuUsageMilli >= CPU_FLOOR_MILLI ? p.cpuUsageMilli / p.cpuRequestMilli : 0;
+  const mem = p.memRequestBytes > 0 && p.memUsageBytes >= MEM_FLOOR_BYTES ? p.memUsageBytes / p.memRequestBytes : 0;
+  const score = Math.max(cpu, mem);
+  return score >= factor ? score : 0;
+}
+
+/**
+ * Threshold-driven pod panels: usage close to limits, and usage far above
+ * requests (right-size candidates). Thresholds persist in UI prefs; filtering
+ * is client-side so changing them never refetches.
+ */
+export function PodUsagePanels({ ctx, namespaces }: { ctx: string; namespaces?: string[] }) {
+  const single = namespaces?.length === 1 ? namespaces[0] : undefined;
+  const { data } = usePodResources(ctx, single);
+  const highUsagePct = useUiPrefsStore((s) => s.highUsagePct);
+  const underRequestedFactor = useUiPrefsStore((s) => s.underRequestedFactor);
+  const setPrefs = useUiPrefsStore((s) => s.set);
+
+  const pods = useMemo(() => {
+    const all = data?.pods ?? [];
+    if (!namespaces?.length || single) return all;
+    const scope = new Set(namespaces);
+    return all.filter((p) => scope.has(p.namespace));
+  }, [data, namespaces, single]);
+
+  const highUsage = useMemo(
+    () =>
+      pods
+        .map((p) => ({ p, score: highUsageScore(p, highUsagePct) }))
+        .filter((e) => e.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, MAX_ROWS),
+    [pods, highUsagePct],
+  );
+  const underRequested = useMemo(
+    () =>
+      pods
+        .map((p) => ({ p, score: underRequestedScore(p, underRequestedFactor) }))
+        .filter((e) => e.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, MAX_ROWS),
+    [pods, underRequestedFactor],
+  );
+
+  if (!data?.available) return null;
+
+  return (
+    <Grid container spacing={1.5} sx={{ mb: 0 }}>
+      <Grid size={{ xs: 12, lg: 6 }}>
+        <PodPanel
+          ctx={ctx}
+          hideNamespace={!!single}
+          title="High usage pods"
+          empty={`No pods above ${highUsagePct}% of their limits.`}
+          entries={highUsage}
+          maxOf={(p) => ({ cpu: p.cpuLimitMilli, mem: p.memLimitBytes })}
+          maxHint="limit"
+          action={
+            <Select
+              size="small"
+              value={highUsagePct}
+              onChange={(e) => setPrefs({ highUsagePct: Number(e.target.value) })}
+              sx={{ fontSize: 13, '& .MuiSelect-select': { py: 0.25 } }}
+            >
+              {HIGH_USAGE_OPTIONS.map((v) => (
+                <MenuItem key={v} value={v}>
+                  ≥ {v}% of limit
+                </MenuItem>
+              ))}
+            </Select>
+          }
+        />
+      </Grid>
+      <Grid size={{ xs: 12, lg: 6 }}>
+        <PodPanel
+          ctx={ctx}
+          hideNamespace={!!single}
+          title="Under-requested pods"
+          empty={`No pods using ≥ ${underRequestedFactor}× their requests.`}
+          entries={underRequested}
+          maxOf={(p) => ({ cpu: p.cpuRequestMilli, mem: p.memRequestBytes })}
+          maxHint="requested"
+          action={
+            <Select
+              size="small"
+              value={underRequestedFactor}
+              onChange={(e) => setPrefs({ underRequestedFactor: Number(e.target.value) })}
+              sx={{ fontSize: 13, '& .MuiSelect-select': { py: 0.25 } }}
+            >
+              {UNDER_REQUESTED_OPTIONS.map((v) => (
+                <MenuItem key={v} value={v}>
+                  ≥ {v}× requests
+                </MenuItem>
+              ))}
+            </Select>
+          }
+        />
+      </Grid>
+    </Grid>
+  );
+}
+
+function PodPanel({
+  ctx,
+  hideNamespace,
+  title,
+  empty,
+  entries,
+  maxOf,
+  maxHint,
+  action,
+}: {
+  ctx: string;
+  hideNamespace?: boolean;
+  title: string;
+  empty: string;
+  entries: Array<{ p: PodResourceUsage }>;
+  maxOf: (p: PodResourceUsage) => { cpu: number; mem: number };
+  maxHint: string;
+  action: React.ReactNode;
+}) {
+  const navigate = useNavigate();
+  return (
+    <ProblemCard title={title} action={action}>
+      {entries.length === 0 && (
+        <Typography variant="body2" color="text.secondary">
+          {empty}
+        </Typography>
+      )}
+      {entries.length > 0 && (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Pod</TableCell>
+              <TableCell sx={{ width: '26%' }}>CPU</TableCell>
+              <TableCell sx={{ width: '26%' }}>Memory</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {entries.map(({ p }) => {
+              const max = maxOf(p);
+              return (
+                <TableRow
+                  key={`${p.namespace}/${p.name}`}
+                  hover
+                  sx={{ cursor: 'pointer' }}
+                  onClick={() =>
+                    navigate(kindListPath({ group: '', version: 'v1', plural: 'pods' }, { sel: { ctx, namespace: p.namespace, name: p.name } }))
+                  }
+                >
+                  <TableCell sx={{ maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <Box component="span" title={`${p.namespace}/${p.name}`}>
+                      {hideNamespace ? p.name : `${p.namespace}/${p.name}`}
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <UsageMeter value={p.cpuUsageMilli} max={max.cpu || undefined} format={formatCpu} maxHint={maxHint} placeholder />
+                  </TableCell>
+                  <TableCell>
+                    <UsageMeter value={p.memUsageBytes} max={max.mem || undefined} format={formatBytes} maxHint={maxHint} placeholder />
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </ProblemCard>
+  );
+}

--- a/client/src/components/overview/WorkloadHealthSection.tsx
+++ b/client/src/components/overview/WorkloadHealthSection.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import ButtonBase from '@mui/material/ButtonBase';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router';
+import { pluralLabel, type OverviewKindHealth, type OverviewWorkloadIssue } from '@kubus/shared';
+import { StatusChip } from '../StatusChip.js';
+import { ProblemCard, kindListPath } from './cards.js';
+
+/**
+ * Unified workload health: one tile per kind (Deployments … ResourceQuotas)
+ * linking to its list, plus the issues behind the unhealthy counts. List
+ * links inherit the global namespace filter, so a scoped overview lands on
+ * equally scoped lists.
+ */
+export function WorkloadHealthSection({
+  ctx,
+  health,
+  issues,
+  scoped,
+  hideNamespace,
+}: {
+  ctx: string;
+  health: OverviewKindHealth[];
+  issues: OverviewWorkloadIssue[];
+  /** Namespace-scoped view: hide kinds with nothing in scope. */
+  scoped?: boolean;
+  /** Single-namespace scope: the prefix would repeat on every row. */
+  hideNamespace?: boolean;
+}) {
+  const navigate = useNavigate();
+  const gvrByKind = useMemo(() => new Map(health.map((h) => [h.kind, h])), [health]);
+  // Scoped view: the inventory card already shows per-kind counts, so this
+  // section reduces to the issue list.
+  if (scoped && issues.length === 0) return null;
+
+  return (
+    <ProblemCard title="Workload health">
+      {!scoped && (
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        {health.map((h) => (
+          <ButtonBase
+            key={h.kind}
+            onClick={() => navigate(kindListPath(h))}
+            sx={{
+              px: 1.25,
+              py: 0.75,
+              border: 1,
+              borderColor: h.unhealthy > 0 ? 'warning.main' : 'divider',
+              borderRadius: 1.5,
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 0.75,
+              '&:hover': { bgcolor: 'action.hover', borderColor: h.unhealthy > 0 ? 'warning.main' : 'primary.main' },
+            }}
+          >
+            <Typography variant="caption" color="text.secondary">
+              {pluralLabel(h.kind)}
+            </Typography>
+            {h.unavailable ? (
+              <Typography variant="body2" color="text.disabled" title="Resource API unavailable on this cluster">
+                —
+              </Typography>
+            ) : (
+              <>
+                <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                  {h.total}
+                </Typography>
+                {h.unhealthy > 0 && (
+                  <Typography variant="body2" sx={{ fontWeight: 700, color: 'warning.main' }}>
+                    {h.unhealthy} unhealthy
+                  </Typography>
+                )}
+              </>
+            )}
+          </ButtonBase>
+        ))}
+      </Box>
+      )}
+      {issues.length > 0 && (
+        <Table size="small" sx={{ mt: scoped ? 0 : 1 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Kind</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Status</TableCell>
+              <TableCell>Ready</TableCell>
+              <TableCell>Detail</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {issues.map((w) => {
+              const gvr = gvrByKind.get(w.kind);
+              return (
+                <TableRow
+                  key={`${w.kind}/${w.namespace}/${w.name}`}
+                  hover={!!gvr}
+                  sx={{ cursor: gvr ? 'pointer' : 'default' }}
+                  onClick={() => gvr && navigate(kindListPath(gvr, { sel: { ctx, namespace: w.namespace || undefined, name: w.name } }))}
+                >
+                  <TableCell>{w.kind}</TableCell>
+                  <TableCell>
+                    {w.namespace && !hideNamespace ? `${w.namespace}/` : ''}
+                    {w.name}
+                  </TableCell>
+                  <TableCell>
+                    <StatusChip status={w.reason ?? 'Unhealthy'} />
+                  </TableCell>
+                  <TableCell>{w.ready !== undefined && w.desired !== undefined ? `${w.ready}/${w.desired}` : ''}</TableCell>
+                  <TableCell sx={{ maxWidth: 420, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={w.message}>
+                    {w.message ?? ''}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+    </ProblemCard>
+  );
+}

--- a/client/src/components/overview/cards.tsx
+++ b/client/src/components/overview/cards.tsx
@@ -1,0 +1,190 @@
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+import { alpha } from '@mui/material/styles';
+import { useNavigate } from 'react-router';
+import { groupToPath, type OverviewProblemPod, type OverviewWarningEvent } from '@kubus/shared';
+import { AgeCell } from '../AgeCell.js';
+import { StatusChip } from '../StatusChip.js';
+
+/** List-page path for a kind, optionally deep-linking a selection via ?sel=. */
+export function kindListPath(
+  gvr: { group: string; version: string; plural: string },
+  opts?: { sel?: { ctx: string; namespace?: string; name: string } },
+): string {
+  const params = new URLSearchParams();
+  if (opts?.sel) params.set('sel', `${opts.sel.ctx}|${opts.sel.namespace ?? ''}|${opts.sel.name}`);
+  const q = params.toString();
+  return `/r/${groupToPath(gvr.group)}/${gvr.version}/${gvr.plural}${q ? `?${q}` : ''}`;
+}
+
+export function FailingPodsCard({ ctx, pods, hideNamespace }: { ctx: string; pods: OverviewProblemPod[]; hideNamespace?: boolean }) {
+  const navigate = useNavigate();
+  if (pods.length === 0) return null;
+  return (
+    <ProblemCard title="Failing pods">
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Pod</TableCell>
+            <TableCell>Reason</TableCell>
+            <TableCell>Restarts</TableCell>
+            <TableCell>Message</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {pods.map((p) => (
+            <TableRow
+              key={`${p.namespace}/${p.name}`}
+              hover
+              sx={{ cursor: 'pointer' }}
+              onClick={() =>
+                navigate(kindListPath({ group: '', version: 'v1', plural: 'pods' }, { sel: { ctx, namespace: p.namespace || undefined, name: p.name } }))
+              }
+            >
+              <TableCell>{hideNamespace ? p.name : `${p.namespace}/${p.name}`}</TableCell>
+              <TableCell>
+                <StatusChip status={p.reason} />
+              </TableCell>
+              <TableCell>{p.restarts}</TableCell>
+              <TableCell sx={{ maxWidth: 400, overflow: 'hidden', textOverflow: 'ellipsis' }} title={p.message}>
+                {p.message ?? ''}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </ProblemCard>
+  );
+}
+
+export function WarningEventsCard({ events }: { events: OverviewWarningEvent[] }) {
+  if (events.length === 0) return null;
+  return (
+    <ProblemCard title="Warning events (1h)">
+      <Stack spacing={0.5}>
+        {events.slice(0, 15).map((e) => (
+          <Typography key={`${e.namespace}/${e.involvedKind}/${e.involvedName}/${e.reason}/${e.lastTimestamp ?? ''}/${e.message}`} variant="body2">
+            <Typography component="span" variant="body2" sx={{ color: 'warning.main', fontWeight: 600 }}>
+              {e.reason}
+            </Typography>
+            {e.count > 1 && (
+              <Typography component="span" variant="caption" sx={{ fontWeight: 600 }}>
+                {' '}({e.count}x)
+              </Typography>
+            )}{' '}
+            <Typography component="span" variant="caption" color="text.secondary">
+              <AgeCell timestamp={e.lastTimestamp} /> ago
+            </Typography>{' '}
+            — {e.involvedKind}/{e.namespace ? `${e.namespace}/` : ''}{e.involvedName}: {e.message}
+          </Typography>
+        ))}
+      </Stack>
+    </ProblemCard>
+  );
+}
+
+export function StatCard({
+  label,
+  value,
+  sub,
+  warn,
+  icon,
+  onClick,
+}: {
+  label: string;
+  value: number | string;
+  sub?: string;
+  warn?: boolean;
+  icon?: React.ReactElement;
+  onClick?: () => void;
+}) {
+  return (
+    <Grid size={{ xs: 6, sm: 4, md: 2 }}>
+      <Card
+        variant="outlined"
+        onClick={onClick}
+        role={onClick ? 'button' : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        onKeyDown={(event) => {
+          if (!onClick) return;
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick();
+          }
+        }}
+        sx={(theme) => ({
+          height: '100%',
+          cursor: onClick ? 'pointer' : 'default',
+          borderColor: warn ? 'warning.main' : undefined,
+          transition: 'border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease',
+          ...(onClick && {
+            '&:hover': {
+              borderColor: warn ? 'warning.main' : 'primary.main',
+              transform: 'translateY(-1px)',
+              boxShadow: `0 4px 14px ${alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.35 : 0.08)}`,
+            },
+          }),
+        })}
+      >
+        <CardContent sx={{ py: '12px !important', display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          {icon && (
+            <Box
+              sx={(theme) => {
+                const main = warn ? theme.palette.warning.main : theme.palette.primary.main;
+                return {
+                  width: 36,
+                  height: 36,
+                  borderRadius: 2,
+                  flexShrink: 0,
+                  display: 'grid',
+                  placeItems: 'center',
+                  color: main,
+                  bgcolor: alpha(main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
+                  '& svg': { fontSize: 20 },
+                };
+              }}
+            >
+              {icon}
+            </Box>
+          )}
+          <Box sx={{ minWidth: 0 }}>
+            <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
+              {label}
+            </Typography>
+            <Typography variant="h6" color={warn ? 'warning.main' : undefined} noWrap>
+              {value}
+              {sub && (
+                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
+                  {sub}
+                </Typography>
+              )}
+            </Typography>
+          </Box>
+        </CardContent>
+      </Card>
+    </Grid>
+  );
+}
+
+export function ProblemCard({ title, action, children }: { title: string; action?: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <Card variant="outlined" sx={{ mb: 2 }}>
+      <CardContent sx={{ py: 1.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1, gap: 1 }}>
+          <Typography variant="subtitle2">{title}</Typography>
+          {action}
+        </Box>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -11,13 +11,7 @@ import Grid from '@mui/material/Grid';
 import LinearProgress from '@mui/material/LinearProgress';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableHead from '@mui/material/TableHead';
-import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
-import { alpha } from '@mui/material/styles';
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
 import WorkspacesOutlinedIcon from '@mui/icons-material/WorkspacesOutlined';
 import ViewInArOutlinedIcon from '@mui/icons-material/ViewInArOutlined';
@@ -31,11 +25,14 @@ import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router';
 import { useContexts, useKubeconfigSettings, useNodeMetrics, useOverview } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
-import { AgeCell } from '../components/AgeCell.js';
 import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { InstallMetricsServerButton } from '../components/MetricsServerControls.js';
-import { StatusChip } from '../components/StatusChip.js';
 import { formatBytes, formatCpu } from '../components/format.js';
+import { FailingPodsCard, ProblemCard, StatCard, WarningEventsCard } from '../components/overview/cards.js';
+import { NamespaceOverviewSection } from '../components/overview/NamespaceOverviewSection.js';
+import { OperatorSection } from '../components/overview/OperatorSection.js';
+import { PodUsagePanels } from '../components/overview/PodUsagePanels.js';
+import { WorkloadHealthSection } from '../components/overview/WorkloadHealthSection.js';
 
 // Adding a cluster pulls the settings chunk (js-yaml); keep it lazy here.
 const AddClusterDialog = lazy(() => import('../components/settings/AddClusterDialog.js').then((m) => ({ default: m.AddClusterDialog })));
@@ -143,13 +140,25 @@ export function OverviewPage() {
 }
 
 function ClusterOverviewSection({ ctx }: { ctx: string }) {
+  // The global namespace filter scopes the whole overview: with namespaces
+  // selected in the nav this section becomes the namespace-level view.
+  const namespaces = useClustersStore((s) => s.namespaces);
+
+  return (
+    <Box>
+      <ClusterSectionHeader ctx={ctx} />
+      {namespaces.length > 0 ? <NamespaceOverviewSection ctx={ctx} namespaces={namespaces} /> : <WholeClusterSection ctx={ctx} />}
+    </Box>
+  );
+}
+
+function WholeClusterSection({ ctx }: { ctx: string }) {
   const { data, isLoading, error } = useOverview(ctx);
   const { data: nodeMetrics } = useNodeMetrics(ctx);
   const navigate = useNavigate();
 
   return (
-    <Box>
-      <ClusterSectionHeader ctx={ctx} />
+    <>
       {isLoading && <OverviewSkeleton />}
       {error && <Alert severity="error">{error.message}</Alert>}
       {data && (
@@ -212,52 +221,13 @@ function ClusterOverviewSection({ ctx }: { ctx: string }) {
 
           {data.counts.nodes > 0 && <NodeUsageCard ctx={ctx} nodeMetrics={nodeMetrics} />}
 
-          {data.failingPods.length > 0 && (
-            <ProblemCard title="Failing pods">
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Pod</TableCell>
-                    <TableCell>Reason</TableCell>
-                    <TableCell>Restarts</TableCell>
-                    <TableCell>Message</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {data.failingPods.map((p) => (
-                    <TableRow key={`${p.namespace}/${p.name}`} hover sx={{ cursor: 'pointer' }} onClick={() => navigate(`/r/core/v1/pods?sel=${ctx}|${p.namespace}|${p.name}`)}>
-                      <TableCell>
-                        {p.namespace}/{p.name}
-                      </TableCell>
-                      <TableCell>
-                        <StatusChip status={p.reason} />
-                      </TableCell>
-                      <TableCell>{p.restarts}</TableCell>
-                      <TableCell sx={{ maxWidth: 400, overflow: 'hidden', textOverflow: 'ellipsis' }} title={p.message}>
-                        {p.message ?? ''}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </ProblemCard>
-          )}
+          <WorkloadHealthSection ctx={ctx} health={data.workloadHealth} issues={data.unavailableWorkloads} />
 
-          {data.unavailableWorkloads.length > 0 && (
-            <ProblemCard title="Unavailable workloads">
-              <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 1 }}>
-                {data.unavailableWorkloads.map((w) => (
-                  <Chip
-                    key={`${w.namespace}/${w.name}`}
-                    label={`${w.namespace}/${w.name} ${w.ready}/${w.desired}`}
-                    color="warning"
-                    variant="outlined"
-                    onClick={() => navigate(`/r/apps/v1/deployments?sel=${ctx}|${w.namespace}|${w.name}`)}
-                  />
-                ))}
-              </Stack>
-            </ProblemCard>
-          )}
+          <OperatorSection ctx={ctx} operators={data.operators} />
+
+          <PodUsagePanels ctx={ctx} />
+
+          <FailingPodsCard ctx={ctx} pods={data.failingPods} />
 
           {data.recentRestarts.length > 0 && (
             <ProblemCard title="Recent restarts (1h)">
@@ -269,31 +239,7 @@ function ClusterOverviewSection({ ctx }: { ctx: string }) {
             </ProblemCard>
           )}
 
-          {data.warningEvents.length > 0 && (
-            <ProblemCard title="Warning events (1h)">
-              <Stack spacing={0.5}>
-                {data.warningEvents.slice(0, 15).map((e) => (
-                  <Typography
-                    key={`${e.namespace}/${e.involvedKind}/${e.involvedName}/${e.reason}/${e.lastTimestamp ?? ''}/${e.message}`}
-                    variant="body2"
-                  >
-                    <Typography component="span" variant="body2" sx={{ color: 'warning.main', fontWeight: 600 }}>
-                      {e.reason}
-                    </Typography>
-                    {e.count > 1 && (
-                      <Typography component="span" variant="caption" sx={{ fontWeight: 600 }}>
-                        {' '}({e.count}x)
-                      </Typography>
-                    )}{' '}
-                    <Typography component="span" variant="caption" color="text.secondary">
-                      <AgeCell timestamp={e.lastTimestamp} /> ago
-                    </Typography>{' '}
-                    — {e.involvedKind}/{e.namespace ? `${e.namespace}/` : ''}{e.involvedName}: {e.message}
-                  </Typography>
-                ))}
-              </Stack>
-            </ProblemCard>
-          )}
+          <WarningEventsCard events={data.warningEvents} />
 
           {data.failingPods.length === 0 && data.unavailableWorkloads.length === 0 && data.warningEvents.length === 0 && (
             <Alert severity="success" variant="outlined">
@@ -302,7 +248,7 @@ function ClusterOverviewSection({ ctx }: { ctx: string }) {
           )}
         </>
       )}
-    </Box>
+    </>
   );
 }
 
@@ -384,102 +330,6 @@ function NodeUsageCard({ ctx, nodeMetrics }: { ctx: string; nodeMetrics: ReturnT
             ))}
           </Stack>
         )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function StatCard({
-  label,
-  value,
-  sub,
-  warn,
-  icon,
-  onClick,
-}: {
-  label: string;
-  value: number | string;
-  sub?: string;
-  warn?: boolean;
-  icon?: React.ReactElement;
-  onClick?: () => void;
-}) {
-  return (
-    <Grid size={{ xs: 6, sm: 4, md: 2 }}>
-      <Card
-        variant="outlined"
-        onClick={onClick}
-        role={onClick ? 'button' : undefined}
-        tabIndex={onClick ? 0 : undefined}
-        onKeyDown={(event) => {
-          if (!onClick) return;
-          if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            onClick();
-          }
-        }}
-        sx={(theme) => ({
-          height: '100%',
-          cursor: onClick ? 'pointer' : 'default',
-          borderColor: warn ? 'warning.main' : undefined,
-          transition: 'border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease',
-          ...(onClick && {
-            '&:hover': {
-              borderColor: warn ? 'warning.main' : 'primary.main',
-              transform: 'translateY(-1px)',
-              boxShadow: `0 4px 14px ${alpha(theme.palette.common.black, theme.palette.mode === 'dark' ? 0.35 : 0.08)}`,
-            },
-          }),
-        })}
-      >
-        <CardContent sx={{ py: '12px !important', display: 'flex', alignItems: 'center', gap: 1.5 }}>
-          {icon && (
-            <Box
-              sx={(theme) => {
-                const main = warn ? theme.palette.warning.main : theme.palette.primary.main;
-                return {
-                  width: 36,
-                  height: 36,
-                  borderRadius: 2,
-                  flexShrink: 0,
-                  display: 'grid',
-                  placeItems: 'center',
-                  color: main,
-                  bgcolor: alpha(main, theme.palette.mode === 'dark' ? 0.14 : 0.08),
-                  '& svg': { fontSize: 20 },
-                };
-              }}
-            >
-              {icon}
-            </Box>
-          )}
-          <Box sx={{ minWidth: 0 }}>
-            <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
-              {label}
-            </Typography>
-            <Typography variant="h6" color={warn ? 'warning.main' : undefined} noWrap>
-              {value}
-              {sub && (
-                <Typography component="span" variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
-                  {sub}
-                </Typography>
-              )}
-            </Typography>
-          </Box>
-        </CardContent>
-      </Card>
-    </Grid>
-  );
-}
-
-function ProblemCard({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <Card variant="outlined" sx={{ mb: 2 }}>
-      <CardContent sx={{ py: 1.5 }}>
-        <Typography variant="subtitle2" sx={{ mb: 1 }}>
-          {title}
-        </Typography>
-        {children}
       </CardContent>
     </Card>
   );

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -256,11 +256,15 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
 
           <WarningEventsCard events={data.warningEvents} />
 
-          {data.failingPods.length === 0 && data.unavailableWorkloads.length === 0 && data.warningEvents.length === 0 && (
-            <Alert severity="success" variant="outlined">
-              No problems detected — all workloads healthy.
-            </Alert>
-          )}
+          {data.failingPods.length === 0 &&
+            data.unavailableWorkloads.length === 0 &&
+            data.warningEvents.length === 0 &&
+            data.certificates.expiring.length === 0 &&
+            data.operators.every((op) => op.resources.every((r) => r.issues.length === 0 && r.ready >= r.total)) && (
+              <Alert severity="success" variant="outlined">
+                No problems detected — all workloads healthy.
+              </Alert>
+            )}
         </>
       )}
     </>

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -21,6 +21,7 @@ import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
+import VerifiedUserOutlinedIcon from '@mui/icons-material/VerifiedUserOutlined';
 import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router';
 import { useContexts, useKubeconfigSettings, useNodeMetrics, useOverview } from '../api/queries.js';
@@ -28,6 +29,7 @@ import { useClustersStore } from '../state/clusters.js';
 import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { InstallMetricsServerButton } from '../components/MetricsServerControls.js';
 import { formatBytes, formatCpu } from '../components/format.js';
+import { CertExpiryCard } from '../components/overview/CertExpiryCard.js';
 import { FailingPodsCard, ProblemCard, StatCard, WarningEventsCard } from '../components/overview/cards.js';
 import { NamespaceOverviewSection } from '../components/overview/NamespaceOverviewSection.js';
 import { OperatorSection } from '../components/overview/OperatorSection.js';
@@ -204,6 +206,17 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
               icon={<Inventory2OutlinedIcon />}
             />
             <StatCard
+              label="TLS certificates"
+              value={data.certificates.expiring.length > 0 ? data.certificates.expiring.length : data.certificates.total}
+              sub={data.certificates.expiring.length > 0 ? 'expiring <30d' : 'tracked'}
+              warn={data.certificates.expiring.length > 0}
+              icon={<VerifiedUserOutlinedIcon />}
+              onClick={() => {
+                const certs = data.operators.find((o) => o.id === 'cert-manager')?.resources.find((r) => r.plural === 'certificates');
+                void navigate(certs ? `/r/${certs.group}/${certs.version}/${certs.plural}` : '/r/core/v1/secrets');
+              }}
+            />
+            <StatCard
               label="Failing pods"
               value={data.failingPods.length}
               warn={data.failingPods.length > 0}
@@ -224,6 +237,8 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
           <WorkloadHealthSection ctx={ctx} health={data.workloadHealth} issues={data.unavailableWorkloads} />
 
           <OperatorSection ctx={ctx} operators={data.operators} />
+
+          <CertExpiryCard ctx={ctx} certificates={data.certificates} />
 
           <PodUsagePanels ctx={ctx} />
 

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -23,6 +23,10 @@ interface UiPrefsState {
   protectByDefault: boolean;
   /** Nav rail collapsed to reclaim width (wide viewports only). */
   navCollapsed: boolean;
+  /** Overview "high usage" pod panel: usage ≥ this % of the limit. */
+  highUsagePct: number;
+  /** Overview "under-requested" pod panel: usage ≥ this multiple of the request. */
+  underRequestedFactor: number;
   /** User-resized column widths, keyed by table id then column field. */
   columnWidths: Record<string, Record<string, number>>;
   /** User-toggled column visibility models, keyed by table id then column field. */
@@ -59,6 +63,8 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       defaultShell: 'auto',
       protectByDefault: false,
       navCollapsed: false,
+      highUsagePct: 80,
+      underRequestedFactor: 2,
       columnWidths: {},
       columnVisibility: {},
       sortModels: {},

--- a/server/src/kube/cert-expiry.ts
+++ b/server/src/kube/cert-expiry.ts
@@ -53,6 +53,7 @@ export async function collectCertificates(handle: ClusterHandle, crds: KubeObjec
   };
 
   const certCrd = resolveCrd(new Map(crds.map((c) => [c.metadata.name, c])), 'certificates.cert-manager.io');
+  const collectedCerts = new Set<string>();
   if (certCrd) {
     const acquired = handle.watchers.acquire(certCrd.group, certCrd.version, certCrd.plural);
     try {
@@ -60,6 +61,7 @@ export async function collectCertificates(handle: ClusterHandle, crds: KubeObjec
       for (const cert of result.items) {
         if (!inScope(cert)) continue;
         total += 1;
+        collectedCerts.add(`${cert.metadata.namespace ?? ''}/${cert.metadata.name}`);
         const notAfter = (cert.status as { notAfter?: string } | undefined)?.notAfter;
         if (notAfter) {
           push({
@@ -86,9 +88,11 @@ export async function collectCertificates(handle: ClusterHandle, crds: KubeObjec
     secretsUnavailable = result.unavailable;
     for (const secret of result.items) {
       if ((secret as { type?: string }).type !== 'kubernetes.io/tls' || !inScope(secret)) continue;
-      // cert-manager stamps the secrets it manages — the Certificate entry
-      // above already covers those.
-      if (secret.metadata.annotations?.['cert-manager.io/certificate-name']) continue;
+      // cert-manager stamps the secrets it manages — skip only when the
+      // owning Certificate was actually collected above (RBAC may allow
+      // Secrets but deny Certificates; then the Secret is our only view).
+      const ownerCert = secret.metadata.annotations?.['cert-manager.io/certificate-name'];
+      if (ownerCert && collectedCerts.has(`${secret.metadata.namespace ?? ''}/${ownerCert}`)) continue;
       total += 1;
       const notAfter = tlsSecretNotAfter(secret);
       if (notAfter) {

--- a/server/src/kube/cert-expiry.ts
+++ b/server/src/kube/cert-expiry.ts
@@ -1,0 +1,160 @@
+import { X509Certificate } from 'node:crypto';
+import * as tls from 'node:tls';
+import type { CertExpiryEntry, KubeObject, OverviewCertificates } from '@kubus/shared';
+import type { ClusterHandle } from './cluster-manager.js';
+import { resolveCrd } from './operator-rollups.js';
+import { optionalItems } from './overview.js';
+
+const EXPIRY_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const API_SERVER_CERT_TTL_MS = 60 * 60 * 1000;
+const HANDSHAKE_TIMEOUT_MS = 3_000;
+
+/**
+ * notAfter per TLS secret, keyed by `uid@resourceVersion` so the x509 parse
+ * runs once per secret revision, not on every overview poll.
+ */
+const secretNotAfterCache = new Map<string, string | undefined>();
+const SECRET_CACHE_MAX = 10_000;
+
+function tlsSecretNotAfter(secret: KubeObject): string | undefined {
+  const key = `${secret.metadata.uid}@${secret.metadata.resourceVersion ?? ''}`;
+  if (secretNotAfterCache.has(key)) return secretNotAfterCache.get(key);
+  if (secretNotAfterCache.size > SECRET_CACHE_MAX) secretNotAfterCache.clear();
+  let notAfter: string | undefined;
+  try {
+    const b64 = (secret.data as Record<string, string> | undefined)?.['tls.crt'];
+    if (b64) {
+      const pem = Buffer.from(b64, 'base64').toString('utf8');
+      // The leaf certificate is the first block by convention.
+      const block = pem.match(/-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/)?.[0];
+      if (block) notAfter = new Date(new X509Certificate(block).validTo).toISOString();
+    }
+  } catch {
+    // Garbage in the secret — treat as unknown.
+  }
+  secretNotAfterCache.set(key, notAfter);
+  return notAfter;
+}
+
+/**
+ * Certificate expiry rollup: cert-manager Certificates (when the CRD is
+ * installed) plus kubernetes.io/tls Secrets, deduped so a cert-manager-owned
+ * secret doesn't count its Certificate twice.
+ */
+export async function collectCertificates(handle: ClusterHandle, crds: KubeObject[], namespaces?: ReadonlySet<string>): Promise<OverviewCertificates> {
+  const inScope = (o: KubeObject) => !namespaces || namespaces.has(o.metadata.namespace ?? '');
+  const now = Date.now();
+  const expiring: CertExpiryEntry[] = [];
+  let total = 0;
+
+  const push = (entry: CertExpiryEntry) => {
+    const t = Date.parse(entry.notAfter);
+    if (!Number.isNaN(t) && t - now < EXPIRY_WINDOW_MS) expiring.push(entry);
+  };
+
+  const certCrd = resolveCrd(new Map(crds.map((c) => [c.metadata.name, c])), 'certificates.cert-manager.io');
+  if (certCrd) {
+    const acquired = handle.watchers.acquire(certCrd.group, certCrd.version, certCrd.plural);
+    try {
+      const result = await optionalItems(acquired.watcher);
+      for (const cert of result.items) {
+        if (!inScope(cert)) continue;
+        total += 1;
+        const notAfter = (cert.status as { notAfter?: string } | undefined)?.notAfter;
+        if (notAfter) {
+          push({
+            source: 'cert-manager',
+            kind: certCrd.kind,
+            group: certCrd.group,
+            version: certCrd.version,
+            plural: certCrd.plural,
+            namespace: cert.metadata.namespace ?? '',
+            name: cert.metadata.name,
+            notAfter,
+          });
+        }
+      }
+    } finally {
+      acquired.release();
+    }
+  }
+
+  const secretsWatcher = handle.watchers.acquire('', 'v1', 'secrets');
+  let secretsUnavailable = false;
+  try {
+    const result = await optionalItems(secretsWatcher.watcher);
+    secretsUnavailable = result.unavailable;
+    for (const secret of result.items) {
+      if ((secret as { type?: string }).type !== 'kubernetes.io/tls' || !inScope(secret)) continue;
+      // cert-manager stamps the secrets it manages — the Certificate entry
+      // above already covers those.
+      if (secret.metadata.annotations?.['cert-manager.io/certificate-name']) continue;
+      total += 1;
+      const notAfter = tlsSecretNotAfter(secret);
+      if (notAfter) {
+        push({
+          source: 'tls-secret',
+          kind: 'Secret',
+          group: '',
+          version: 'v1',
+          plural: 'secrets',
+          namespace: secret.metadata.namespace ?? '',
+          name: secret.metadata.name,
+          notAfter,
+        });
+      }
+    }
+  } finally {
+    secretsWatcher.release();
+  }
+
+  expiring.sort((a, b) => a.notAfter.localeCompare(b.notAfter));
+  return { total, expiring, secretsUnavailable: secretsUnavailable || undefined };
+}
+
+const apiServerCertCache = new WeakMap<ClusterHandle, { at: number; value?: string }>();
+
+/**
+ * Expiry of the API server's serving certificate, read from a TLS handshake.
+ * Best-effort: proxied/tunneled clusters may not be directly reachable —
+ * then the overview simply omits it. Cached for an hour per handle.
+ */
+export async function apiServerCertNotAfter(handle: ClusterHandle): Promise<string | undefined> {
+  const cached = apiServerCertCache.get(handle);
+  if (cached && Date.now() - cached.at < API_SERVER_CERT_TTL_MS) return cached.value;
+
+  const server = handle.kc.getCurrentCluster()?.server;
+  let value: string | undefined;
+  if (server) {
+    try {
+      const url = new URL(server);
+      if (url.protocol === 'https:') {
+        value = await new Promise<string | undefined>((resolve) => {
+          const socket = tls.connect(
+            {
+              host: url.hostname,
+              port: Number(url.port || 443),
+              servername: url.hostname,
+              rejectUnauthorized: false,
+              timeout: HANDSHAKE_TIMEOUT_MS,
+            },
+            () => {
+              const cert = socket.getPeerCertificate();
+              socket.end();
+              resolve(cert?.valid_to ? new Date(cert.valid_to).toISOString() : undefined);
+            },
+          );
+          socket.on('timeout', () => {
+            socket.destroy();
+            resolve(undefined);
+          });
+          socket.on('error', () => resolve(undefined));
+        });
+      }
+    } catch {
+      value = undefined;
+    }
+  }
+  apiServerCertCache.set(handle, { at: Date.now(), value });
+  return value;
+}

--- a/server/src/kube/namespace-overview.ts
+++ b/server/src/kube/namespace-overview.ts
@@ -1,0 +1,165 @@
+import {
+  BUILTIN_NAV_GROUPS,
+  type KubeObject,
+  type NamespaceInventoryEntry,
+  type NamespaceOverview,
+  type NamespaceQuotaStatus,
+} from '@kubus/shared';
+import type { ClusterHandle } from './cluster-manager.js';
+import { computeOperatorRollups, resolveCrd } from './operator-rollups.js';
+import { collectWarningEvents, optionalItems, podFailure } from './overview.js';
+import { parseQuantity } from './quantity.js';
+import { HEALTH_KINDS, computeWorkloadHealth, type HealthKindItems } from './workload-health.js';
+
+/**
+ * `kubectl get all -n <ns>`-style inventory: every namespaced builtin kind
+ * from the nav catalog (Events excluded — they get their own section).
+ */
+const INVENTORY_KINDS = BUILTIN_NAV_GROUPS.flatMap((g) => g.kinds).filter((k) => k.namespaced && k.kind !== 'Event');
+
+/**
+ * Popular CRDs surfaced in the inventory when installed, `<plural>.<group>`.
+ * Operator kinds (cert-manager, Argo, Flux, KEDA) show up through the
+ * operator rollups too; the extras here are common cluster add-ons.
+ */
+const POPULAR_CRDS = [
+  'certificates.cert-manager.io',
+  'issuers.cert-manager.io',
+  'applications.argoproj.io',
+  'rollouts.argoproj.io',
+  'kustomizations.kustomize.toolkit.fluxcd.io',
+  'helmreleases.helm.toolkit.fluxcd.io',
+  'gitrepositories.source.toolkit.fluxcd.io',
+  'scaledobjects.keda.sh',
+  'servicemonitors.monitoring.coreos.com',
+  'prometheusrules.monitoring.coreos.com',
+  'externalsecrets.external-secrets.io',
+  'sealedsecrets.bitnami.com',
+  'virtualservices.networking.istio.io',
+  'httproutes.gateway.networking.k8s.io',
+  'ingressroutes.traefik.io',
+];
+
+export async function computeNamespaceOverview(handle: ClusterHandle, namespaces: string[]): Promise<NamespaceOverview> {
+  const scope = new Set(namespaces);
+  const namespacesWatcher = handle.watchers.acquire('', 'v1', 'namespaces');
+  const eventsWatcher = handle.watchers.acquire('', 'v1', 'events');
+  const crdsWatcher = handle.watchers.acquire('apiextensions.k8s.io', 'v1', 'customresourcedefinitions');
+  const inventoryWatchers = INVENTORY_KINDS.map((spec) => ({
+    spec,
+    handle: handle.watchers.acquire(spec.group, spec.version, spec.plural),
+  }));
+  try {
+    await Promise.all([namespacesWatcher.watcher.ready(), eventsWatcher.watcher.ready()]);
+    const [crdsResult, ...inventoryResults] = await Promise.all([
+      optionalItems(crdsWatcher.watcher),
+      ...inventoryWatchers.map((w) => optionalItems(w.handle.watcher)),
+    ]);
+
+    const inNamespace = (o: KubeObject) => scope.has(o.metadata.namespace ?? '');
+    const itemsByKind = new Map<string, { items: KubeObject[]; unavailable: boolean }>();
+    INVENTORY_KINDS.forEach((spec, i) => {
+      const result = inventoryResults[i] ?? { items: [], unavailable: true };
+      itemsByKind.set(spec.kind, {
+        items: result.items.filter(inNamespace),
+        unavailable: result.unavailable,
+      });
+    });
+
+    // Unified health over the kinds that have a notion of it.
+    const healthKinds: HealthKindItems[] = HEALTH_KINDS.map((spec) => {
+      const entry = itemsByKind.get(spec.kind);
+      return { spec, items: entry?.items ?? [], unavailable: entry?.unavailable ?? true };
+    });
+    const health = computeWorkloadHealth(healthKinds);
+    const unhealthyByKind = new Map(health.kinds.map((k) => [k.kind, k.unhealthy]));
+
+    const now = Date.now();
+    const pods = itemsByKind.get('Pod')?.items ?? [];
+    const failingPods = pods
+      .flatMap((pod) => {
+        const failure = podFailure(pod, now);
+        return failure ? [{ namespace: pod.metadata.namespace ?? '', name: pod.metadata.name, ...failure }] : [];
+      })
+      .sort((a, b) => `${a.namespace}/${a.name}`.localeCompare(`${b.namespace}/${b.name}`));
+    unhealthyByKind.set('Pod', failingPods.length);
+
+    const inventory: NamespaceInventoryEntry[] = INVENTORY_KINDS.map((spec) => {
+      const entry = itemsByKind.get(spec.kind);
+      return {
+        kind: spec.kind,
+        group: spec.group,
+        version: spec.version,
+        plural: spec.plural,
+        total: entry?.items.length ?? 0,
+        unhealthy: unhealthyByKind.get(spec.kind),
+        unavailable: entry?.unavailable || undefined,
+      };
+    });
+
+    // Installed popular CRDs, counted within the namespace.
+    const crdsByName = new Map(crdsResult.items.map((c) => [c.metadata.name, c]));
+    const installedCrds = POPULAR_CRDS.map((name) => resolveCrd(crdsByName, name)).filter(
+      (crd): crd is NonNullable<typeof crd> => !!crd && crd.namespaced,
+    );
+    const crdCounts = await Promise.all(
+      installedCrds.map(async (crd) => {
+        const acquired = handle.watchers.acquire(crd.group, crd.version, crd.plural);
+        try {
+          const result = await optionalItems(acquired.watcher);
+          return {
+            kind: crd.kind,
+            group: crd.group,
+            version: crd.version,
+            plural: crd.plural,
+            total: result.items.filter(inNamespace).length,
+            custom: true,
+            unavailable: result.unavailable || undefined,
+          };
+        } finally {
+          acquired.release();
+        }
+      }),
+    );
+    inventory.push(...crdCounts);
+
+    const quotas: NamespaceQuotaStatus[] = (itemsByKind.get('ResourceQuota')?.items ?? []).map((quota) => {
+      const status = quota.status as { hard?: Record<string, string>; used?: Record<string, string> } | undefined;
+      return {
+        name: scope.size > 1 ? `${quota.metadata.namespace}/${quota.metadata.name}` : quota.metadata.name,
+        resources: Object.entries(status?.hard ?? {})
+          .map(([resource, hard]) => {
+            const hardVal = parseQuantity(hard);
+            const used = status?.used?.[resource] ?? '0';
+            return {
+              resource,
+              used,
+              hard,
+              pct: hardVal > 0 ? (parseQuantity(used) / hardVal) * 100 : undefined,
+            };
+          })
+          .sort((a, b) => a.resource.localeCompare(b.resource)),
+      };
+    });
+
+    const nsObject = scope.size === 1 ? namespacesWatcher.watcher.items().find((n) => scope.has(n.metadata.name)) : undefined;
+    const events = eventsWatcher.watcher.items().filter(inNamespace);
+
+    return {
+      namespaces,
+      status: (nsObject?.status as { phase?: string } | undefined)?.phase,
+      inventory,
+      workloadHealth: health.kinds,
+      issues: health.issues,
+      failingPods,
+      quotas,
+      warningEvents: collectWarningEvents(events, now),
+      operators: await computeOperatorRollups(handle, crdsResult.items, scope),
+    };
+  } finally {
+    namespacesWatcher.release();
+    eventsWatcher.release();
+    crdsWatcher.release();
+    for (const w of inventoryWatchers) w.handle.release();
+  }
+}

--- a/server/src/kube/namespace-overview.ts
+++ b/server/src/kube/namespace-overview.ts
@@ -5,6 +5,7 @@ import {
   type NamespaceOverview,
   type NamespaceQuotaStatus,
 } from '@kubus/shared';
+import { collectCertificates } from './cert-expiry.js';
 import type { ClusterHandle } from './cluster-manager.js';
 import { computeOperatorRollups, resolveCrd } from './operator-rollups.js';
 import { collectWarningEvents, optionalItems, podFailure } from './overview.js';
@@ -155,6 +156,7 @@ export async function computeNamespaceOverview(handle: ClusterHandle, namespaces
       quotas,
       warningEvents: collectWarningEvents(events, now),
       operators: await computeOperatorRollups(handle, crdsResult.items, scope),
+      certificates: await collectCertificates(handle, crdsResult.items, scope),
     };
   } finally {
     namespacesWatcher.release();

--- a/server/src/kube/operator-rollups.ts
+++ b/server/src/kube/operator-rollups.ts
@@ -1,0 +1,196 @@
+import type { KubeObject, OperatorResourceRollup, OperatorRollup, OverviewWorkloadIssue } from '@kubus/shared';
+import type { ClusterHandle } from './cluster-manager.js';
+
+/**
+ * Health rollups for popular operators, driven by which CRDs the cluster has
+ * installed. Only installed operators are returned; each resource is read
+ * from the shared watcher cache (acquired on demand, lingers after release).
+ */
+
+type ReadinessCheck = 'ready-condition' | 'argo-app' | 'argo-rollout';
+
+interface OperatorResourceDef {
+  /** CRD metadata.name, i.e. `<plural>.<group>`. */
+  crd: string;
+  check: ReadinessCheck;
+}
+
+interface OperatorDef {
+  id: string;
+  name: string;
+  resources: OperatorResourceDef[];
+}
+
+const OPERATORS: OperatorDef[] = [
+  {
+    id: 'cert-manager',
+    name: 'cert-manager',
+    resources: [
+      { crd: 'certificates.cert-manager.io', check: 'ready-condition' },
+      { crd: 'issuers.cert-manager.io', check: 'ready-condition' },
+      { crd: 'clusterissuers.cert-manager.io', check: 'ready-condition' },
+    ],
+  },
+  {
+    id: 'argo',
+    name: 'Argo',
+    resources: [
+      { crd: 'applications.argoproj.io', check: 'argo-app' },
+      { crd: 'rollouts.argoproj.io', check: 'argo-rollout' },
+    ],
+  },
+  {
+    id: 'flux',
+    name: 'Flux',
+    resources: [
+      { crd: 'gitrepositories.source.toolkit.fluxcd.io', check: 'ready-condition' },
+      { crd: 'helmrepositories.source.toolkit.fluxcd.io', check: 'ready-condition' },
+      { crd: 'kustomizations.kustomize.toolkit.fluxcd.io', check: 'ready-condition' },
+      { crd: 'helmreleases.helm.toolkit.fluxcd.io', check: 'ready-condition' },
+    ],
+  },
+  {
+    id: 'keda',
+    name: 'KEDA',
+    resources: [
+      { crd: 'scaledobjects.keda.sh', check: 'ready-condition' },
+      { crd: 'scaledjobs.keda.sh', check: 'ready-condition' },
+    ],
+  },
+  {
+    id: 'karpenter',
+    name: 'Karpenter',
+    resources: [
+      { crd: 'nodepools.karpenter.sh', check: 'ready-condition' },
+      { crd: 'nodeclaims.karpenter.sh', check: 'ready-condition' },
+    ],
+  },
+];
+
+const MAX_ISSUES_PER_RESOURCE = 20;
+
+interface CrdSpec {
+  group?: string;
+  scope?: string;
+  names?: { kind?: string; plural?: string };
+  versions?: Array<{ name?: string; served?: boolean; storage?: boolean }>;
+}
+
+export interface InstalledCrd {
+  group: string;
+  version: string;
+  plural: string;
+  kind: string;
+  namespaced: boolean;
+}
+
+/** Resolve a CRD by `<plural>.<group>` name to its served storage version. */
+export function resolveCrd(crds: Map<string, KubeObject>, name: string): InstalledCrd | undefined {
+  const crd = crds.get(name);
+  if (!crd) return undefined;
+  const spec = crd.spec as CrdSpec | undefined;
+  const versions = spec?.versions ?? [];
+  const version = versions.find((v) => v.storage && v.served) ?? versions.find((v) => v.served);
+  if (!spec?.group || !spec.names?.plural || !spec.names.kind || !version?.name) return undefined;
+  return {
+    group: spec.group,
+    version: version.name,
+    plural: spec.names.plural,
+    kind: spec.names.kind,
+    namespaced: spec.scope === 'Namespaced',
+  };
+}
+
+interface Condition {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+}
+
+function readiness(check: ReadinessCheck, obj: KubeObject): { ready: boolean; reason?: string; message?: string } {
+  if (check === 'argo-app') {
+    const status = obj.status as { health?: { status?: string; message?: string }; sync?: { status?: string } } | undefined;
+    const health = status?.health?.status ?? 'Unknown';
+    const sync = status?.sync?.status ?? 'Unknown';
+    const ready = health === 'Healthy' && sync === 'Synced';
+    return ready ? { ready } : { ready, reason: health !== 'Healthy' ? health : sync, message: status?.health?.message };
+  }
+  if (check === 'argo-rollout') {
+    const status = obj.status as { phase?: string; message?: string } | undefined;
+    const ready = status?.phase !== 'Degraded';
+    return ready ? { ready } : { ready, reason: status?.phase, message: status?.message };
+  }
+  const conditions = (obj.status as { conditions?: Condition[] } | undefined)?.conditions ?? [];
+  const readyCond = conditions.find((c) => c.type === 'Ready');
+  // No Ready condition at all (not yet reconciled schema, cluster-scoped
+  // config objects) — don't invent a failure.
+  if (!readyCond || readyCond.status === 'True') return { ready: true };
+  return { ready: false, reason: readyCond.reason ?? 'NotReady', message: readyCond.message };
+}
+
+export async function computeOperatorRollups(handle: ClusterHandle, crds: KubeObject[], namespaces?: ReadonlySet<string>): Promise<OperatorRollup[]> {
+  const crdsByName = new Map(crds.map((c) => [c.metadata.name, c]));
+  const rollups: OperatorRollup[] = [];
+  for (const op of OPERATORS) {
+    const installed = op.resources
+      .map((r) => ({ def: r, crd: resolveCrd(crdsByName, r.crd) }))
+      .filter((r): r is { def: OperatorResourceDef; crd: InstalledCrd } => !!r.crd)
+      // A namespace-scoped view has nothing to say about cluster-scoped resources.
+      .filter((r) => !namespaces || r.crd.namespaced);
+    if (installed.length === 0) continue;
+    const resources = await Promise.all(installed.map(({ def, crd }) => rollupResource(handle, def, crd, namespaces)));
+    rollups.push({ id: op.id, name: op.name, resources });
+  }
+  return rollups;
+}
+
+async function rollupResource(
+  handle: ClusterHandle,
+  def: OperatorResourceDef,
+  crd: InstalledCrd,
+  namespaces?: ReadonlySet<string>,
+): Promise<OperatorResourceRollup> {
+  const { watcher, release } = handle.watchers.acquire(crd.group, crd.version, crd.plural);
+  try {
+    let items: KubeObject[] = [];
+    let unavailable = false;
+    try {
+      await watcher.ready();
+      items = watcher.items();
+      unavailable = watcher.currentState() === 'unavailable';
+    } catch {
+      unavailable = true;
+    }
+    if (namespaces) items = items.filter((o) => namespaces.has(o.metadata.namespace ?? ''));
+    const issues: OverviewWorkloadIssue[] = [];
+    let ready = 0;
+    for (const obj of items) {
+      const r = readiness(def.check, obj);
+      if (r.ready) {
+        ready += 1;
+      } else if (issues.length < MAX_ISSUES_PER_RESOURCE) {
+        issues.push({
+          kind: crd.kind,
+          namespace: obj.metadata.namespace ?? '',
+          name: obj.metadata.name,
+          reason: r.reason ?? 'NotReady',
+          message: r.message,
+        });
+      }
+    }
+    issues.sort((a, b) => `${a.namespace}/${a.name}`.localeCompare(`${b.namespace}/${b.name}`));
+    return {
+      kind: crd.kind,
+      group: crd.group,
+      version: crd.version,
+      plural: crd.plural,
+      namespaced: crd.namespaced,
+      total: unavailable ? 0 : items.length,
+      ready,
+      issues,
+    };
+  } finally {
+    release();
+  }
+}

--- a/server/src/kube/operator-rollups.ts
+++ b/server/src/kube/operator-rollups.ts
@@ -118,8 +118,10 @@ function readiness(check: ReadinessCheck, obj: KubeObject): { ready: boolean; re
   }
   if (check === 'argo-rollout') {
     const status = obj.status as { phase?: string; message?: string } | undefined;
-    const ready = status?.phase !== 'Degraded';
-    return ready ? { ready } : { ready, reason: status?.phase, message: status?.message };
+    // No phase yet (not reconciled) — don't invent a failure; any explicit
+    // non-Healthy phase (Progressing, Paused, Degraded) is not ready.
+    if (!status?.phase || status.phase === 'Healthy') return { ready: true };
+    return { ready: false, reason: status.phase, message: status.message };
   }
   const conditions = (obj.status as { conditions?: Condition[] } | undefined)?.conditions ?? [];
   const readyCond = conditions.find((c) => c.type === 'Ready');
@@ -186,9 +188,10 @@ async function rollupResource(
       version: crd.version,
       plural: crd.plural,
       namespaced: crd.namespaced,
-      total: unavailable ? 0 : items.length,
+      total: items.length,
       ready,
       issues,
+      unavailable: unavailable || undefined,
     };
   } finally {
     release();

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -1,5 +1,7 @@
-import type { ClusterOverview, KubeObject } from '@kubus/shared';
+import type { ClusterOverview, KubeObject, OverviewWarningEvent } from '@kubus/shared';
 import type { ClusterHandle } from './cluster-manager.js';
+import { computeOperatorRollups } from './operator-rollups.js';
+import { HEALTH_KINDS, computeWorkloadHealth, type HealthKindItems } from './workload-health.js';
 
 const RECENT_MS = 60 * 60 * 1000; // 1h window for restarts/events
 
@@ -21,6 +23,12 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
   const namespacesWatcher = handle.watchers.acquire('', 'v1', 'namespaces');
   const pvsWatcher = handle.watchers.acquire('', 'v1', 'persistentvolumes');
   const crdsWatcher = handle.watchers.acquire('apiextensions.k8s.io', 'v1', 'customresourcedefinitions');
+  // Deployments are pinned above; the remaining health kinds are acquired on
+  // demand and shared with the list pages (30s linger between polls).
+  const healthWatchers = HEALTH_KINDS.filter((spec) => spec.kind !== 'Deployment').map((spec) => ({
+    spec,
+    handle: handle.watchers.acquire(spec.group, spec.version, spec.plural),
+  }));
   try {
     await Promise.all([
       podsWatcher.watcher.ready(),
@@ -29,9 +37,10 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       nodesWatcher.watcher.ready(),
       namespacesWatcher.watcher.ready(),
     ]);
-    const [persistentVolumesResult, crdsResult] = await Promise.all([
+    const [persistentVolumesResult, crdsResult, ...healthResults] = await Promise.all([
       optionalItems(pvsWatcher.watcher),
       optionalItems(crdsWatcher.watcher),
+      ...healthWatchers.map((w) => optionalItems(w.handle.watcher)),
     ]);
     const pods = podsWatcher.watcher.items();
     const deployments = deploysWatcher.watcher.items();
@@ -61,48 +70,31 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       unavailableWorkloads: [],
       recentRestarts: [],
       warningEvents: [],
+      workloadHealth: [],
+      operators: [],
     };
+
+    const healthBySpec = new Map(healthWatchers.map((w, i) => [w.spec, healthResults[i] ?? { items: [], unavailable: true }]));
+    const healthKinds: HealthKindItems[] = HEALTH_KINDS.map((spec) => {
+      if (spec.kind === 'Deployment') return { spec, items: deployments, unavailable: false };
+      const result = healthBySpec.get(spec) ?? { items: [], unavailable: true };
+      return { spec, items: result.items, unavailable: result.unavailable };
+    });
+    const health = computeWorkloadHealth(healthKinds);
+    overview.workloadHealth = health.kinds;
+    overview.unavailableWorkloads = health.issues;
+    overview.operators = await computeOperatorRollups(handle, crds);
 
     const now = Date.now();
     for (const pod of pods) {
-      const status = pod.status as { phase?: string; reason?: string; message?: string; containerStatuses?: ContainerStatus[] } | undefined;
+      const status = pod.status as { phase?: string; containerStatuses?: ContainerStatus[] } | undefined;
       if (status?.phase === 'Running') overview.counts.podsRunning += 1;
-      const statuses = status?.containerStatuses ?? [];
-      const restarts = statuses.reduce((sum, c) => sum + (c.restartCount ?? 0), 0);
-
-      let reason: string | undefined;
-      let message: string | undefined;
-      if (status?.phase === 'Failed') {
-        reason = status.reason ?? 'Failed';
-        message = status.message;
-      } else {
-        for (const c of statuses) {
-          const waiting = c.state?.waiting;
-          if (waiting?.reason && FAILING_WAIT_REASONS.has(waiting.reason)) {
-            reason = waiting.reason;
-            message = waiting.message;
-            break;
-          }
-        }
-      }
-      // Pending too long (unschedulable) also counts as failing.
-      if (!reason && status?.phase === 'Pending') {
-        const created = Date.parse(pod.metadata.creationTimestamp ?? '');
-        if (!Number.isNaN(created) && now - created > 5 * 60 * 1000) {
-          reason = 'Pending';
-        }
-      }
-      if (reason) {
-        overview.failingPods.push({
-          namespace: pod.metadata.namespace ?? '',
-          name: pod.metadata.name,
-          reason,
-          message,
-          restarts,
-        });
+      const failure = podFailure(pod, now);
+      if (failure) {
+        overview.failingPods.push({ namespace: pod.metadata.namespace ?? '', name: pod.metadata.name, ...failure });
       }
 
-      for (const c of statuses) {
+      for (const c of status?.containerStatuses ?? []) {
         const finishedAt = c.lastState?.terminated?.finishedAt;
         if (finishedAt && now - Date.parse(finishedAt) < RECENT_MS && (c.restartCount ?? 0) > 0) {
           overview.recentRestarts.push({
@@ -117,49 +109,7 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       }
     }
 
-    for (const d of deployments) {
-      const spec = d.spec as { replicas?: number } | undefined;
-      const status = d.status as { availableReplicas?: number } | undefined;
-      const desired = spec?.replicas ?? 1;
-      const available = status?.availableReplicas ?? 0;
-      if (desired > 0 && available < desired) {
-        overview.unavailableWorkloads.push({
-          kind: 'Deployment',
-          namespace: d.metadata.namespace ?? '',
-          name: d.metadata.name,
-          ready: available,
-          desired,
-        });
-      }
-    }
-
-    overview.warningEvents = events
-      .flatMap((e) => {
-        if ((e as { type?: string }).type !== 'Warning') return [];
-        const time = eventTime(e);
-        const t = Date.parse(time);
-        return !Number.isNaN(t) && now - t < RECENT_MS ? [{ e, time }] : [];
-      })
-      .sort((a, b) => b.time.localeCompare(a.time))
-      .slice(0, 50)
-      .map(({ e, time }) => {
-        const ev = e as KubeObject & {
-          reason?: string;
-          message?: string;
-          count?: number;
-          lastTimestamp?: string;
-          involvedObject?: { kind?: string; name?: string };
-        };
-        return {
-          namespace: e.metadata.namespace ?? '',
-          reason: ev.reason ?? '',
-          message: ev.message ?? '',
-          involvedKind: ev.involvedObject?.kind ?? '',
-          involvedName: ev.involvedObject?.name ?? '',
-          count: ev.count ?? 1,
-          lastTimestamp: time || undefined,
-        };
-      });
+    overview.warningEvents = collectWarningEvents(events, now);
 
     overview.failingPods.sort((a, b) => `${a.namespace}/${a.name}`.localeCompare(`${b.namespace}/${b.name}`));
     overview.recentRestarts.sort((a, b) => (b.finishedAt ?? '').localeCompare(a.finishedAt ?? ''));
@@ -172,7 +122,64 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
     namespacesWatcher.release();
     pvsWatcher.release();
     crdsWatcher.release();
+    for (const w of healthWatchers) w.handle.release();
   }
+}
+
+/** Failing-pod detection shared with the namespace overview. */
+export function podFailure(pod: KubeObject, now: number): { reason: string; message?: string; restarts: number } | undefined {
+  const status = pod.status as { phase?: string; reason?: string; message?: string; containerStatuses?: ContainerStatus[] } | undefined;
+  const statuses = status?.containerStatuses ?? [];
+  const restarts = statuses.reduce((sum, c) => sum + (c.restartCount ?? 0), 0);
+
+  if (status?.phase === 'Failed') {
+    return { reason: status.reason ?? 'Failed', message: status.message, restarts };
+  }
+  for (const c of statuses) {
+    const waiting = c.state?.waiting;
+    if (waiting?.reason && FAILING_WAIT_REASONS.has(waiting.reason)) {
+      return { reason: waiting.reason, message: waiting.message, restarts };
+    }
+  }
+  // Pending too long (unschedulable) also counts as failing.
+  if (status?.phase === 'Pending') {
+    const created = Date.parse(pod.metadata.creationTimestamp ?? '');
+    if (!Number.isNaN(created) && now - created > 5 * 60 * 1000) {
+      return { reason: 'Pending', restarts };
+    }
+  }
+  return undefined;
+}
+
+/** Warning events within the 1h window, newest first, capped at 50. */
+export function collectWarningEvents(events: KubeObject[], now: number): OverviewWarningEvent[] {
+  return events
+    .flatMap((e) => {
+      if ((e as { type?: string }).type !== 'Warning') return [];
+      const time = eventTime(e);
+      const t = Date.parse(time);
+      return !Number.isNaN(t) && now - t < RECENT_MS ? [{ e, time }] : [];
+    })
+    .sort((a, b) => b.time.localeCompare(a.time))
+    .slice(0, 50)
+    .map(({ e, time }) => {
+      const ev = e as KubeObject & {
+        reason?: string;
+        message?: string;
+        count?: number;
+        lastTimestamp?: string;
+        involvedObject?: { kind?: string; name?: string };
+      };
+      return {
+        namespace: e.metadata.namespace ?? '',
+        reason: ev.reason ?? '',
+        message: ev.message ?? '',
+        involvedKind: ev.involvedObject?.kind ?? '',
+        involvedName: ev.involvedObject?.name ?? '',
+        count: ev.count ?? 1,
+        lastTimestamp: time || undefined,
+      };
+    });
 }
 
 function eventTime(e: KubeObject): string {
@@ -185,7 +192,7 @@ function isEstablishedCrd(crd: KubeObject): boolean {
   return conditions.some((c) => c.type === 'Established' && c.status === 'True');
 }
 
-async function optionalItems(watcher: {
+export async function optionalItems(watcher: {
   ready(): Promise<void>;
   items(): KubeObject[];
   currentState(): string;

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -1,4 +1,5 @@
 import type { ClusterOverview, KubeObject, OverviewWarningEvent } from '@kubus/shared';
+import { apiServerCertNotAfter, collectCertificates } from './cert-expiry.js';
 import type { ClusterHandle } from './cluster-manager.js';
 import { computeOperatorRollups } from './operator-rollups.js';
 import { HEALTH_KINDS, computeWorkloadHealth, type HealthKindItems } from './workload-health.js';
@@ -72,6 +73,7 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       warningEvents: [],
       workloadHealth: [],
       operators: [],
+      certificates: { total: 0, expiring: [] },
     };
 
     const healthBySpec = new Map(healthWatchers.map((w, i) => [w.spec, healthResults[i] ?? { items: [], unavailable: true }]));
@@ -83,7 +85,13 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
     const health = computeWorkloadHealth(healthKinds);
     overview.workloadHealth = health.kinds;
     overview.unavailableWorkloads = health.issues;
-    overview.operators = await computeOperatorRollups(handle, crds);
+    const [operators, certificates, apiServerNotAfter] = await Promise.all([
+      computeOperatorRollups(handle, crds),
+      collectCertificates(handle, crds),
+      apiServerCertNotAfter(handle),
+    ]);
+    overview.operators = operators;
+    overview.certificates = { ...certificates, apiServerNotAfter };
 
     const now = Date.now();
     for (const pod of pods) {

--- a/server/src/kube/pod-resources.ts
+++ b/server/src/kube/pod-resources.ts
@@ -16,20 +16,24 @@ interface PodSpecResources {
 
 function podSpecResources(pod: KubeObject): PodSpecResources {
   const spec = pod.spec as { containers?: ContainerSpec[]; initContainers?: ContainerSpec[] } | undefined;
-  // Regular containers plus restartable init containers (sidecars) — those
-  // run for the pod's whole life and count toward scheduling.
-  const containers = [
-    ...(spec?.containers ?? []),
-    ...(spec?.initContainers ?? []).filter((c) => c.restartPolicy === 'Always'),
-  ];
-  const acc: PodSpecResources = { cpuRequestMilli: 0, memRequestBytes: 0, cpuLimitMilli: 0, memLimitBytes: 0 };
-  for (const c of containers) {
-    acc.cpuRequestMilli += cpuToMilli(c.resources?.requests?.cpu);
-    acc.memRequestBytes += memToBytes(c.resources?.requests?.memory);
-    acc.cpuLimitMilli += cpuToMilli(c.resources?.limits?.cpu);
-    acc.memLimitBytes += memToBytes(c.resources?.limits?.memory);
-  }
-  return acc;
+  const inits = spec?.initContainers ?? [];
+  // Kubernetes effective pod resources: regular containers plus restartable
+  // init containers (sidecars) run for the pod's whole life and sum; a
+  // non-restartable init container runs alone first, so the pod reserves at
+  // least its single largest requirement.
+  const running = [...(spec?.containers ?? []), ...inits.filter((c) => c.restartPolicy === 'Always')];
+  const regularInits = inits.filter((c) => c.restartPolicy !== 'Always');
+  const effective = (pick: (c: ContainerSpec) => number): number =>
+    Math.max(
+      running.reduce((sum, c) => sum + pick(c), 0),
+      regularInits.reduce((max, c) => Math.max(max, pick(c)), 0),
+    );
+  return {
+    cpuRequestMilli: effective((c) => cpuToMilli(c.resources?.requests?.cpu)),
+    memRequestBytes: effective((c) => memToBytes(c.resources?.requests?.memory)),
+    cpuLimitMilli: effective((c) => cpuToMilli(c.resources?.limits?.cpu)),
+    memLimitBytes: effective((c) => memToBytes(c.resources?.limits?.memory)),
+  };
 }
 
 /**

--- a/server/src/kube/pod-resources.ts
+++ b/server/src/kube/pod-resources.ts
@@ -1,0 +1,65 @@
+import type { KubeObject, PodResourceUsage, PodResourcesResponse } from '@kubus/shared';
+import type { ClusterHandle } from './cluster-manager.js';
+import { cpuToMilli, memToBytes } from './quantity.js';
+
+interface ContainerSpec {
+  restartPolicy?: string;
+  resources?: { requests?: { cpu?: string; memory?: string }; limits?: { cpu?: string; memory?: string } };
+}
+
+interface PodSpecResources {
+  cpuRequestMilli: number;
+  memRequestBytes: number;
+  cpuLimitMilli: number;
+  memLimitBytes: number;
+}
+
+function podSpecResources(pod: KubeObject): PodSpecResources {
+  const spec = pod.spec as { containers?: ContainerSpec[]; initContainers?: ContainerSpec[] } | undefined;
+  // Regular containers plus restartable init containers (sidecars) — those
+  // run for the pod's whole life and count toward scheduling.
+  const containers = [
+    ...(spec?.containers ?? []),
+    ...(spec?.initContainers ?? []).filter((c) => c.restartPolicy === 'Always'),
+  ];
+  const acc: PodSpecResources = { cpuRequestMilli: 0, memRequestBytes: 0, cpuLimitMilli: 0, memLimitBytes: 0 };
+  for (const c of containers) {
+    acc.cpuRequestMilli += cpuToMilli(c.resources?.requests?.cpu);
+    acc.memRequestBytes += memToBytes(c.resources?.requests?.memory);
+    acc.cpuLimitMilli += cpuToMilli(c.resources?.limits?.cpu);
+    acc.memLimitBytes += memToBytes(c.resources?.limits?.memory);
+  }
+  return acc;
+}
+
+/**
+ * Join live pod usage (metrics poller) with spec requests/limits (pods
+ * watcher) so the client can apply threshold filters without refetching.
+ */
+export async function computePodResources(handle: ClusterHandle, namespace?: string): Promise<PodResourcesResponse> {
+  const podsWatcher = handle.watchers.acquire('', 'v1', 'pods');
+  try {
+    await podsWatcher.watcher.ready();
+    const specs = new Map<string, PodSpecResources>();
+    for (const pod of podsWatcher.watcher.items()) {
+      if (namespace && pod.metadata.namespace !== namespace) continue;
+      specs.set(`${pod.metadata.namespace ?? ''}/${pod.metadata.name}`, podSpecResources(pod));
+    }
+    const pods: PodResourceUsage[] = [];
+    for (const usage of handle.metricsPoller.podSnapshot(namespace)) {
+      const spec = specs.get(`${usage.namespace ?? ''}/${usage.name}`);
+      if (!spec) continue; // metrics for a pod the watcher no longer has
+      pods.push({
+        namespace: usage.namespace ?? '',
+        name: usage.name,
+        cpuUsageMilli: usage.cpuMilli,
+        memUsageBytes: usage.memBytes,
+        ...spec,
+      });
+    }
+    pods.sort((a, b) => b.cpuUsageMilli - a.cpuUsageMilli);
+    return { available: handle.metricsPoller.available, pods };
+  } finally {
+    podsWatcher.release();
+  }
+}

--- a/server/src/kube/workload-health.ts
+++ b/server/src/kube/workload-health.ts
@@ -1,0 +1,228 @@
+import type { KubeObject, OverviewKindHealth, OverviewWorkloadIssue } from '@kubus/shared';
+import { parseQuantity } from './quantity.js';
+
+/**
+ * Unified health checks across workload, autoscaling, storage, and policy
+ * kinds. Consumed by both the cluster overview and the namespace overview so
+ * "unhealthy" means the same thing everywhere.
+ */
+
+export interface HealthKindSpec {
+  kind: string;
+  group: string;
+  version: string;
+  plural: string;
+}
+
+/** Kinds the unified health section covers, in display order. */
+export const HEALTH_KINDS: HealthKindSpec[] = [
+  { kind: 'Deployment', group: 'apps', version: 'v1', plural: 'deployments' },
+  { kind: 'StatefulSet', group: 'apps', version: 'v1', plural: 'statefulsets' },
+  { kind: 'DaemonSet', group: 'apps', version: 'v1', plural: 'daemonsets' },
+  { kind: 'Job', group: 'batch', version: 'v1', plural: 'jobs' },
+  { kind: 'CronJob', group: 'batch', version: 'v1', plural: 'cronjobs' },
+  { kind: 'HorizontalPodAutoscaler', group: 'autoscaling', version: 'v2', plural: 'horizontalpodautoscalers' },
+  { kind: 'PersistentVolumeClaim', group: '', version: 'v1', plural: 'persistentvolumeclaims' },
+  { kind: 'PodDisruptionBudget', group: 'policy', version: 'v1', plural: 'poddisruptionbudgets' },
+  { kind: 'ResourceQuota', group: '', version: 'v1', plural: 'resourcequotas' },
+];
+
+export interface HealthKindItems {
+  spec: HealthKindSpec;
+  items: KubeObject[];
+  unavailable: boolean;
+}
+
+export interface WorkloadHealthResult {
+  kinds: OverviewKindHealth[];
+  issues: OverviewWorkloadIssue[];
+}
+
+interface Condition {
+  type?: string;
+  status?: string;
+  reason?: string;
+  message?: string;
+}
+
+function conditions(obj: KubeObject): Condition[] {
+  return (obj.status as { conditions?: Condition[] } | undefined)?.conditions ?? [];
+}
+
+function issueBase(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue {
+  return { kind: spec.kind, namespace: obj.metadata.namespace ?? '', name: obj.metadata.name };
+}
+
+/**
+ * Latest Job per owning CronJob (`namespace/name` key) — CronJob health is
+ * "did the most recent run fail".
+ */
+export function latestJobsByCronJob(jobs: KubeObject[]): Map<string, KubeObject> {
+  const latest = new Map<string, KubeObject>();
+  for (const job of jobs) {
+    const owner = (job.metadata.ownerReferences ?? []).find((o) => o.kind === 'CronJob');
+    if (!owner) continue;
+    const key = `${job.metadata.namespace ?? ''}/${owner.name}`;
+    const prev = latest.get(key);
+    if (!prev || (job.metadata.creationTimestamp ?? '').localeCompare(prev.metadata.creationTimestamp ?? '') > 0) {
+      latest.set(key, job);
+    }
+  }
+  return latest;
+}
+
+function jobFailure(job: KubeObject): Condition | undefined {
+  return conditions(job).find((c) => c.type === 'Failed' && c.status === 'True');
+}
+
+function checkDeployment(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const desired = (obj.spec as { replicas?: number } | undefined)?.replicas ?? 1;
+  const ready = (obj.status as { availableReplicas?: number } | undefined)?.availableReplicas ?? 0;
+  if (desired > 0 && ready < desired) return { ...issueBase(spec, obj), ready, desired, reason: 'Unavailable' };
+  return undefined;
+}
+
+function checkStatefulSet(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const desired = (obj.spec as { replicas?: number } | undefined)?.replicas ?? 1;
+  const ready = (obj.status as { readyReplicas?: number } | undefined)?.readyReplicas ?? 0;
+  if (desired > 0 && ready < desired) return { ...issueBase(spec, obj), ready, desired, reason: 'Unavailable' };
+  return undefined;
+}
+
+function checkDaemonSet(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const status = obj.status as { desiredNumberScheduled?: number; numberReady?: number } | undefined;
+  const desired = status?.desiredNumberScheduled ?? 0;
+  const ready = status?.numberReady ?? 0;
+  if (desired > 0 && ready < desired) return { ...issueBase(spec, obj), ready, desired, reason: 'Unavailable' };
+  return undefined;
+}
+
+function checkJob(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const failed = jobFailure(obj);
+  if (!failed) return undefined;
+  const desired = (obj.spec as { completions?: number } | undefined)?.completions ?? 1;
+  const ready = (obj.status as { succeeded?: number } | undefined)?.succeeded ?? 0;
+  return { ...issueBase(spec, obj), ready, desired, reason: failed.reason ?? 'Failed', message: failed.message };
+}
+
+function checkCronJob(spec: HealthKindSpec, obj: KubeObject, latestJobs: Map<string, KubeObject>): OverviewWorkloadIssue | undefined {
+  if ((obj.spec as { suspend?: boolean } | undefined)?.suspend) return undefined;
+  const latest = latestJobs.get(`${obj.metadata.namespace ?? ''}/${obj.metadata.name}`);
+  const failed = latest && jobFailure(latest);
+  if (!failed) return undefined;
+  return { ...issueBase(spec, obj), reason: 'LastRunFailed', message: failed.message ?? `Job ${latest.metadata.name} failed` };
+}
+
+function checkHpa(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const bad = conditions(obj).find(
+    (c) => (c.type === 'AbleToScale' || c.type === 'ScalingActive') && c.status === 'False' && c.reason !== 'ScalingDisabled',
+  );
+  if (!bad) return undefined;
+  const status = obj.status as { currentReplicas?: number; desiredReplicas?: number } | undefined;
+  return {
+    ...issueBase(spec, obj),
+    ready: status?.currentReplicas,
+    desired: status?.desiredReplicas,
+    reason: bad.reason ?? bad.type,
+    message: bad.message,
+  };
+}
+
+function checkPvc(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const phase = (obj.status as { phase?: string } | undefined)?.phase;
+  if (phase === 'Bound') return undefined;
+  return { ...issueBase(spec, obj), reason: phase ?? 'Pending' };
+}
+
+function checkPdb(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const status = obj.status as { expectedPods?: number; disruptionsAllowed?: number; currentHealthy?: number; desiredHealthy?: number } | undefined;
+  if ((status?.expectedPods ?? 0) > 0 && (status?.disruptionsAllowed ?? 0) === 0) {
+    return {
+      ...issueBase(spec, obj),
+      ready: status?.currentHealthy,
+      desired: status?.desiredHealthy,
+      reason: 'NoDisruptionsAllowed',
+      message: 'Voluntary evictions are blocked — a node drain would hang on this budget.',
+    };
+  }
+  return undefined;
+}
+
+function checkQuota(spec: HealthKindSpec, obj: KubeObject): OverviewWorkloadIssue | undefined {
+  const status = obj.status as { hard?: Record<string, string>; used?: Record<string, string> } | undefined;
+  const at: string[] = [];
+  const near: string[] = [];
+  for (const [resource, hard] of Object.entries(status?.hard ?? {})) {
+    const hardVal = parseQuantity(hard);
+    if (hardVal <= 0) continue;
+    const used = parseQuantity(status?.used?.[resource]);
+    if (used >= hardVal) at.push(`${resource} ${status?.used?.[resource] ?? '0'}/${hard}`);
+    else if (used >= hardVal * 0.9) near.push(`${resource} ${status?.used?.[resource] ?? '0'}/${hard}`);
+  }
+  if (at.length === 0 && near.length === 0) return undefined;
+  return {
+    ...issueBase(spec, obj),
+    reason: at.length > 0 ? 'AtQuota' : 'NearQuota',
+    message: [...at, ...near].join(', '),
+  };
+}
+
+/**
+ * Per-kind totals + unified issue list. Items must be pre-filtered to the
+ * namespace of interest by the caller (or cluster-wide for the overview).
+ */
+export function computeWorkloadHealth(kinds: HealthKindItems[]): WorkloadHealthResult {
+  const jobs = kinds.find((k) => k.spec.kind === 'Job')?.items ?? [];
+  const latestJobs = latestJobsByCronJob(jobs);
+  const result: WorkloadHealthResult = { kinds: [], issues: [] };
+  for (const { spec, items, unavailable } of kinds) {
+    let unhealthy = 0;
+    for (const obj of items) {
+      let issue: OverviewWorkloadIssue | undefined;
+      switch (spec.kind) {
+        case 'Deployment':
+          issue = checkDeployment(spec, obj);
+          break;
+        case 'StatefulSet':
+          issue = checkStatefulSet(spec, obj);
+          break;
+        case 'DaemonSet':
+          issue = checkDaemonSet(spec, obj);
+          break;
+        case 'Job':
+          issue = checkJob(spec, obj);
+          break;
+        case 'CronJob':
+          issue = checkCronJob(spec, obj, latestJobs);
+          break;
+        case 'HorizontalPodAutoscaler':
+          issue = checkHpa(spec, obj);
+          break;
+        case 'PersistentVolumeClaim':
+          issue = checkPvc(spec, obj);
+          break;
+        case 'PodDisruptionBudget':
+          issue = checkPdb(spec, obj);
+          break;
+        case 'ResourceQuota':
+          issue = checkQuota(spec, obj);
+          break;
+      }
+      if (issue) {
+        unhealthy += 1;
+        result.issues.push(issue);
+      }
+    }
+    result.kinds.push({
+      kind: spec.kind,
+      group: spec.group,
+      version: spec.version,
+      plural: spec.plural,
+      total: items.length,
+      unhealthy,
+      unavailable: unavailable || undefined,
+    });
+  }
+  result.issues.sort((a, b) => `${a.kind}/${a.namespace}/${a.name}`.localeCompare(`${b.kind}/${b.namespace}/${b.name}`));
+  return result;
+}

--- a/server/src/routes/metrics.ts
+++ b/server/src/routes/metrics.ts
@@ -1,7 +1,9 @@
 import type { FastifyInstance } from 'fastify';
 import type { MetricsHistoryResponse, MetricsServerInstallRequest, MetricsSnapshot } from '@kubus/shared';
 import type { AppContext } from '../app.js';
+import { computeNamespaceOverview } from '../kube/namespace-overview.js';
 import { computeOverview } from '../kube/overview.js';
+import { computePodResources } from '../kube/pod-resources.js';
 import { installMetricsServer, metricsServerStatus, uninstallMetricsServer } from '../kube/metrics-server.js';
 import { computeMetricsSummary } from '../kube/metrics-summary.js';
 import { cpuToMilli, memToBytes } from '../kube/quantity.js';
@@ -111,6 +113,34 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
     try {
       const handle = ctx.clusters.get(req.params.ctx);
       return await computeOverview(handle);
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  app.get<{ Params: { ctx: string }; Querystring: { namespace?: string } }>('/api/contexts/:ctx/overview/pod-resources', async (req, reply) => {
+    try {
+      const handle = ctx.clusters.get(req.params.ctx);
+      return await computePodResources(handle, req.query.namespace || undefined);
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  app.get<{ Params: { ctx: string }; Querystring: { namespaces?: string } }>('/api/contexts/:ctx/namespace-overview', async (req, reply) => {
+    try {
+      const namespaces = (req.query.namespaces ?? '')
+        .split(',')
+        .map((ns) => ns.trim())
+        .filter(Boolean);
+      if (namespaces.length === 0) {
+        reply.code(400).send({ message: 'namespaces query parameter is required', reason: 'BadRequest', code: 400 });
+        return reply;
+      }
+      const handle = ctx.clusters.get(req.params.ctx);
+      return await computeNamespaceOverview(handle, namespaces);
     } catch (err) {
       sendError(reply, err);
       return reply;

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -719,6 +719,8 @@ export interface OperatorResourceRollup {
   total: number;
   ready: number;
   issues: OverviewWorkloadIssue[];
+  /** Resource API missing or RBAC-denied — counts are unknown, not zero. */
+  unavailable?: boolean;
 }
 
 export interface OperatorRollup {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -690,8 +690,43 @@ export interface OverviewWorkloadIssue {
   kind: string;
   namespace: string;
   name: string;
+  /** Replica-shaped kinds only (Deployment ready/desired, PDB healthy/desired…). */
+  ready?: number;
+  desired?: number;
+  /** Short machine-ish cause: Unavailable, Failed, Pending, NoDisruptionsAllowed, AtQuota… */
+  reason?: string;
+  message?: string;
+}
+
+/** Per-kind rollup for the unified workload-health section. */
+export interface OverviewKindHealth {
+  kind: string;
+  group: string;
+  version: string;
+  plural: string;
+  total: number;
+  unhealthy: number;
+  /** Resource API missing or RBAC-denied on this cluster. */
+  unavailable?: boolean;
+}
+
+export interface OperatorResourceRollup {
+  kind: string;
+  group: string;
+  version: string;
+  plural: string;
+  namespaced: boolean;
+  total: number;
   ready: number;
-  desired: number;
+  issues: OverviewWorkloadIssue[];
+}
+
+export interface OperatorRollup {
+  /** Stable slug: cert-manager, argo, flux, keda, karpenter. */
+  id: string;
+  /** Display name. */
+  name: string;
+  resources: OperatorResourceRollup[];
 }
 
 export interface OverviewWarningEvent {
@@ -733,6 +768,73 @@ export interface ClusterOverview {
   unavailableWorkloads: OverviewWorkloadIssue[];
   recentRestarts: OverviewRestart[];
   warningEvents: OverviewWarningEvent[];
+  /** Unified per-kind health across workloads, autoscaling, storage, and policy. */
+  workloadHealth: OverviewKindHealth[];
+  /** Rollups for operators whose CRDs are installed (cert-manager, Argo, Flux, KEDA, Karpenter). */
+  operators: OperatorRollup[];
+}
+
+// ---- Pod resource usage vs requests/limits (overview panels) ----
+
+export interface PodResourceUsage {
+  namespace: string;
+  name: string;
+  cpuUsageMilli: number;
+  memUsageBytes: number;
+  /** Summed container requests/limits; 0 = not set on any container. */
+  cpuRequestMilli: number;
+  memRequestBytes: number;
+  cpuLimitMilli: number;
+  memLimitBytes: number;
+}
+
+export interface PodResourcesResponse {
+  /** metrics-server serving data. */
+  available: boolean;
+  pods: PodResourceUsage[];
+}
+
+// ---- Namespace overview ----
+
+export interface NamespaceInventoryEntry {
+  kind: string;
+  group: string;
+  version: string;
+  plural: string;
+  total: number;
+  /** Entries with a health notion (workloads, PVCs, quotas…). */
+  unhealthy?: number;
+  /** Counted from an installed CRD rather than a builtin API. */
+  custom?: boolean;
+  /** Resource API missing or RBAC-denied. */
+  unavailable?: boolean;
+}
+
+export interface NamespaceQuotaResource {
+  resource: string;
+  used: string;
+  hard: string;
+  /** used/hard as 0-100+, undefined when hard is unparsable or zero. */
+  pct?: number;
+}
+
+export interface NamespaceQuotaStatus {
+  name: string;
+  resources: NamespaceQuotaResource[];
+}
+
+export interface NamespaceOverview {
+  namespaces: string[];
+  /** Namespace phase (Active/Terminating) — only when a single namespace is scoped. */
+  status?: string;
+  inventory: NamespaceInventoryEntry[];
+  workloadHealth: OverviewKindHealth[];
+  issues: OverviewWorkloadIssue[];
+  failingPods: OverviewProblemPod[];
+  quotas: NamespaceQuotaStatus[];
+  warningEvents: OverviewWarningEvent[];
+  /** Operator rollups scoped to this namespace (namespaced resources only). */
+  operators: OperatorRollup[];
 }
 
 // ---- Security audit ----

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -748,6 +748,28 @@ export interface OverviewRestart {
   reason?: string;
 }
 
+export interface CertExpiryEntry {
+  source: 'cert-manager' | 'tls-secret';
+  kind: string;
+  group: string;
+  version: string;
+  plural: string;
+  namespace: string;
+  name: string;
+  notAfter: string;
+}
+
+export interface OverviewCertificates {
+  /** Certificates tracked: cert-manager Certificates plus kubernetes.io/tls Secrets (cert-manager-owned secrets deduped). */
+  total: number;
+  /** Expired or expiring within 30 days, soonest first. */
+  expiring: CertExpiryEntry[];
+  /** API server serving certificate expiry (cluster overview only), from the TLS handshake. */
+  apiServerNotAfter?: string;
+  /** Secrets are RBAC-denied — TLS secret expiry unknown. */
+  secretsUnavailable?: boolean;
+}
+
 export interface ClusterOverview {
   counts: {
     nodes: number;
@@ -772,6 +794,8 @@ export interface ClusterOverview {
   workloadHealth: OverviewKindHealth[];
   /** Rollups for operators whose CRDs are installed (cert-manager, Argo, Flux, KEDA, Karpenter). */
   operators: OperatorRollup[];
+  /** TLS certificate expiry rollup. */
+  certificates: OverviewCertificates;
 }
 
 // ---- Pod resource usage vs requests/limits (overview panels) ----
@@ -835,6 +859,8 @@ export interface NamespaceOverview {
   warningEvents: OverviewWarningEvent[];
   /** Operator rollups scoped to this namespace (namespaced resources only). */
   operators: OperatorRollup[];
+  /** TLS certificate expiry rollup scoped to this namespace. */
+  certificates: OverviewCertificates;
 }
 
 // ---- Security audit ----

--- a/shared/src/jsonpath.ts
+++ b/shared/src/jsonpath.ts
@@ -1,9 +1,11 @@
 /**
  * Minimal evaluator for the Kubernetes JSONPath subset used by CRD
  * additionalPrinterColumns: leading `.`, dot segments, numeric indices
- * (`[0]`), quoted keys (`['x.y/z']`) and wildcards (`[*]` / `.*`, whose
- * results are joined with `,`). Runs in the browser against live-watched
- * objects; returns undefined instead of throwing on any malformed path.
+ * (`[0]`), quoted keys (`['x.y/z']`), wildcards (`[*]` / `.*`, whose
+ * results are joined with `,`) and equality filters
+ * (`[?(@.type=="Ready")]`, as used by cert-manager and most operators'
+ * condition columns). Runs in the browser against live-watched objects;
+ * returns undefined instead of throwing on any malformed path.
  */
 export function evalPrinterColumnPath(obj: unknown, jsonPath: string): unknown {
   let segments = parsedPathCache.get(jsonPath);
@@ -22,6 +24,8 @@ export function evalPrinterColumnPath(obj: unknown, jsonPath: string): unknown {
         else if (typeof v === 'object') next.push(...Object.values(v as Record<string, unknown>));
       } else if (typeof seg === 'number') {
         if (Array.isArray(v)) next.push(v[seg]);
+      } else if (typeof seg === 'object') {
+        if (Array.isArray(v)) next.push(...v.filter((el) => filterMatches(el, seg)));
       } else if (typeof v === 'object' && !Array.isArray(v)) {
         next.push((v as Record<string, unknown>)[seg]);
       }
@@ -41,10 +45,28 @@ export function evalPrinterColumnPath(obj: unknown, jsonPath: string): unknown {
     .join(',');
 }
 
-type Segment = string | number;
+interface FilterSegment {
+  /** Key path after `@.`, e.g. ['type'] for `@.type=="Ready"`. */
+  path: string[];
+  value: string;
+}
+
+type Segment = string | number | FilterSegment;
+
+function filterMatches(el: unknown, filter: FilterSegment): boolean {
+  let v: unknown = el;
+  for (const key of filter.path) {
+    if (v === null || typeof v !== 'object' || Array.isArray(v)) return false;
+    v = (v as Record<string, unknown>)[key];
+  }
+  if (typeof v === 'string') return v === filter.value;
+  if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') return String(v) === filter.value;
+  return false;
+}
 
 const parsedPathCache = new Map<string, Segment[] | undefined>();
 const INDEX_RE = /^-?\d+$/;
+const FILTER_RE = /^\?\(\s*@((?:\.[A-Za-z0-9_-]+)+)\s*==\s*(['"])(.*)\2\s*\)$/;
 
 function parsePath(jsonPath: string): Segment[] | undefined {
   let path = jsonPath.trim();
@@ -72,7 +94,11 @@ function parsePath(jsonPath: string): Segment[] | undefined {
       if (inner === '*') segments.push('*');
       else if (INDEX_RE.test(inner)) segments.push(Number(inner));
       else if ((inner.startsWith("'") && inner.endsWith("'")) || (inner.startsWith('"') && inner.endsWith('"'))) segments.push(inner.slice(1, -1));
-      else return undefined;
+      else {
+        const filter = FILTER_RE.exec(inner);
+        if (!filter) return undefined;
+        segments.push({ path: filter[1]!.slice(1).split('.'), value: filter[3]! });
+      }
     } else {
       // bare leading key without dot (rare but tolerated)
       let key = '';


### PR DESCRIPTION
## Overview expansion

The cluster overview previously rolled up Deployment availability only, with no namespace-level view.

**Unified workload health** — one section covering Deployments, StatefulSets, DaemonSets, Jobs, CronJobs, HPAs, PVCs, PDBs, and ResourceQuotas: per-kind tiles with unhealthy counts plus a single issue table (unavailable replicas, failed Jobs and last CronJob runs via owner references, non-bound claims, budgets with zero disruptions allowed, quotas at/near their limits).

**Operator rollups** — cert-manager, Argo, Flux, KEDA, and Karpenter, driven by which CRDs are installed (served storage version resolved from the CRD). Ready/total per resource kind, with not-ready instances linked to the list. Argo Applications use `status.health`/`status.sync` rather than conditions.

**Pod usage panels** — live usage joined with spec requests/limits server-side; two threshold panels (usage ≥ % of limit, usage ≥ × of requests) with selectable thresholds persisted in UI prefs and filtered client-side, so changing a threshold never refetches.

**Namespace-aware via the nav filter** — selecting namespaces in the global filter turns the overview into a namespace operational view: `kubectl get all -n`-style inventory across builtin kinds plus installed popular CRDs, scoped health, operator rollups, ResourceQuota usage bars, pod panels, failing pods, and warning events. Every tile and issue row deep-links to the matching resource list, which inherits the same namespace filter.

## Certificate expiry

- Future timestamps (`notAfter`, `renewalTime`, CRD date columns) rendered a clamped "0s ago"; relative rendering is now direction-aware ("in 47d" / "5d ago").
- The printer-column JSONPath evaluator supports equality filters (`.status.conditions[?(@.type=="Ready")].status`), so condition-driven columns (cert-manager Ready/Status and similar) resolve instead of showing a dash.
- cert-manager Certificates get an expiry headline in the detail drawer — expires/renews with warn states, including a callout when the renewal time passed without a renewal.
- The overview tracks TLS certificate expiry: cert-manager Certificates plus standalone `kubernetes.io/tls` Secrets (parsed server-side, cached per revision, cert-manager-owned secrets deduped), with a stat card and an "expiring within 30 days" table. The API server serving certificate is read from the TLS handshake (cached an hour, best-effort on proxied clusters).

## Verification

Playwright runs against kind with seeded fixtures (broken Deployment, Pending PVC, blocked PDB, at-limit quota, short/long-lived TLS secrets, cert-manager CRD with ready and not-ready instances) covering: section rendering, threshold panels, nav-filter scoping, list inheritance of the namespace filter, issue-row deep links, secret dedupe, and the expiry headline. Ready/Status columns and the expiry headline additionally verified read-only against a real cert-manager installation. `pnpm typecheck`, `lint`, `build`, and server tests pass.