### PR TITLE
Fix bulk actions not appearing after select-all

### DIFF
--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -272,8 +272,14 @@ export function ResourceTable({
         onRowSelectionModelChange={
           onSelectionChange
             ? (model) => {
+                // The header "select all" checkbox reports an exclude-type
+                // model whose ids are the deselected rows.
                 const ids = model.ids instanceof Set ? model.ids : new Set();
-                onSelectionChange(filtered.filter((r) => ids.has(r.obj.metadata.uid)));
+                const selected =
+                  model.type === 'exclude'
+                    ? filtered.filter((r) => !ids.has(r.obj.metadata.uid))
+                    : filtered.filter((r) => ids.has(r.obj.metadata.uid));
+                onSelectionChange(selected);
               }
             : undefined
         }


### PR DESCRIPTION
## Problem

Selecting all rows via the header checkbox on a resource list did not surface the bulk action buttons (Logs / Restart / Delete). They only appeared when rows were selected individually.

## Cause

MUI X DataGrid v8+ reports row selection as `{ type: 'include' | 'exclude', ids: Set }`. The header select-all checkbox emits an **exclude**-type model whose `ids` are the *deselected* rows (an empty set right after select-all). `ResourceTable`'s `onRowSelectionModelChange` handler ignored `type` and always treated `ids` as the included set, so select-all mapped to zero selected rows.

## Fix

Invert the id set against the filtered rows when the model is exclude-typed; include-typed models behave as before.

## Verification

Verified against a built client and a live kind cluster (22 pods):
- select-all → toolbar shows "Logs (22)" / "Delete (22)", footer shows "22 rows selected"
- deselect-all → bulk buttons disappear
- single-row selection → "Delete (1)" (unchanged behavior)

`tsc --noEmit` passes.