### PR TITLE
Complete the port-forward workflow

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -23,7 +23,9 @@ import type {
   NetworkAgentInstallResult,
   NetworkAgentStatus,
   NetworkAgentUninstallResult,
+  LocalPortCheckResponse,
   PortForwardInfo,
+  PortForwardPreflightResponse,
   PortForwardRequest,
   ResourceKindInfo,
   WatchStatusState,
@@ -1405,4 +1407,30 @@ export function useStopPortForward() {
     mutationFn: (id: string) => apiFetch(`/api/portforwards/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     onSuccess: () => void qc.invalidateQueries({ queryKey: ['portforwards'] }),
   });
+}
+
+export function useStopAllPortForwards() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiFetch('/api/portforwards', { method: 'DELETE' }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['portforwards'] }),
+  });
+}
+
+/** RBAC preflight for pods/portforward create in a namespace. */
+export function usePortForwardPreflight(vars: { ctx: string; namespace: string } | undefined) {
+  return useQuery({
+    queryKey: ['portforward-preflight', vars?.ctx, vars?.namespace],
+    queryFn: () =>
+      apiFetch<PortForwardPreflightResponse>(
+        `/api/contexts/${encodeURIComponent(vars!.ctx)}/portforwards/preflight?namespace=${encodeURIComponent(vars!.namespace)}`,
+      ),
+    enabled: !!vars,
+    staleTime: 60_000,
+  });
+}
+
+/** Whether a local port can be bound right now (advisory — start() re-checks). */
+export function checkLocalPort(port: number): Promise<LocalPortCheckResponse> {
+  return apiFetch<LocalPortCheckResponse>(`/api/portforwards/port-check?port=${port}`);
 }

--- a/client/src/components/PortForwardDialog.tsx
+++ b/client/src/components/PortForwardDialog.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import Checkbox from '@mui/material/Checkbox';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import type { KubeObject, PortForwardTargetKind } from '@kubus/shared';
+import { checkLocalPort, usePortForwardPreflight, useResourceList, useStartPortForward } from '../api/queries.js';
+import { forwardPrefKey, usePortForwardPrefsStore } from '../state/portforward-prefs.js';
+import { showToast } from '../state/toast.js';
+
+const REQUEST_KINDS: Record<string, PortForwardTargetKind> = {
+  Pod: 'pod',
+  Service: 'service',
+  Deployment: 'deployment',
+  StatefulSet: 'statefulset',
+  DaemonSet: 'daemonset',
+  ReplicaSet: 'replicaset',
+};
+
+export function isForwardableKind(kind: string | undefined): boolean {
+  return !!kind && kind in REQUEST_KINDS;
+}
+
+interface PortOption {
+  port: number;
+  label: string;
+}
+
+interface ContainerWithPorts {
+  name: string;
+  ports?: Array<{ containerPort: number; name?: string; protocol?: string }>;
+}
+
+function containerPortOptions(containers: ContainerWithPorts[]): PortOption[] {
+  const seen = new Set<number>();
+  const options: PortOption[] = [];
+  for (const c of containers) {
+    for (const p of c.ports ?? []) {
+      if ((p.protocol ?? 'TCP') !== 'TCP' || seen.has(p.containerPort)) continue;
+      seen.add(p.containerPort);
+      options.push({ port: p.containerPort, label: `${p.containerPort}${p.name ? ` · ${p.name}` : ''} (${c.name})` });
+    }
+  }
+  return options;
+}
+
+/** Known TCP ports of the target, shown as suggestions in the dialog. */
+function portOptions(kind: string, obj: KubeObject): PortOption[] {
+  if (kind === 'Service') {
+    const ports = (obj.spec as { ports?: Array<{ name?: string; port: number; targetPort?: number | string; protocol?: string }> } | undefined)?.ports ?? [];
+    return ports
+      .filter((p) => (p.protocol ?? 'TCP') === 'TCP')
+      .map((p) => ({
+        port: p.port,
+        label: `${p.port}${p.name ? ` · ${p.name}` : ''}${p.targetPort !== undefined && p.targetPort !== p.port ? ` → ${p.targetPort}` : ''}`,
+      }));
+  }
+  if (kind === 'Pod') {
+    const spec = obj.spec as { containers?: ContainerWithPorts[]; initContainers?: ContainerWithPorts[] } | undefined;
+    return containerPortOptions([...(spec?.containers ?? []), ...(spec?.initContainers ?? [])]);
+  }
+  const template = (obj.spec as { template?: { spec?: { containers?: ContainerWithPorts[] } } } | undefined)?.template?.spec;
+  return containerPortOptions(template?.containers ?? []);
+}
+
+interface PodLikeSpec {
+  containers?: ContainerWithPorts[];
+  selector?: { matchLabels?: Record<string, string> };
+  template?: { metadata?: { labels?: Record<string, string> }; spec?: { containers?: ContainerWithPorts[] } };
+}
+
+/**
+ * Ports discovered via Services selecting this pod/workload. Charts often omit
+ * containerPort declarations, leaving the Service targetPort as the only
+ * record of what the pod actually listens on.
+ */
+function serviceDerivedOptions(kind: string, obj: KubeObject, services: KubeObject[] | undefined): PortOption[] {
+  if (kind === 'Service' || !services?.length) return [];
+  const spec = obj.spec as PodLikeSpec | undefined;
+  const labels = kind === 'Pod' ? obj.metadata.labels : (spec?.template?.metadata?.labels ?? spec?.selector?.matchLabels);
+  if (!labels) return [];
+  const containers = kind === 'Pod' ? (spec?.containers ?? []) : (spec?.template?.spec?.containers ?? []);
+  const options: PortOption[] = [];
+  const seen = new Set<number>();
+  for (const svc of services) {
+    const svcSpec = svc.spec as
+      | { selector?: Record<string, string>; ports?: Array<{ name?: string; port: number; targetPort?: number | string; protocol?: string }> }
+      | undefined;
+    const selector = Object.entries(svcSpec?.selector ?? {});
+    if (!selector.length || !selector.every(([k, v]) => labels[k] === v)) continue;
+    for (const p of svcSpec?.ports ?? []) {
+      if ((p.protocol ?? 'TCP') !== 'TCP') continue;
+      const target = p.targetPort ?? p.port;
+      const podPort =
+        typeof target === 'number' ? target : containers.flatMap((c) => c.ports ?? []).find((cp) => cp.name === target)?.containerPort;
+      if (podPort === undefined || seen.has(podPort)) continue;
+      seen.add(podPort);
+      options.push({ port: podPort, label: `${podPort}${p.name ? ` · ${p.name}` : ''} (service ${svc.metadata.name})` });
+    }
+  }
+  return options;
+}
+
+type LocalPortStatus = 'auto' | 'checking' | 'free' | 'busy' | 'invalid';
+
+function parsePort(text: string): number | undefined {
+  const n = Number(text);
+  return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : undefined;
+}
+
+export function PortForwardDialog({
+  ctx,
+  kind,
+  obj,
+  initialRemotePort,
+  onClose,
+}: {
+  ctx: string;
+  /** Kubernetes kind: Pod, Service, Deployment, StatefulSet, DaemonSet or ReplicaSet. */
+  kind: string;
+  obj: KubeObject;
+  /** Pre-select this remote port (inline “forward” buttons beside a port). */
+  initialRemotePort?: number;
+  onClose: () => void;
+}) {
+  const start = useStartPortForward();
+  const name = obj.metadata.name;
+  const namespace = obj.metadata.namespace ?? '';
+  const preflight = usePortForwardPreflight(namespace ? { ctx, namespace } : undefined);
+  const denied = preflight.data?.allowed === false;
+
+  const remember = usePortForwardPrefsStore((s) => s.remember);
+  const prefs = usePortForwardPrefsStore((s) => s.byTarget);
+  const prefFor = (port: number) => prefs[forwardPrefKey(ctx, namespace, kind, name, port)];
+
+  const declaredOptions = useMemo(() => portOptions(kind, obj), [kind, obj]);
+  // Services selecting this pod/workload fill the gap when the pod template
+  // declares no ports (grafana-style charts).
+  const servicesQuery = useResourceList(kind !== 'Service' && namespace ? { ctx, group: '', version: 'v1', plural: 'services', namespace } : undefined);
+  const options = useMemo(() => {
+    const declared = new Set(declaredOptions.map((o) => o.port));
+    return [...declaredOptions, ...serviceDerivedOptions(kind, obj, servicesQuery.data?.items).filter((o) => !declared.has(o.port))];
+  }, [declaredOptions, kind, obj, servicesQuery.data?.items]);
+
+  // Each field stores only what the user chose; null means "follow the
+  // suggestion", so async-arriving options (service-derived ports) flow in
+  // without effects and without stomping manual edits.
+  const [remoteChoice, setRemoteChoice] = useState<{ text: string; custom: boolean } | null>(
+    initialRemotePort !== undefined ? { text: String(initialRemotePort), custom: false } : null,
+  );
+  const remoteText = remoteChoice?.text ?? String(options[0]?.port ?? 80);
+  const customRemote = remoteChoice?.custom || !options.some((o) => String(o.port) === remoteText);
+  const remotePort = parsePort(remoteText);
+
+  // Local port suggestion: last remembered for this target+port, else the
+  // remote port itself.
+  const [localChoice, setLocalChoice] = useState<string | null>(null);
+  const localText = localChoice ?? (remotePort !== undefined ? String(prefFor(remotePort)?.localPort ?? remotePort) : '');
+  const localPort = parsePort(localText);
+
+  const [browserChoice, setBrowserChoice] = useState<boolean | null>(null);
+  const openInBrowser = browserChoice ?? ((remotePort !== undefined && prefFor(remotePort)?.openInBrowser) || false);
+
+  // Advisory availability check for the chosen local port; start() re-checks.
+  const [localStatus, setLocalStatus] = useState<LocalPortStatus>('auto');
+  const checkSeq = useRef(0);
+  useEffect(() => {
+    const seq = ++checkSeq.current;
+    if (localText === '') {
+      setLocalStatus('auto');
+      return;
+    }
+    const port = parsePort(localText);
+    if (port === undefined) {
+      setLocalStatus('invalid');
+      return;
+    }
+    setLocalStatus('checking');
+    const timer = setTimeout(() => {
+      checkLocalPort(port)
+        .then((r) => {
+          if (checkSeq.current === seq) setLocalStatus(r.available ? 'free' : 'busy');
+        })
+        .catch(() => {
+          if (checkSeq.current === seq) setLocalStatus('free');
+        });
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [localText]);
+
+  const [startError, setStartError] = useState<string>();
+
+  const localHelper =
+    localStatus === 'busy'
+      ? `Port ${localText} is already in use on your machine — pick another or leave empty for auto.`
+      : localStatus === 'invalid'
+        ? 'Enter a port between 1 and 65535, or leave empty.'
+        : localStatus === 'auto'
+          ? 'Empty — a free port is picked automatically.'
+          : ' ';
+
+  const doStart = () => {
+    if (remotePort === undefined) return;
+    setStartError(undefined);
+    start.mutate(
+      {
+        ctx,
+        body: { namespace, kind: REQUEST_KINDS[kind] ?? 'pod', name, remotePort, localPort },
+      },
+      {
+        onSuccess: (info) => {
+          // Auto picks are not remembered so a stale random port is never suggested.
+          remember(forwardPrefKey(ctx, namespace, kind, name, remotePort), {
+            ...(localPort !== undefined ? { localPort } : {}),
+            openInBrowser,
+          });
+          showToast('success', `Forwarding localhost:${info.localPort} → ${name}:${info.remotePort}`);
+          if (openInBrowser) window.open(`http://localhost:${info.localPort}`, '_blank', 'noopener');
+          onClose();
+        },
+        onError: (e) => setStartError(e instanceof Error ? e.message : String(e)),
+      },
+    );
+  };
+
+  return (
+    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>
+        Port forward — {kind.toLowerCase()}/{name}
+      </DialogTitle>
+      <DialogContent sx={{ pt: '12px !important' }}>
+        <Stack spacing={2}>
+          {denied && (
+            <Alert severity="error">
+              Your user is not allowed to port-forward in namespace <b>{namespace}</b> on cluster <b>{ctx}</b>
+              {preflight.data?.reason ? ` (${preflight.data.reason})` : ''}. Ask a cluster admin for a role granting <b>create</b> on{' '}
+              <b>pods/portforward</b>.
+            </Alert>
+          )}
+          {startError && !denied && <Alert severity="error">{startError}</Alert>}
+          {options.length > 0 && !customRemote ? (
+            <FormControl fullWidth>
+              <InputLabel id="pf-remote-port">{kind} port</InputLabel>
+              <Select
+                labelId="pf-remote-port"
+                label={`${kind} port`}
+                value={remoteText}
+                onChange={(e) => {
+                  if (e.target.value === 'custom') setRemoteChoice({ text: remoteText, custom: true });
+                  else setRemoteChoice({ text: e.target.value, custom: false });
+                }}
+              >
+                {options.map((o) => (
+                  <MenuItem key={o.port} value={String(o.port)}>
+                    {o.label}
+                  </MenuItem>
+                ))}
+                <MenuItem value="custom">Custom port…</MenuItem>
+              </Select>
+            </FormControl>
+          ) : (
+            <TextField
+              fullWidth
+              label={`${kind} port`}
+              type="number"
+              value={remoteText}
+              error={remotePort === undefined}
+              onChange={(e) => setRemoteChoice({ text: e.target.value, custom: true })}
+            />
+          )}
+          <TextField
+            fullWidth
+            label="Local port"
+            type="number"
+            placeholder="auto"
+            value={localText}
+            error={localStatus === 'busy' || localStatus === 'invalid'}
+            helperText={localHelper}
+            onChange={(e) => setLocalChoice(e.target.value)}
+          />
+          <FormControlLabel
+            control={
+              <Checkbox checked={openInBrowser} onChange={(e) => setBrowserChoice(e.target.checked)} />
+            }
+            label="Open in browser when started"
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          disabled={start.isPending || denied || remotePort === undefined || localStatus === 'busy' || localStatus === 'invalid'}
+          onClick={doStart}
+        >
+          {start.isPending ? 'Starting…' : 'Start'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -54,7 +54,6 @@ import {
   useRolloutRestart,
   useScale,
   useSetImage,
-  useStartPortForward,
   useSuspendCronJob,
   useTriggerCronJob,
 } from '../api/queries.js';
@@ -64,6 +63,7 @@ import { useIsProtected } from '../state/clusters.js';
 import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 import { FileCopyDialog } from './FileCopyDialog.js';
+import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
 import { podContainerNames } from '../kube-display.js';
 import { kindListPath } from '../resource-links.js';
 
@@ -206,7 +206,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const isNode = actionKind === 'Node';
   const isCronJob = actionKind === 'CronJob';
   const isJob = actionKind === 'Job';
-  const canForward = isPod || actionKind === 'Service';
+  const canForward = isForwardableKind(actionKind);
   const canViewLogs = isLogTargetKind(actionKind ?? '');
   const unschedulable = isNode && !!(obj.spec as { unschedulable?: boolean })?.unschedulable;
   const cjSuspended = isCronJob && !!(obj.spec as { suspend?: boolean })?.suspend;
@@ -578,7 +578,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
       {dialog === 'debug' && <DebugDialog target={target} onClose={() => setDialog(null)} onDone={ok} onError={fail} />}
       {dialog === 'files' && <FileCopyDialog ctx={ctx} obj={obj} onClose={() => setDialog(null)} />}
       {dialog === 'set-image' && <SetImageDialog target={target} onClose={() => setDialog(null)} onDone={ok} onError={fail} />}
-      {dialog === 'forward' && <PortForwardDialog target={target} onClose={() => setDialog(null)} onDone={ok} onError={fail} />}
+      {dialog === 'forward' && <PortForwardDialog ctx={ctx} kind={actionKind ?? kind} obj={obj} onClose={() => setDialog(null)} />}
       {dialog === 'drain' && <DrainDialog target={target} onClose={() => setDialog(null)} />}
     </>
   );
@@ -897,58 +897,6 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
           }
         >
           {debug.isPending ? 'Starting…' : 'Start'}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-}
-
-function PortForwardDialog({ target, onClose, onDone, onError }: { target: RowActionTarget; onClose: () => void; onDone: (t: string) => void; onError: (e: unknown) => void }) {
-  const start = useStartPortForward();
-  const isPod = target.kind === 'Pod';
-  const defaultPort = isPod
-    ? ((target.obj.spec as { containers?: Array<{ ports?: Array<{ containerPort: number }> }> })?.containers?.[0]?.ports?.[0]?.containerPort ?? 80)
-    : ((target.obj.spec as { ports?: Array<{ port: number }> })?.ports?.[0]?.port ?? 80);
-  const [remotePort, setRemotePort] = useState(defaultPort);
-  const [localPort, setLocalPort] = useState<number | ''>('');
-  return (
-    <Dialog open onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Port forward {target.obj.metadata.name}</DialogTitle>
-      <DialogContent sx={{ display: 'flex', gap: 2, pt: '12px !important' }}>
-        <TextField label={`${target.kind} port`} type="number" value={remotePort} onChange={(e) => setRemotePort(Number(e.target.value))} />
-        <TextField label="Local port (auto)" type="number" value={localPort} onChange={(e) => setLocalPort(e.target.value === '' ? '' : Number(e.target.value))} placeholder="auto" />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button
-          variant="contained"
-          disabled={start.isPending}
-          onClick={() =>
-            start.mutate(
-              {
-                ctx: target.ctx,
-                body: {
-                  namespace: target.obj.metadata.namespace ?? '',
-                  kind: isPod ? 'pod' : 'service',
-                  name: target.obj.metadata.name,
-                  remotePort,
-                  localPort: localPort === '' ? undefined : localPort,
-                },
-              },
-              {
-                onSuccess: (info) => {
-                  onClose();
-                  onDone(`Forwarding localhost:${info.localPort} → ${info.name}:${info.remotePort}`);
-                },
-                onError: (e) => {
-                  onClose();
-                  onError(e);
-                },
-              },
-            )
-          }
-        >
-          Start
         </Button>
       </DialogActions>
     </Dialog>

--- a/client/src/components/detail/ContainerCards.tsx
+++ b/client/src/components/detail/ContainerCards.tsx
@@ -1,6 +1,7 @@
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { AgeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
@@ -19,7 +20,7 @@ export interface ContainerCardData {
   stateMessage?: string;
   restarts?: number;
   lastRestart?: { reason?: string; at?: string };
-  ports?: string;
+  ports?: Array<{ port: number; protocol?: string; name?: string }>;
   resources: ContainerResources;
   usage?: { cpuMilli: number; memBytes: number };
   /** Pods aggregated into `usage` (workload views); scales the bar's denominator. */
@@ -27,18 +28,18 @@ export interface ContainerCardData {
 }
 
 /** Card grid for a pod's (or workload template's) containers. */
-export function ContainerCards({ items }: { items: ContainerCardData[] }) {
+export function ContainerCards({ items, onForwardPort }: { items: ContainerCardData[]; onForwardPort?: (port: number) => void }) {
   if (!items.length) return null;
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(270px, 1fr))', gap: 1.5 }}>
       {items.map((c) => (
-        <ContainerCard key={`${c.kind ?? 'app'}:${c.name}`} c={c} />
+        <ContainerCard key={`${c.kind ?? 'app'}:${c.name}`} c={c} onForwardPort={onForwardPort} />
       ))}
     </Box>
   );
 }
 
-function ContainerCard({ c }: { c: ContainerCardData }) {
+function ContainerCard({ c, onForwardPort }: { c: ContainerCardData; onForwardPort?: (port: number) => void }) {
   const showRestarts = (c.restarts ?? 0) > 0 || c.lastRestart;
   return (
     <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.5, minWidth: 0 }}>
@@ -98,10 +99,31 @@ function ContainerCard({ c }: { c: ContainerCardData }) {
           )}
         </Typography>
       )}
-      {c.ports && (
-        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.25 }}>
-          Ports {c.ports}
-        </Typography>
+      {!!c.ports?.length && (
+        <Stack direction="row" sx={{ alignItems: 'center', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+          <Typography variant="caption" color="text.secondary">
+            Ports
+          </Typography>
+          {c.ports.map((p) => {
+            const forwardable = onForwardPort && (p.protocol ?? 'TCP') === 'TCP';
+            const chip = (
+              <Chip
+                label={`${p.port}${p.name ? ` · ${p.name}` : ''}/${p.protocol ?? 'TCP'}`}
+                sx={{ height: 18, fontSize: 11 }}
+                clickable={!!forwardable}
+                onClick={forwardable ? () => onForwardPort(p.port) : undefined}
+              />
+            );
+            const key = `${p.port}/${p.protocol ?? 'TCP'}`;
+            return forwardable ? (
+              <Tooltip key={key} title={`Forward port ${p.port}`}>
+                {chip}
+              </Tooltip>
+            ) : (
+              <span key={key}>{chip}</span>
+            );
+          })}
+        </Stack>
       )}
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5, mt: 1 }}>
         <Meter

--- a/client/src/components/detail/DeploymentDetail.tsx
+++ b/client/src/components/detail/DeploymentDetail.tsx
@@ -2,7 +2,8 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import type { ContainerUsage, KubeObject } from '@kubus/shared';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { PortForwardDialog } from '../PortForwardDialog.js';
 import { useResourceList, useResourceMetrics } from '../../api/queries.js';
 import { containerResources, workloadReady } from '../../kube-display.js';
 import { ReadyCounter } from '../ReadyCounter.js';
@@ -20,7 +21,7 @@ interface TemplateContainer {
   name: string;
   image?: string;
   restartPolicy?: string;
-  ports?: Array<{ containerPort: number; protocol?: string }>;
+  ports?: Array<{ containerPort: number; protocol?: string; name?: string }>;
   resources?: { requests?: Record<string, string>; limits?: Record<string, string> };
 }
 
@@ -52,6 +53,7 @@ function ownedBy(obj: KubeObject, uid: string | undefined): boolean {
 const deploymentGoodWhen = (type: string): 'True' | 'False' => (type === 'ReplicaFailure' ? 'False' : 'True');
 
 export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
+  const [forwardPort, setForwardPort] = useState<number>();
   const namespace = obj.metadata.namespace;
   const spec = obj.spec as DeploymentSpec | undefined;
   const labelSelector = selectorToString(spec?.selector);
@@ -99,7 +101,7 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
         name: c.name,
         image: c.image,
         kind,
-        ports: (c.ports ?? []).map((p) => `${p.containerPort}/${p.protocol ?? 'TCP'}`).join(', ') || undefined,
+        ports: (c.ports ?? []).map((p) => ({ port: p.containerPort, protocol: p.protocol, name: p.name })),
         resources: containerResources(c),
         usage: usage ? { cpuMilli: usage.cpuMilli, memBytes: usage.memBytes } : undefined,
         podCount: usage?.pods,
@@ -128,7 +130,7 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
         <ConditionChips obj={obj} goodWhen={deploymentGoodWhen} />
       </Stack>
       <Section title="Containers" count={cards.length}>
-        <ContainerCards items={cards} />
+        <ContainerCards items={cards} onForwardPort={setForwardPort} />
       </Section>
       <Section title="Pods" count={pods.length}>
         <PodMiniList
@@ -150,6 +152,9 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
       <KeyValueSection title="Labels" entries={obj.metadata.labels} />
       <KeyValueSection title="Annotations" entries={obj.metadata.annotations} defaultOpen={false} />
       <MetadataSection obj={obj} ctx={ctx} defaultOpen={false} />
+      {forwardPort !== undefined && (
+        <PortForwardDialog ctx={ctx} kind="Deployment" obj={obj} initialRemotePort={forwardPort} onClose={() => setForwardPort(undefined)} />
+      )}
     </Stack>
   );
 }

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -18,6 +18,7 @@ import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import type { ContainerUsage, KubeObject, PodEnvVar } from '@kubus/shared';
 import { gvkForKind } from '@kubus/shared';
 import { ConditionChips, KeyValueChips, KeyValueSection, MetadataSection } from './GenericDetail.js';
+import { PortForwardDialog } from '../PortForwardDialog.js';
 import { PodProblems } from './PodProblems.js';
 import { Section } from './Section.js';
 import { ContainerCards, type ContainerCardData } from './ContainerCards.js';
@@ -34,7 +35,7 @@ interface ContainerSpec {
   name: string;
   image?: string;
   restartPolicy?: string;
-  ports?: Array<{ containerPort: number; protocol?: string }>;
+  ports?: Array<{ containerPort: number; protocol?: string; name?: string }>;
   volumeMounts?: Array<{ name: string; mountPath: string; readOnly?: boolean; subPath?: string }>;
   resources?: { requests?: Record<string, string>; limits?: Record<string, string> };
 }
@@ -84,7 +85,7 @@ function containerCard(c: ContainerSpec, st: ContainerStatus | undefined, usage:
     stateMessage: stateKey && stateKey !== 'running' ? st!.state![stateKey]?.message : undefined,
     restarts: st?.restartCount,
     lastRestart: last ? { reason: last.reason, at: last.finishedAt } : undefined,
-    ports: (c.ports ?? []).map((p) => `${p.containerPort}/${p.protocol ?? 'TCP'}`).join(', ') || undefined,
+    ports: (c.ports ?? []).map((p) => ({ port: p.containerPort, protocol: p.protocol, name: p.name })),
     resources: containerResources(c),
     usage: usage ? { cpuMilli: usage.cpuMilli, memBytes: usage.memBytes } : undefined,
   };
@@ -100,6 +101,7 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
   const initStatusByName = new Map((status?.initContainerStatuses ?? []).map((c) => [c.name, c]));
   const push = useDetailStore((s) => s.push);
   const namespace = obj.metadata.namespace;
+  const [forwardPort, setForwardPort] = useState<number>();
 
   const metricsQuery = useResourceMetrics([ctx], 'pods');
   const usageByContainer = useMemo(() => {
@@ -143,7 +145,7 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
       </Stack>
       <PodProblems obj={obj} ctx={ctx} />
       <Section title="Containers" count={mainCards.length}>
-        <ContainerCards items={mainCards} />
+        <ContainerCards items={mainCards} onForwardPort={terminal ? undefined : setForwardPort} />
       </Section>
       {initCards.length > 0 && (
         <Section title="Init containers" count={initCards.length}>
@@ -157,6 +159,9 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
       <KeyValueSection title="Labels" entries={obj.metadata.labels} />
       <KeyValueSection title="Annotations" entries={obj.metadata.annotations} defaultOpen={false} />
       <MetadataSection obj={obj} ctx={ctx} defaultOpen={false} />
+      {forwardPort !== undefined && (
+        <PortForwardDialog ctx={ctx} kind="Pod" obj={obj} initialRemotePort={forwardPort} onClose={() => setForwardPort(undefined)} />
+      )}
     </Stack>
   );
 }

--- a/client/src/components/detail/ServiceDetail.tsx
+++ b/client/src/components/detail/ServiceDetail.tsx
@@ -1,16 +1,21 @@
+import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import CableIcon from '@mui/icons-material/Cable';
 import type { KubeObject } from '@kubus/shared';
 import { GenericDetail, KeyValueChips } from './GenericDetail.js';
 import { PodMiniList } from './PodMiniList.js';
+import { PortForwardDialog } from '../PortForwardDialog.js';
 import { useResourceList } from '../../api/queries.js';
 
 interface ServiceSpec {
@@ -26,6 +31,7 @@ interface ServiceStatus {
 }
 
 export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
+  const [forwardPort, setForwardPort] = useState<number>();
   const spec = (obj.spec ?? {}) as ServiceSpec;
   const status = (obj.status ?? {}) as ServiceStatus;
   const lbAddresses = (status.loadBalancer?.ingress ?? []).flatMap((i) => {
@@ -66,6 +72,7 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                   <TableCell>Target</TableCell>
                   <TableCell>NodePort</TableCell>
                   <TableCell>Protocol</TableCell>
+                  <TableCell padding="none" />
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -76,6 +83,15 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                     <TableCell>{p.targetPort ?? p.port}</TableCell>
                     <TableCell>{p.nodePort ?? ''}</TableCell>
                     <TableCell>{p.protocol ?? 'TCP'}</TableCell>
+                    <TableCell padding="none" align="right">
+                      {(p.protocol ?? 'TCP') === 'TCP' && (
+                        <Tooltip title={`Forward port ${p.port}`}>
+                          <IconButton size="small" aria-label={`Forward port ${p.port}`} onClick={() => setForwardPort(p.port)}>
+                            <CableIcon fontSize="inherit" />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
@@ -95,6 +111,9 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
         )}
       </Stack>
       <GenericDetail obj={obj} ctx={ctx} />
+      {forwardPort !== undefined && (
+        <PortForwardDialog ctx={ctx} kind="Service" obj={obj} initialRemotePort={forwardPort} onClose={() => setForwardPort(undefined)} />
+      )}
     </Box>
   );
 }

--- a/client/src/pages/PortForwardsPage.tsx
+++ b/client/src/pages/PortForwardsPage.tsx
@@ -1,15 +1,17 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
 import Tooltip from '@mui/material/Tooltip';
 import StopIcon from '@mui/icons-material/Stop';
+import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import CableOutlinedIcon from '@mui/icons-material/CableOutlined';
 import type { GridColDef } from '@mui/x-data-grid';
 import { DataGrid } from '@mui/x-data-grid';
 import type { PortForwardInfo } from '@kubus/shared';
-import { usePortForwards, useStopPortForward } from '../api/queries.js';
+import { usePortForwards, useStopAllPortForwards, useStopPortForward } from '../api/queries.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
@@ -19,6 +21,8 @@ import { PageHeader } from '../components/PageHeader.js';
 export function PortForwardsPage() {
   const { data, isLoading } = usePortForwards();
   const { mutate: stop } = useStopPortForward();
+  const stopAll = useStopAllPortForwards();
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   const columns: GridColDef<PortForwardInfo>[] = useMemo(() => {
     const defs: GridColDef<PortForwardInfo>[] = [
@@ -72,12 +76,42 @@ export function PortForwardsPage() {
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5 }}>
       <PageHeader title="Port Forwards" icon={<CableOutlinedIcon />}>
         <Chip label={`${data?.length ?? 0} active`} variant="outlined" />
+        <Box sx={{ flex: 1 }} />
+        {selectedIds.length > 0 && (
+          <Button
+            size="small"
+            variant="outlined"
+            color="error"
+            startIcon={<StopIcon />}
+            onClick={() => {
+              for (const id of selectedIds) stop(id);
+              setSelectedIds([]);
+            }}
+          >
+            Stop selected ({selectedIds.length})
+          </Button>
+        )}
+        {(data?.length ?? 0) > 0 && (
+          <Button
+            size="small"
+            variant="outlined"
+            color="error"
+            startIcon={<StopCircleOutlinedIcon />}
+            disabled={stopAll.isPending}
+            onClick={() => {
+              stopAll.mutate();
+              setSelectedIds([]);
+            }}
+          >
+            Stop all
+          </Button>
+        )}
       </PageHeader>
       {(data?.length ?? 0) === 0 && !isLoading ? (
         <EmptyState
           icon={<CableOutlinedIcon />}
           title="No active forwards"
-          subtitle="Start one from a Pod or Service row menu (⋮ → Port forward)."
+          subtitle="Start one from a Pod, Service or workload row menu (⋮ → Port forward…), or from the ports listed in a resource's details."
         />
       ) : (
         <DataGrid
@@ -86,6 +120,17 @@ export function PortForwardsPage() {
           loading={isLoading}
           getRowId={(r) => r.id}
           density={grid.density}
+          checkboxSelection
+          disableRowSelectionOnClick
+          onRowSelectionModelChange={(model) => {
+            // The header "select all" checkbox reports an exclude-type model
+            // whose ids are the deselected rows.
+            const ids = model.ids instanceof Set ? model.ids : new Set();
+            const rows = data ?? [];
+            setSelectedIds(
+              (model.type === 'exclude' ? rows.filter((r) => !ids.has(r.id)) : rows.filter((r) => ids.has(r.id))).map((r) => r.id),
+            );
+          }}
           onColumnWidthChange={grid.onColumnWidthChange}
           onCellKeyDown={handleCopyCellKeyDown}
           sx={{ border: 0, ...copyCellGridSx }}

--- a/client/src/state/portforward-prefs.ts
+++ b/client/src/state/portforward-prefs.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+import { kubusStateStorage } from './persist-storage.js';
+
+export interface ForwardTargetPref {
+  /** Last explicitly chosen local port (auto picks are not remembered). */
+  localPort?: number;
+  openInBrowser?: boolean;
+}
+
+interface PortForwardPrefsState {
+  byTarget: Record<string, ForwardTargetPref>;
+  remember: (key: string, pref: ForwardTargetPref) => void;
+}
+
+export function forwardPrefKey(ctx: string, namespace: string, kind: string, name: string, remotePort: number): string {
+  return `${ctx}/${namespace}/${kind}/${name}:${remotePort}`;
+}
+
+export const usePortForwardPrefsStore = create<PortForwardPrefsState>()(
+  persist(
+    (set) => ({
+      byTarget: {},
+      remember: (key, pref) =>
+        set((s) => ({
+          byTarget: { ...s.byTarget, [key]: { ...s.byTarget[key], ...pref } },
+        })),
+    }),
+    {
+      name: 'kubus-portforward-prefs',
+      version: 1,
+      storage: createJSONStorage(() => kubusStateStorage),
+    },
+  ),
+);

--- a/server/src/kube/portforward-manager.ts
+++ b/server/src/kube/portforward-manager.ts
@@ -3,9 +3,10 @@ import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { nanoid } from 'nanoid';
 import type { FastifyBaseLogger } from 'fastify';
-import type { KubeObject, PortForwardInfo, PortForwardPreflightResponse, PortForwardRequest } from '@kubus/shared';
+import type { KubeObject, LogTargetKind, PortForwardInfo, PortForwardPreflightResponse, PortForwardRequest } from '@kubus/shared';
 import type { ClusterManager } from './cluster-manager.js';
 import { resourcePath } from './raw-client.js';
+import { resolveTargetPods } from './target-pods.js';
 import { HttpProblem } from '../util/errors.js';
 
 interface ActiveForward {
@@ -14,29 +15,12 @@ interface ActiveForward {
   sockets: Set<net.Socket>;
 }
 
-const WORKLOAD_PLURALS: Partial<Record<PortForwardRequest['kind'], string>> = {
-  deployment: 'deployments',
-  statefulset: 'statefulsets',
-  daemonset: 'daemonsets',
-  replicaset: 'replicasets',
+const WORKLOADS: Partial<Record<PortForwardRequest['kind'], { plural: string; kind: LogTargetKind }>> = {
+  deployment: { plural: 'deployments', kind: 'Deployment' },
+  statefulset: { plural: 'statefulsets', kind: 'StatefulSet' },
+  daemonset: { plural: 'daemonsets', kind: 'DaemonSet' },
+  replicaset: { plural: 'replicasets', kind: 'ReplicaSet' },
 };
-
-interface LabelSelector {
-  matchLabels?: Record<string, string>;
-  matchExpressions?: Array<{ key: string; operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist'; values?: string[] }>;
-}
-
-function selectorToString(selector: LabelSelector | undefined): string | undefined {
-  if (!selector) return undefined;
-  const parts = Object.entries(selector.matchLabels ?? {}).map(([k, v]) => `${k}=${v}`);
-  for (const expr of selector.matchExpressions ?? []) {
-    if (expr.operator === 'In') parts.push(`${expr.key} in (${(expr.values ?? []).join(',')})`);
-    else if (expr.operator === 'NotIn') parts.push(`${expr.key} notin (${(expr.values ?? []).join(',')})`);
-    else if (expr.operator === 'Exists') parts.push(expr.key);
-    else if (expr.operator === 'DoesNotExist') parts.push(`!${expr.key}`);
-  }
-  return parts.length ? parts.join(',') : undefined;
-}
 
 function isPodReady(pod: KubeObject): boolean {
   const status = pod.status as { phase?: string; conditions?: Array<{ type?: string; status?: string }> } | undefined;
@@ -178,14 +162,11 @@ export class PortForwardManager extends EventEmitter {
     if (req.kind === 'pod') return { pod: req.name, port: req.remotePort };
     const handle = this.clusters.get(ctx);
 
-    const workloadPlural = WORKLOAD_PLURALS[req.kind];
-    if (workloadPlural) {
-      const workload = await handle.raw.json<KubeObject>(resourcePath('apps', 'v1', workloadPlural, { namespace: req.namespace, name: req.name }));
-      const selector = selectorToString((workload.spec as { selector?: LabelSelector } | undefined)?.selector);
-      if (!selector) throw new HttpProblem(422, `${req.kind} "${req.namespace}/${req.name}" has no pod selector`);
-      const query = new URLSearchParams({ labelSelector: selector });
-      const pods = await handle.raw.json<{ items?: KubeObject[] }>(resourcePath('', 'v1', 'pods', { namespace: req.namespace, query }));
-      const candidates = (pods.items ?? []).filter((p) => !p.metadata.deletionTimestamp);
+    const workload = WORKLOADS[req.kind];
+    if (workload) {
+      const target = await handle.raw.json<KubeObject>(resourcePath('apps', 'v1', workload.plural, { namespace: req.namespace, name: req.name }));
+      const pods = await resolveTargetPods(handle, target, workload.kind, req.namespace);
+      const candidates = pods.filter((p) => !p.metadata.deletionTimestamp);
       const pod = candidates.find(isPodReady) ?? candidates[0];
       if (!pod) throw new HttpProblem(503, `${req.kind} "${req.namespace}/${req.name}" has no running pods`);
       return { pod: pod.metadata.name, port: req.remotePort };

--- a/server/src/kube/portforward-manager.ts
+++ b/server/src/kube/portforward-manager.ts
@@ -3,14 +3,45 @@ import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { nanoid } from 'nanoid';
 import type { FastifyBaseLogger } from 'fastify';
-import type { PortForwardInfo, PortForwardRequest } from '@kubus/shared';
+import type { KubeObject, PortForwardInfo, PortForwardPreflightResponse, PortForwardRequest } from '@kubus/shared';
 import type { ClusterManager } from './cluster-manager.js';
+import { resourcePath } from './raw-client.js';
 import { HttpProblem } from '../util/errors.js';
 
 interface ActiveForward {
   info: PortForwardInfo;
   server: net.Server;
   sockets: Set<net.Socket>;
+}
+
+const WORKLOAD_PLURALS: Partial<Record<PortForwardRequest['kind'], string>> = {
+  deployment: 'deployments',
+  statefulset: 'statefulsets',
+  daemonset: 'daemonsets',
+  replicaset: 'replicasets',
+};
+
+interface LabelSelector {
+  matchLabels?: Record<string, string>;
+  matchExpressions?: Array<{ key: string; operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist'; values?: string[] }>;
+}
+
+function selectorToString(selector: LabelSelector | undefined): string | undefined {
+  if (!selector) return undefined;
+  const parts = Object.entries(selector.matchLabels ?? {}).map(([k, v]) => `${k}=${v}`);
+  for (const expr of selector.matchExpressions ?? []) {
+    if (expr.operator === 'In') parts.push(`${expr.key} in (${(expr.values ?? []).join(',')})`);
+    else if (expr.operator === 'NotIn') parts.push(`${expr.key} notin (${(expr.values ?? []).join(',')})`);
+    else if (expr.operator === 'Exists') parts.push(expr.key);
+    else if (expr.operator === 'DoesNotExist') parts.push(`!${expr.key}`);
+  }
+  return parts.length ? parts.join(',') : undefined;
+}
+
+function isPodReady(pod: KubeObject): boolean {
+  const status = pod.status as { phase?: string; conditions?: Array<{ type?: string; status?: string }> } | undefined;
+  if (status?.phase !== 'Running') return false;
+  return (status.conditions ?? []).some((c) => c.type === 'Ready' && c.status === 'True');
 }
 
 /**
@@ -36,6 +67,15 @@ export class PortForwardManager extends EventEmitter {
     const handle = this.clusters.get(ctx);
     const id = nanoid(10);
 
+    const access = await this.preflight(ctx, req.namespace);
+    if (!access.allowed) {
+      throw new HttpProblem(
+        403,
+        `Your user is not allowed to port-forward in namespace "${req.namespace}" on cluster "${ctx}"` +
+          `${access.reason ? ` (${access.reason})` : ''}. Ask a cluster admin for a role granting "create" on "pods/portforward" in this namespace.`,
+      );
+    }
+
     // Validate the target up front so obvious errors fail the request.
     const target = await this.resolveTarget(ctx, req);
 
@@ -60,9 +100,15 @@ export class PortForwardManager extends EventEmitter {
     });
 
     await new Promise<void>((resolve, reject) => {
-      server.once('error', reject);
+      server.once('error', (err: NodeJS.ErrnoException) => {
+        reject(
+          err.code === 'EADDRINUSE'
+            ? new HttpProblem(409, `Local port ${info.localPort} is already in use — pick another port or leave it empty for an automatic one.`)
+            : err,
+        );
+      });
       server.listen(info.localPort, '127.0.0.1', () => {
-        server.removeListener('error', reject);
+        server.removeAllListeners('error');
         resolve();
       });
     });
@@ -86,6 +132,14 @@ export class PortForwardManager extends EventEmitter {
       let errText = '';
       errStream.on('data', (chunk: Buffer) => {
         errText += chunk.toString('utf8');
+        // The kubelet reports forwarding failures (e.g. connection refused on
+        // the pod port) on the error channel while the websocket stays open —
+        // cut the connection instead of leaving the client hanging bytelessly.
+        info.state = 'error';
+        info.error = errText.trim();
+        this.log.warn({ id: info.id, err: info.error }, 'port-forward stream error');
+        socket.destroy();
+        this.emitUpdate();
       });
       const ws = await handle.makePortForward().portForward(req.namespace, target.pod, [target.port], socket, errStream, socket);
       info.state = 'active';
@@ -117,11 +171,25 @@ export class PortForwardManager extends EventEmitter {
   /**
    * Resolve the concrete pod and container port. Pod targets pass through;
    * service targets pick a ready endpoint pod and map the service port to
-   * its targetPort (numeric or named), like kubectl does.
+   * its targetPort (numeric or named), like kubectl does; workload targets
+   * pick a ready pod matching the workload's selector.
    */
   private async resolveTarget(ctx: string, req: PortForwardRequest): Promise<{ pod: string; port: number }> {
     if (req.kind === 'pod') return { pod: req.name, port: req.remotePort };
     const handle = this.clusters.get(ctx);
+
+    const workloadPlural = WORKLOAD_PLURALS[req.kind];
+    if (workloadPlural) {
+      const workload = await handle.raw.json<KubeObject>(resourcePath('apps', 'v1', workloadPlural, { namespace: req.namespace, name: req.name }));
+      const selector = selectorToString((workload.spec as { selector?: LabelSelector } | undefined)?.selector);
+      if (!selector) throw new HttpProblem(422, `${req.kind} "${req.namespace}/${req.name}" has no pod selector`);
+      const query = new URLSearchParams({ labelSelector: selector });
+      const pods = await handle.raw.json<{ items?: KubeObject[] }>(resourcePath('', 'v1', 'pods', { namespace: req.namespace, query }));
+      const candidates = (pods.items ?? []).filter((p) => !p.metadata.deletionTimestamp);
+      const pod = candidates.find(isPodReady) ?? candidates[0];
+      if (!pod) throw new HttpProblem(503, `${req.kind} "${req.namespace}/${req.name}" has no running pods`);
+      return { pod: pod.metadata.name, port: req.remotePort };
+    }
 
     const svcPromise = handle.core.readNamespacedService({ name: req.name, namespace: req.namespace });
     svcPromise.catch(() => undefined);
@@ -150,6 +218,41 @@ export class PortForwardManager extends EventEmitter {
       if (match) return { pod: podName, port: match.containerPort };
     }
     throw new HttpProblem(422, `could not resolve named port "${targetPort}" on pod ${podName}`);
+  }
+
+  /**
+   * SelfSubjectAccessReview for pods/portforward create. Fails open when the
+   * review itself cannot be performed — the forward attempt still surfaces
+   * the real error.
+   */
+  async preflight(ctx: string, namespace: string): Promise<PortForwardPreflightResponse> {
+    const handle = this.clusters.get(ctx);
+    try {
+      const review = await handle.raw.json<{ status?: { allowed?: boolean; reason?: string } }>('/apis/authorization.k8s.io/v1/selfsubjectaccessreviews', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          apiVersion: 'authorization.k8s.io/v1',
+          kind: 'SelfSubjectAccessReview',
+          spec: { resourceAttributes: { namespace, verb: 'create', resource: 'pods', subresource: 'portforward' } },
+        }),
+      });
+      return { allowed: review.status?.allowed !== false, reason: review.status?.reason };
+    } catch (err) {
+      this.log.debug({ ctx, err: err instanceof Error ? err.message : String(err) }, 'port-forward access review failed');
+      return { allowed: true };
+    }
+  }
+
+  /** Try to bind the port on 127.0.0.1 the same way start() will. */
+  async isLocalPortFree(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const probe = net.createServer();
+      probe.once('error', () => resolve(false));
+      probe.listen(port, '127.0.0.1', () => {
+        probe.close(() => resolve(true));
+      });
+    });
   }
 
   stop(id: string): void {

--- a/server/src/kube/target-pods.ts
+++ b/server/src/kube/target-pods.ts
@@ -1,0 +1,68 @@
+import type { KubeObject, LogTargetKind } from '@kubus/shared';
+import type { ClusterHandle } from './cluster-manager.js';
+import { resourcePath } from './raw-client.js';
+
+export interface LabelSelector {
+  matchLabels?: Record<string, string>;
+  matchExpressions?: Array<{ key: string; operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist'; values?: string[] }>;
+}
+
+export function selectorToString(selector: LabelSelector | undefined): string | undefined {
+  if (!selector) return undefined;
+  const parts = Object.entries(selector.matchLabels ?? {}).map(([k, v]) => `${k}=${v}`);
+  for (const expr of selector.matchExpressions ?? []) {
+    if (expr.operator === 'In') parts.push(`${expr.key} in (${(expr.values ?? []).join(',')})`);
+    else if (expr.operator === 'NotIn') parts.push(`${expr.key} notin (${(expr.values ?? []).join(',')})`);
+    else if (expr.operator === 'Exists') parts.push(expr.key);
+    else if (expr.operator === 'DoesNotExist') parts.push(`!${expr.key}`);
+  }
+  return parts.length ? parts.join(',') : undefined;
+}
+
+async function listPods(handle: ClusterHandle, namespace: string, selector?: string): Promise<KubeObject[]> {
+  const query = new URLSearchParams();
+  if (selector) query.set('labelSelector', selector);
+  const list = await handle.raw.json<{ items?: KubeObject[] }>(resourcePath('', 'v1', 'pods', { namespace, query }));
+  return list.items ?? [];
+}
+
+function owns(obj: KubeObject, uid: string | undefined): boolean {
+  if (!uid) return false;
+  return (obj.metadata.ownerReferences ?? []).some((owner) => owner.uid === uid && owner.controller);
+}
+
+/**
+ * Resolve a pod/workload/service to its pods. Label selectors alone are not
+ * enough for workloads — unowned pods can share the labels — so candidates
+ * are filtered by controller ownership (via the owned ReplicaSets for
+ * Deployments), matching what the detail views show.
+ */
+export async function resolveTargetPods(handle: ClusterHandle, target: KubeObject, kind: LogTargetKind, namespace: string): Promise<KubeObject[]> {
+  if (kind === 'Pod') return [target];
+
+  if (kind === 'Service') {
+    const selector = (target.spec as { selector?: Record<string, string> } | undefined)?.selector;
+    const labelSelector = selectorToString({ matchLabels: selector });
+    return labelSelector ? listPods(handle, namespace, labelSelector) : [];
+  }
+
+  const selector = selectorToString((target.spec as { selector?: LabelSelector } | undefined)?.selector);
+  if (kind === 'Job') {
+    const pods = await listPods(handle, namespace, selector);
+    return pods.filter((pod) => owns(pod, target.metadata.uid));
+  }
+  if (!selector) return [];
+
+  if (kind === 'Deployment') {
+    const query = new URLSearchParams({ labelSelector: selector });
+    const [rsList, pods] = await Promise.all([
+      handle.raw.json<{ items?: KubeObject[] }>(resourcePath('apps', 'v1', 'replicasets', { namespace, query })),
+      listPods(handle, namespace, selector),
+    ]);
+    const rsUids = new Set((rsList.items ?? []).filter((rs) => owns(rs, target.metadata.uid)).map((rs) => rs.metadata.uid));
+    return pods.filter((pod) => (pod.metadata.ownerReferences ?? []).some((owner) => rsUids.has(owner.uid) && owner.controller));
+  }
+
+  const pods = await listPods(handle, namespace, selector);
+  return pods.filter((pod) => owns(pod, target.metadata.uid));
+}

--- a/server/src/routes/detail.ts
+++ b/server/src/routes/detail.ts
@@ -2,73 +2,14 @@ import { X509Certificate } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import type { KubeObject, LogTargetKind, LogTargetPodsResponse, PodEnvResponse, SecretTlsResponse, TlsCertInfo } from '@kubus/shared';
 import type { AppContext } from '../app.js';
-import type { ClusterHandle } from '../kube/cluster-manager.js';
 import { podContainers } from '../kube/actions.js';
 import { getRolloutHistory } from '../kube/rollout.js';
 import { resolvePodEnv } from '../kube/pod-env.js';
 import { resourcePath } from '../kube/raw-client.js';
+import { resolveTargetPods } from '../kube/target-pods.js';
 import { HttpProblem, sendError } from '../util/errors.js';
 
-interface LabelSelector {
-  matchLabels?: Record<string, string>;
-  matchExpressions?: Array<{ key: string; operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist'; values?: string[] }>;
-}
-
 const CERT_BLOCK_RE = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
-
-function selectorToString(selector: LabelSelector | undefined): string | undefined {
-  if (!selector) return undefined;
-  const parts = Object.entries(selector.matchLabels ?? {}).map(([k, v]) => `${k}=${v}`);
-  for (const expr of selector.matchExpressions ?? []) {
-    if (expr.operator === 'In') parts.push(`${expr.key} in (${(expr.values ?? []).join(',')})`);
-    else if (expr.operator === 'NotIn') parts.push(`${expr.key} notin (${(expr.values ?? []).join(',')})`);
-    else if (expr.operator === 'Exists') parts.push(expr.key);
-    else if (expr.operator === 'DoesNotExist') parts.push(`!${expr.key}`);
-  }
-  return parts.length ? parts.join(',') : undefined;
-}
-
-async function listPods(handle: ClusterHandle, namespace: string, selector?: string): Promise<KubeObject[]> {
-  const query = new URLSearchParams();
-  if (selector) query.set('labelSelector', selector);
-  const list = await handle.raw.json<{ items?: KubeObject[] }>(resourcePath('', 'v1', 'pods', { namespace, query }));
-  return list.items ?? [];
-}
-
-function owns(obj: KubeObject, uid: string | undefined): boolean {
-  if (!uid) return false;
-  return (obj.metadata.ownerReferences ?? []).some((owner) => owner.uid === uid && owner.controller);
-}
-
-async function resolveLogTargetPods(handle: ClusterHandle, target: KubeObject, kind: LogTargetKind, namespace: string): Promise<KubeObject[]> {
-  if (kind === 'Pod') return [target];
-
-  if (kind === 'Service') {
-    const selector = (target.spec as { selector?: Record<string, string> } | undefined)?.selector;
-    const labelSelector = selectorToString({ matchLabels: selector });
-    return labelSelector ? listPods(handle, namespace, labelSelector) : [];
-  }
-
-  const selector = selectorToString((target.spec as { selector?: LabelSelector } | undefined)?.selector);
-  if (kind === 'Job') {
-    const pods = await listPods(handle, namespace, selector);
-    return pods.filter((pod) => owns(pod, target.metadata.uid));
-  }
-  if (!selector) return [];
-
-  if (kind === 'Deployment') {
-    const query = new URLSearchParams({ labelSelector: selector });
-    const [rsList, pods] = await Promise.all([
-      handle.raw.json<{ items?: KubeObject[] }>(resourcePath('apps', 'v1', 'replicasets', { namespace, query })),
-      listPods(handle, namespace, selector),
-    ]);
-    const rsUids = new Set((rsList.items ?? []).filter((rs) => owns(rs, target.metadata.uid)).map((rs) => rs.metadata.uid));
-    return pods.filter((pod) => (pod.metadata.ownerReferences ?? []).some((owner) => rsUids.has(owner.uid) && owner.controller));
-  }
-
-  const pods = await listPods(handle, namespace, selector);
-  return pods.filter((pod) => owns(pod, target.metadata.uid));
-}
 
 export function registerDetailRoutes(app: FastifyInstance, ctx: AppContext): void {
   app.get<{ Params: { ctx: string }; Querystring: { namespace?: string; name?: string; reveal?: string } }>(
@@ -96,7 +37,7 @@ export function registerDetailRoutes(app: FastifyInstance, ctx: AppContext): voi
       if (!version || !plural || !kind || !namespace || !name) throw new HttpProblem(422, 'group, version, plural, kind, namespace and name are required');
       const handle = ctx.clusters.get(req.params.ctx);
       const target = await handle.raw.json<KubeObject>(resourcePath(group, version, plural, { namespace, name }));
-      const pods = await resolveLogTargetPods(handle, target, kind, namespace);
+      const pods = await resolveTargetPods(handle, target, kind, namespace);
       const response: LogTargetPodsResponse = {
         pods: pods
           .map((pod) => ({

--- a/server/src/routes/portforward.ts
+++ b/server/src/routes/portforward.ts
@@ -1,10 +1,33 @@
 import type { FastifyInstance } from 'fastify';
-import type { PortForwardRequest } from '@kubus/shared';
+import type { LocalPortCheckResponse, PortForwardPreflightResponse, PortForwardRequest } from '@kubus/shared';
 import type { AppContext } from '../app.js';
-import { sendError } from '../util/errors.js';
+import { HttpProblem, sendError } from '../util/errors.js';
 
 export function registerPortForwardRoutes(app: FastifyInstance, ctx: AppContext): void {
   app.get('/api/portforwards', async () => ctx.portForwards.list());
+
+  app.get<{ Querystring: { port?: string } }>('/api/portforwards/port-check', async (req, reply) => {
+    try {
+      const port = Number(req.query.port);
+      if (!Number.isInteger(port) || port < 1 || port > 65535) throw new HttpProblem(422, 'port must be an integer between 1 and 65535');
+      const response: LocalPortCheckResponse = { port, available: await ctx.portForwards.isLocalPortFree(port) };
+      return response;
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  app.get<{ Params: { ctx: string }; Querystring: { namespace?: string } }>('/api/contexts/:ctx/portforwards/preflight', async (req, reply) => {
+    try {
+      if (!req.query.namespace) throw new HttpProblem(422, 'namespace is required');
+      const response: PortForwardPreflightResponse = await ctx.portForwards.preflight(req.params.ctx, req.query.namespace);
+      return response;
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
 
   app.post<{ Params: { ctx: string }; Body: PortForwardRequest }>('/api/contexts/:ctx/portforwards', async (req, reply) => {
     try {
@@ -13,6 +36,11 @@ export function registerPortForwardRoutes(app: FastifyInstance, ctx: AppContext)
       sendError(reply, err);
       return reply;
     }
+  });
+
+  app.delete('/api/portforwards', async () => {
+    ctx.portForwards.stopAll();
+    return { ok: true };
   });
 
   app.delete<{ Params: { id: string } }>('/api/portforwards/:id', async (req, reply) => {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -1187,13 +1187,15 @@ export interface HelmChartUpdate {
 
 // ---- Port forward ----
 
+export type PortForwardTargetKind = 'pod' | 'service' | 'deployment' | 'statefulset' | 'daemonset' | 'replicaset';
+
 export interface PortForwardInfo {
   id: string;
   ctx: string;
   namespace: string;
-  kind: 'pod' | 'service';
+  kind: PortForwardTargetKind;
   name: string;
-  /** Pod actually being forwarded to (resolved for services). */
+  /** Pod actually being forwarded to (resolved for services and workloads). */
   targetPod?: string;
   remotePort: number;
   localPort: number;
@@ -1204,8 +1206,19 @@ export interface PortForwardInfo {
 
 export interface PortForwardRequest {
   namespace: string;
-  kind: 'pod' | 'service';
+  kind: PortForwardTargetKind;
   name: string;
   remotePort: number;
   localPort?: number;
+}
+
+export interface PortForwardPreflightResponse {
+  allowed: boolean;
+  /** RBAC denial reason, when the cluster reports one. */
+  reason?: string;
+}
+
+export interface LocalPortCheckResponse {
+  port: number;
+  available: boolean;
 }


### PR DESCRIPTION
Completes the port-forward workflow: forwards can start from more places, the dialog suggests and remembers ports, permissions and port conflicts are checked before starting, and sessions can be stopped in bulk.

## What's new

- **Forward from workloads** — Deployments, StatefulSets, DaemonSets and ReplicaSets join Pods and Services in the row menu; the server resolves a ready pod via the workload selector and re-resolves per connection, so forwards survive pod churn.
- **Inline port buttons** — start a forward straight from the ports table in the Service detail or the container-port chips on Pod/Deployment cards, pre-filled with that port.
- **Smarter dialog** (extracted to `PortForwardDialog.tsx`):
  - Known ports as a dropdown with a custom fallback; the remote port doubles as the suggested local port.
  - **Service-derived suggestions** — pods/workloads that declare no `containerPort` (common with charts) get their ports from the Services selecting them: numeric `targetPort` directly, named ports resolved against declared container ports.
  - The last explicitly chosen local port and the "Open in browser when started" choice are remembered per target+port in a persisted store; auto-assigned ports are deliberately not remembered.
  - Local-port availability preflight (`GET /api/portforwards/port-check`, debounced) blocks Start with an inline explanation; the server maps `EADDRINUSE` to an actionable 409 as backstop.
  - RBAC preflight via SelfSubjectAccessReview on `pods/portforward` create — shown as an alert when the dialog opens and enforced again at start with a 403 naming the missing grant. The review fails open so environments that block SSAR don't lose working forwards.
  - Start failures keep the dialog open and show the error inline instead of closing with a toast.
- **Bulk stop** — checkbox selection with "Stop selected (n)" and a "Stop all" button on the Port Forwards page (`DELETE /api/portforwards`).
- **Fail fast on dead target ports** — kubelet error-channel messages (e.g. connection refused on the pod port) previously surfaced only once the client disconnected, so connections hung bytelessly on a forward still showing Ready; they now cut the connection immediately and land the kubelet's message on the forward state.

## Testing

- `tsc --noEmit` and `oxlint --deny-warnings` clean across the workspace
- API-level against kind: deployment and service forwards move real traffic, named `targetPort` resolution, port-check free/busy/invalid, `EADDRINUSE` → 409, stop-all closes listeners, and a view-only ServiceAccount gets `allowed:false` plus an actionable 403 on start
- Against a SOCKS-proxied cluster (kubeconfig `proxy-url`): forwards work end-to-end; a forward to a port nothing listens on now fails in ~1.6s with the kubelet error surfaced instead of hanging forever
- Headless Playwright runs: row-menu flow (suggestion → remember → busy-port blocking), inline Service/Pod entry points, open-in-browser popup with remembered checkbox, service-derived preselection for a deployment with no declared ports, multi-select stop and stop all — all passing with no page errors