### PR TITLE
Add a per-key ConfigMap and Secret data editor

### DIFF
--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -63,9 +63,16 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   const [tab, setTab] = useState('overview');
   const [reveal, setReveal] = useState(false);
   const [fullScreen, setFullScreen] = useState(false);
-  const [dataDirty, setDataDirty] = useState(false);
-  const [pendingLeave, setPendingLeave] = useState<() => void>();
   const pushDetail = useDetailStore((s) => s.push);
+  // Leaving the Data tab drops its staged per-key edits. The guard lives in
+  // the detail store because selection replacements (row clicks, topology,
+  // search) bypass the drawer entirely; the drawer routes its own affordances
+  // (tab switch, back, close) through the same guard and dialog.
+  const guardLeave = useDetailStore((s) => s.guard);
+  const setDataDirty = useDetailStore((s) => s.setDataDirty);
+  const pendingDiscard = useDetailStore((s) => s.pendingDiscard);
+  const confirmDiscard = useDetailStore((s) => s.confirmDiscard);
+  const cancelDiscard = useDetailStore((s) => s.cancelDiscard);
   const registeredKind = sel && gvkForResource(sel.group, sel.version, sel.plural)?.kind;
   const isCrdResource = sel?.group === 'apiextensions.k8s.io' && sel.version === 'v1' && sel.plural === 'customresourcedefinitions';
   const behaviorKind = sel && (registeredKind === sel.kind || isCrdResource) ? sel.kind : undefined;
@@ -88,16 +95,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   useEffect(() => {
     setTab('overview');
     setReveal(false);
-    setDataDirty(false);
-    setPendingLeave(undefined);
   }, [selKey]);
-
-  // Leaving the Data tab drops its staged per-key edits — route tab switches,
-  // back and close through a discard confirmation while it is dirty.
-  const guardLeave = (leave: () => void) => {
-    if (tab === 'data' && dataDirty) setPendingLeave(() => leave);
-    else leave();
-  };
 
   const hasSel = !!sel;
   useEffect(() => {
@@ -332,17 +330,13 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
             )}
           </Box>
           <ConfirmDialog
-            open={!!pendingLeave}
+            open={!!pendingDiscard}
             title="Discard data changes?"
             message="The Data tab has key edits that have not been applied. Leaving discards them."
             confirmLabel="Discard"
             danger
-            onConfirm={() => {
-              setDataDirty(false);
-              pendingLeave?.();
-              setPendingLeave(undefined);
-            }}
-            onClose={() => setPendingLeave(undefined)}
+            onConfirm={confirmDiscard}
+            onClose={cancelDiscard}
           />
         </Box>
       )}

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -22,7 +22,10 @@ import { useApplyResource, useDryRunResource, useResource, useResourceEvents } f
 import { withoutManagedFields } from '../kube-display.js';
 import { isTextEntryTarget } from '../text-entry.js';
 import { YamlEditor, useYamlSchema } from './YamlEditor.js';
+import { ConfirmDialog } from './ConfirmDialog.js';
 import { GenericDetail } from './detail/GenericDetail.js';
+import { ConfigMapDetail } from './detail/ConfigMapDetail.js';
+import { DataEditor } from './detail/DataEditor.js';
 import { DeploymentDetail } from './detail/DeploymentDetail.js';
 import { PodDetail } from './detail/PodDetail.js';
 import { NodeDetail } from './detail/NodeDetail.js';
@@ -60,11 +63,14 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   const [tab, setTab] = useState('overview');
   const [reveal, setReveal] = useState(false);
   const [fullScreen, setFullScreen] = useState(false);
+  const [dataDirty, setDataDirty] = useState(false);
+  const [pendingLeave, setPendingLeave] = useState<() => void>();
   const pushDetail = useDetailStore((s) => s.push);
   const registeredKind = sel && gvkForResource(sel.group, sel.version, sel.plural)?.kind;
   const isCrdResource = sel?.group === 'apiextensions.k8s.io' && sel.version === 'v1' && sel.plural === 'customresourcedefinitions';
   const behaviorKind = sel && (registeredKind === sel.kind || isCrdResource) ? sel.kind : undefined;
   const isSecret = behaviorKind === 'Secret';
+  const hasDataTab = isSecret || behaviorKind === 'ConfigMap';
   const isCrd = isCrdResource && sel?.kind === 'CustomResourceDefinition';
   const backingCrdSelection = sel?.custom && !isCrd && sel.group
     ? {
@@ -82,7 +88,16 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   useEffect(() => {
     setTab('overview');
     setReveal(false);
+    setDataDirty(false);
+    setPendingLeave(undefined);
   }, [selKey]);
+
+  // Leaving the Data tab drops its staged per-key edits — route tab switches,
+  // back and close through a discard confirmation while it is dirty.
+  const guardLeave = (leave: () => void) => {
+    if (tab === 'data' && dataDirty) setPendingLeave(() => leave);
+    else leave();
+  };
 
   const hasSel = !!sel;
   useEffect(() => {
@@ -157,7 +172,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
       anchor="right"
       variant={inline ? 'permanent' : 'temporary'}
       open={inline || !!sel}
-      onClose={onClose}
+      onClose={() => guardLeave(onClose)}
       sx={
         inline
           ? {
@@ -183,14 +198,14 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
             if (e.key === 'ArrowLeft' && e.altKey && !e.ctrlKey && !e.metaKey && onBack && !isTextEntryTarget(e.target)) {
               e.preventDefault();
               e.stopPropagation();
-              onBack();
+              guardLeave(onBack);
             }
           }}
           sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
         >
           <Stack direction="row" sx={{ px: 2, py: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center' }}>
             {onBack && (
-              <IconButton onClick={onBack} sx={{ mr: 1 }}>
+              <IconButton onClick={() => guardLeave(onBack)} sx={{ mr: 1 }}>
                 <ArrowBackIcon />
               </IconButton>
             )}
@@ -239,18 +254,19 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
                 </IconButton>
               </Tooltip>
             )}
-            <IconButton onClick={onClose} aria-label="Close resource details">
+            <IconButton onClick={() => guardLeave(onClose)} aria-label="Close resource details">
               <CloseIcon />
             </IconButton>
           </Stack>
           <Tabs
             value={tab}
-            onChange={(_e, v) => setTab(v as string)}
+            onChange={(_e, v) => guardLeave(() => setTab(v as string))}
             variant="scrollable"
             scrollButtons="auto"
             sx={{ borderBottom: 1, borderColor: 'divider', minHeight: 36 }}
           >
             <Tab value="overview" label="Overview" sx={{ minHeight: 36 }} />
+            {hasDataTab && <Tab value="data" label="Data" sx={{ minHeight: 36 }} />}
             {versions.map((v) => (
               <Tab key={v.name} value={`crd:${v.name}`} label={v.name} sx={{ minHeight: 36 }} />
             ))}
@@ -262,6 +278,14 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
           </Tabs>
           <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
             {tab === 'overview' && obj && <OverviewForKind kind={behaviorKind} obj={obj} ctx={sel.ctx} crd={isCrd ? undefined : backingCrd} version={sel.version} />}
+            {hasDataTab && tab === 'data' && (
+              <DataEditor
+                key={selKey}
+                sel={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, name: sel.name, namespace: sel.namespace }}
+                isSecret={isSecret}
+                onDirtyChange={setDataDirty}
+              />
+            )}
             {tab.startsWith('crd:') && schemaSource && <CrdSchemaDetail obj={schemaSource} versionName={tab.slice('crd:'.length)} />}
             {showMap && tab === 'map' && (
               <Box sx={{ height: '100%', p: 1.25 }}>
@@ -307,6 +331,19 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
               <RolloutHistory ctx={sel.ctx} kind={sel.kind as 'Deployment' | 'StatefulSet'} obj={obj} />
             )}
           </Box>
+          <ConfirmDialog
+            open={!!pendingLeave}
+            title="Discard data changes?"
+            message="The Data tab has key edits that have not been applied. Leaving discards them."
+            confirmLabel="Discard"
+            danger
+            onConfirm={() => {
+              setDataDirty(false);
+              pendingLeave?.();
+              setPendingLeave(undefined);
+            }}
+            onClose={() => setPendingLeave(undefined)}
+          />
         </Box>
       )}
     </Drawer>
@@ -327,6 +364,8 @@ function OverviewForKind({ kind, obj, ctx, crd, version }: { kind: string | unde
       return <NodeDetail obj={obj} ctx={ctx} />;
     case 'Service':
       return <ServiceDetail obj={obj} ctx={ctx} />;
+    case 'ConfigMap':
+      return <ConfigMapDetail obj={obj} ctx={ctx} />;
     case 'Secret':
       return <SecretDetail obj={obj} ctx={ctx} />;
     case 'CustomResourceDefinition':

--- a/client/src/components/detail/ConfigMapDetail.tsx
+++ b/client/src/components/detail/ConfigMapDetail.tsx
@@ -1,0 +1,47 @@
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import type { KubeObject } from '@kubus/shared';
+import { formatBytes } from '../format.js';
+import { GenericDetail } from './GenericDetail.js';
+import { b64ByteLength } from './data-editor.js';
+
+function stringEntries(obj: KubeObject, field: 'data' | 'binaryData'): Array<[string, string]> {
+  const map = obj[field] as Record<string, unknown> | undefined;
+  return Object.entries(map ?? {}).filter((kv): kv is [string, string] => typeof kv[1] === 'string');
+}
+
+export function ConfigMapDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
+  const textKeys = stringEntries(obj, 'data');
+  const binaryKeys = stringEntries(obj, 'binaryData');
+  const total = textKeys.length + binaryKeys.length;
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={1} sx={{ px: 2, pt: 2, flexWrap: 'wrap' }}>
+        <Chip label={`${total} key${total === 1 ? '' : 's'}`} variant="outlined" />
+        {obj.immutable === true && <Chip label="immutable" variant="outlined" color="warning" />}
+      </Stack>
+      {total > 0 && (
+        <Box sx={{ px: 2, pt: 2 }}>
+          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+            Data keys
+          </Typography>
+          <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+            {textKeys.map(([k, v]) => (
+              <Chip key={k} label={`${k} · ${formatBytes(new TextEncoder().encode(v).length)}`} variant="outlined" title={k} />
+            ))}
+            {binaryKeys.map(([k, v]) => (
+              <Chip key={k} label={`${k} · binary ${formatBytes(b64ByteLength(v))}`} variant="outlined" title={k} />
+            ))}
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            View and edit values per key in the Data tab.
+          </Typography>
+        </Box>
+      )}
+      <GenericDetail obj={obj} ctx={ctx} />
+    </Box>
+  );
+}

--- a/client/src/components/detail/DataEditor.tsx
+++ b/client/src/components/detail/DataEditor.tsx
@@ -1,0 +1,613 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
+import Collapse from '@mui/material/Collapse';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Switch from '@mui/material/Switch';
+import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import AddIcon from '@mui/icons-material/Add';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import UndoIcon from '@mui/icons-material/Undo';
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined';
+import VisibilityOffOutlinedIcon from '@mui/icons-material/VisibilityOffOutlined';
+import VisibilityOutlinedIcon from '@mui/icons-material/VisibilityOutlined';
+import { dump as dumpYaml } from 'js-yaml';
+import type { KubeObject } from '@kubus/shared';
+import { useApplyResource, useDryRunResource, useResource } from '../../api/queries.js';
+import { copyToClipboard } from '../../clipboard.js';
+import { showToast } from '../../state/toast.js';
+import { ConfirmDialog } from '../ConfirmDialog.js';
+import { DiffViewer } from '../DiffViewer.js';
+import { formatBytes } from '../format.js';
+import {
+  REDACTED,
+  anyDirty,
+  b64ByteLength,
+  b64ToBytes,
+  b64ToText,
+  buildManifest,
+  bytesToB64,
+  entriesFromObject,
+  entryDirty,
+  entryRaw,
+  maskSecretValues,
+  textToB64,
+  validateEntries,
+  type DataEntry,
+  type EntryProblem,
+  type ValueMode,
+} from './data-editor.js';
+
+export interface DataEditorSelection {
+  ctx: string;
+  group: string;
+  version: string;
+  plural: string;
+  kind: string;
+  name: string;
+  namespace?: string;
+}
+
+const YAML_OPTS = { noRefs: true, lineWidth: 140 } as const;
+
+function dumpForDiff(obj: KubeObject): string {
+  const clone = JSON.parse(JSON.stringify(obj)) as KubeObject;
+  delete (clone.metadata as unknown as Record<string, unknown>).managedFields;
+  return dumpYaml(clone, YAML_OPTS);
+}
+
+function entryByteSize(entry: DataEntry): number {
+  return entry.mode === 'binary' ? b64ByteLength(entry.value) : new TextEncoder().encode(entry.value).length;
+}
+
+/** Trigger a browser download of the entry's decoded bytes. */
+function downloadEntry(entry: DataEntry) {
+  let bytes: Uint8Array;
+  if (entry.mode === 'binary') {
+    try {
+      bytes = b64ToBytes(entry.value.replace(/\s/g, ''));
+    } catch {
+      showToast('error', 'Value is not valid base64');
+      return;
+    }
+  } else {
+    bytes = new TextEncoder().encode(entry.value);
+  }
+  const url = URL.createObjectURL(new Blob([bytes as unknown as BlobPart]));
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = entry.name || 'value';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Per-key editor for ConfigMap and Secret data. Edits are staged locally
+ * (add/rename/edit/delete per key) and applied in one PUT after a diff +
+ * server dry-run review. Secret values stay masked until explicitly revealed.
+ */
+export function DataEditor({ sel, isSecret, onDirtyChange }: { sel: DataEditorSelection; isSecret: boolean; onDirtyChange?: (dirty: boolean) => void }) {
+  // Secrets are fetched revealed so the draft holds real values (masked in the
+  // UI until per-key reveal); the redacted overview query is separate.
+  const { data: latest, error: loadError, refetch } = useResource({ ...sel, reveal: isSecret });
+  const [entries, setEntries] = useState<DataEntry[]>();
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<number>>(new Set<number>());
+  const [revealedIds, setRevealedIds] = useState<ReadonlySet<number>>(new Set<number>());
+  const [revealAll, setRevealAll] = useState(false);
+  const [confirmReset, setConfirmReset] = useState(false);
+  const [review, setReview] = useState(false);
+  const nextIdRef = useRef(1);
+
+  useEffect(() => {
+    if (latest && !entries) {
+      const list = entriesFromObject(latest, isSecret, nextIdRef.current);
+      nextIdRef.current += list.length;
+      setEntries(list);
+    }
+  }, [latest, entries, isSecret]);
+
+  const dirty = useMemo(() => (entries ? anyDirty(entries, isSecret) : false), [entries, isSecret]);
+  const problems = useMemo(() => validateEntries(entries ?? []), [entries]);
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
+  useEffect(() => () => onDirtyChange?.(false), [onDirtyChange]);
+
+  const readOnly = latest?.immutable === true;
+
+  const update = (id: number, patch: Partial<DataEntry>) => {
+    setEntries((prev) => prev?.map((e) => (e.id === id ? { ...e, ...patch } : e)));
+  };
+
+  const valueShown = (entry: DataEntry) => !isSecret || !entry.originalName || revealAll || revealedIds.has(entry.id);
+
+  const toggleReveal = (entry: DataEntry) => {
+    setRevealedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(entry.id)) next.delete(entry.id);
+      else next.add(entry.id);
+      return next;
+    });
+  };
+
+  const toggleExpanded = (id: number) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const copyValue = async (entry: DataEntry) => {
+    const ok = await copyToClipboard(entry.mode === 'binary' ? entryRaw(entry, isSecret) : entry.value);
+    showToast(ok ? 'success' : 'error', ok ? `Copied value of ${entry.name}` : 'Copy to clipboard failed');
+  };
+
+  const addKey = () => {
+    const id = nextIdRef.current++;
+    setEntries((prev) => [...(prev ?? []), { id, name: '', mode: 'text', value: '', deleted: false }]);
+    setExpandedIds((prev) => new Set(prev).add(id));
+  };
+
+  const removeKey = (entry: DataEntry) => {
+    if (entry.originalName) update(entry.id, { deleted: true });
+    else setEntries((prev) => prev?.filter((e) => e.id !== entry.id));
+  };
+
+  const setMode = (entry: DataEntry, mode: ValueMode) => {
+    if (mode === entry.mode) return;
+    if (mode === 'binary') {
+      update(entry.id, { mode, value: textToB64(entry.value) });
+      return;
+    }
+    const text = b64ToText(entry.value.replace(/\s/g, ''));
+    if (text === undefined) {
+      showToast('warning', 'Value is not valid UTF-8 text — keep editing it as base64');
+      return;
+    }
+    update(entry.id, { mode, value: text });
+  };
+
+  const uploadFile = (entry: DataEntry, file: File) => {
+    void file.arrayBuffer().then((buf) => {
+      update(entry.id, { mode: 'binary', value: bytesToB64(new Uint8Array(buf)) });
+    });
+  };
+
+  const reset = () => {
+    setEntries(undefined);
+    setExpandedIds(new Set<number>());
+    setConfirmReset(false);
+  };
+
+  if (loadError) {
+    return (
+      <Alert severity="error" sx={{ m: 2 }}>
+        {loadError instanceof Error ? loadError.message : 'Failed to load resource data'}
+      </Alert>
+    );
+  }
+  if (!entries || !latest) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+      <Stack direction="row" spacing={1} sx={{ p: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center', flexShrink: 0 }}>
+        {isSecret && (
+          <FormControlLabel
+            control={<Switch size="small" checked={revealAll} onChange={(e) => setRevealAll(e.target.checked)} />}
+            label={<Typography variant="caption">Reveal values</Typography>}
+            sx={{ ml: 0 }}
+          />
+        )}
+        <Box sx={{ flex: 1 }} />
+        {!readOnly && (
+          <>
+            <Button startIcon={<AddIcon fontSize="small" />} onClick={addKey}>
+              Add key
+            </Button>
+            <Button disabled={!dirty} onClick={() => setConfirmReset(true)}>
+              Reset
+            </Button>
+            <Button variant="contained" disabled={!dirty || problems.length > 0} onClick={() => setReview(true)}>
+              Review & apply
+            </Button>
+          </>
+        )}
+      </Stack>
+      <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', p: 2 }}>
+        {readOnly && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            This {sel.kind} is immutable — its data cannot be changed.
+          </Alert>
+        )}
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1.5 }}>
+          {isSecret
+            ? 'Secret values are stored base64-encoded. Text mode edits the decoded value and re-encodes it on apply; base64 mode edits the stored payload directly.'
+            : 'Text keys are stored as plain UTF-8 strings in data; binary keys are stored base64-encoded in binaryData.'}
+        </Typography>
+        {entries.length === 0 && (
+          <Typography variant="body2" color="text.secondary">
+            No data keys.
+          </Typography>
+        )}
+        <Stack spacing={1}>
+          {entries.map((entry) => (
+            <EntryRow
+              key={entry.id}
+              entry={entry}
+              isSecret={isSecret}
+              readOnly={readOnly}
+              expanded={expandedIds.has(entry.id)}
+              shown={valueShown(entry)}
+              problems={problems}
+              onToggleExpanded={() => toggleExpanded(entry.id)}
+              onToggleReveal={() => toggleReveal(entry)}
+              onCopy={() => void copyValue(entry)}
+              onRemove={() => removeKey(entry)}
+              onRestore={() => update(entry.id, { deleted: false })}
+              onRename={(name) => update(entry.id, { name })}
+              onValueChange={(value) => update(entry.id, { value })}
+              onModeChange={(mode) => setMode(entry, mode)}
+              onUpload={(file) => uploadFile(entry, file)}
+              onDownload={() => downloadEntry(entry)}
+            />
+          ))}
+        </Stack>
+      </Box>
+      <ConfirmDialog
+        open={confirmReset}
+        title="Discard changes?"
+        message="All staged key edits will be discarded and the editor reloaded from the cluster."
+        confirmLabel="Discard"
+        danger
+        onConfirm={reset}
+        onClose={() => setConfirmReset(false)}
+      />
+      {review && (
+        <ReviewDialog
+          sel={sel}
+          isSecret={isSecret}
+          latest={latest}
+          entries={entries}
+          revealAll={revealAll}
+          revealedIds={revealedIds}
+          onClose={() => setReview(false)}
+          onApplied={(updated) => {
+            setReview(false);
+            setExpandedIds(new Set<number>());
+            // Rebuild the draft from the PUT response — the query cache only
+            // catches up after the invalidation refetch lands.
+            const list = entriesFromObject(updated, isSecret, nextIdRef.current);
+            nextIdRef.current += list.length;
+            setEntries(list);
+            void refetch();
+            showToast('success', `${sel.kind} ${sel.name} updated`);
+          }}
+          onConflict={() => void refetch()}
+        />
+      )}
+    </Box>
+  );
+}
+
+function entryStatus(entry: DataEntry, isSecret: boolean): { label: string; color: 'success' | 'warning' | 'error' } | undefined {
+  if (!entry.originalName) return { label: 'new', color: 'success' };
+  if (entry.deleted) return { label: 'deleted', color: 'error' };
+  if (entry.name !== entry.originalName) return { label: 'renamed', color: 'warning' };
+  if (entryDirty(entry, isSecret)) return { label: 'edited', color: 'warning' };
+  return undefined;
+}
+
+function entryPreview(entry: DataEntry, shown: boolean): string {
+  if (entry.deleted) return 'Will be removed on apply';
+  if (!shown) return REDACTED;
+  if (entry.mode === 'binary') return `binary · ${formatBytes(entryByteSize(entry))}`;
+  const lines = entry.value.split('\n');
+  const first = lines[0] ?? '';
+  return lines.length > 1 ? `${first} … (${lines.length} lines)` : first;
+}
+
+function EntryRow({
+  entry,
+  isSecret,
+  readOnly,
+  expanded,
+  shown,
+  problems,
+  onToggleExpanded,
+  onToggleReveal,
+  onCopy,
+  onRemove,
+  onRestore,
+  onRename,
+  onValueChange,
+  onModeChange,
+  onUpload,
+  onDownload,
+}: {
+  entry: DataEntry;
+  isSecret: boolean;
+  readOnly: boolean;
+  expanded: boolean;
+  shown: boolean;
+  problems: EntryProblem[];
+  onToggleExpanded: () => void;
+  onToggleReveal: () => void;
+  onCopy: () => void;
+  onRemove: () => void;
+  onRestore: () => void;
+  onRename: (name: string) => void;
+  onValueChange: (value: string) => void;
+  onModeChange: (mode: ValueMode) => void;
+  onUpload: (file: File) => void;
+  onDownload: () => void;
+}) {
+  const status = entryStatus(entry, isSecret);
+  const nameProblem = problems.find((p) => p.id === entry.id && p.target === 'name');
+  const valueProblem = problems.find((p) => p.id === entry.id && p.target === 'value');
+  const multiline = entry.mode === 'binary' || entry.value.includes('\n');
+  return (
+    <Box sx={{ border: 1, borderColor: nameProblem || valueProblem ? 'error.main' : 'divider', borderRadius: 1, opacity: entry.deleted ? 0.6 : 1 }}>
+      <Stack direction="row" sx={{ alignItems: 'center', pr: 1 }}>
+        <ButtonBase
+          onClick={onToggleExpanded}
+          aria-expanded={expanded}
+          sx={{ flex: 1, minWidth: 0, justifyContent: 'flex-start', alignItems: 'center', gap: 1, px: 1, py: 0.5, textAlign: 'left', borderRadius: 1, '&:hover': { bgcolor: 'action.hover' } }}
+        >
+          <KeyboardArrowRightIcon
+            sx={{ fontSize: 18, color: 'text.secondary', transform: expanded ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s', flexShrink: 0 }}
+          />
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Typography variant="body2" noWrap sx={{ fontWeight: 600, fontFamily: 'monospace', textDecoration: entry.deleted ? 'line-through' : 'none' }}>
+              {entry.name || '(unnamed key)'}
+            </Typography>
+            <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block', fontFamily: 'monospace' }}>
+              {entryPreview(entry, shown)}
+            </Typography>
+          </Box>
+          {status && <Chip label={status.label} size="small" color={status.color} variant="outlined" sx={{ flexShrink: 0 }} />}
+          {entry.mode === 'binary' && !entry.deleted && <Chip label="binary" size="small" variant="outlined" sx={{ flexShrink: 0 }} />}
+          <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0, minWidth: 42, textAlign: 'right' }}>
+            {formatBytes(entryByteSize(entry))}
+          </Typography>
+        </ButtonBase>
+        <Stack direction="row" sx={{ flexShrink: 0, ml: 0.5 }}>
+          {isSecret && entry.originalName && (
+            <Tooltip title={shown ? 'Hide value' : 'Reveal value'}>
+              <IconButton size="small" onClick={onToggleReveal} aria-label={shown ? `Hide value of ${entry.name}` : `Reveal value of ${entry.name}`}>
+                {shown ? <VisibilityOffOutlinedIcon fontSize="small" /> : <VisibilityOutlinedIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+          )}
+          <Tooltip title={entry.mode === 'binary' ? 'Copy base64 value' : 'Copy value'}>
+            <IconButton size="small" onClick={onCopy} aria-label={`Copy value of ${entry.name}`}>
+              <ContentCopyIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          {!readOnly &&
+            (entry.deleted ? (
+              <Tooltip title="Restore key">
+                <IconButton size="small" onClick={onRestore} aria-label={`Restore ${entry.name}`}>
+                  <UndoIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ) : (
+              <Tooltip title="Delete key">
+                <IconButton size="small" onClick={onRemove} aria-label={`Delete ${entry.name}`}>
+                  <DeleteOutlinedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            ))}
+        </Stack>
+      </Stack>
+      <Collapse in={expanded && !entry.deleted} timeout={150} unmountOnExit>
+        <Stack spacing={1.5} sx={{ px: 1.5, pb: 1.5, pt: 1, borderTop: 1, borderColor: 'divider' }}>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center', flexWrap: 'wrap', rowGap: 1 }}>
+            <TextField
+              label="Key"
+              size="small"
+              value={entry.name}
+              onChange={(e) => onRename(e.target.value)}
+              disabled={readOnly}
+              error={!!nameProblem}
+              helperText={nameProblem?.message}
+              slotProps={{ input: { sx: { fontFamily: 'monospace', fontSize: 13 } } }}
+              sx={{ width: 320, maxWidth: '100%' }}
+            />
+            <ToggleButtonGroup size="small" exclusive value={entry.mode} onChange={(_e, v) => v && onModeChange(v as ValueMode)}>
+              <ToggleButton value="text" disabled={readOnly}>
+                Text
+              </ToggleButton>
+              <ToggleButton value="binary" disabled={readOnly}>
+                Base64
+              </ToggleButton>
+            </ToggleButtonGroup>
+            <Box sx={{ flex: 1 }} />
+            <Tooltip title="Download value as a file">
+              <IconButton size="small" onClick={onDownload} aria-label={`Download value of ${entry.name}`}>
+                <DownloadOutlinedIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            {!readOnly && (
+              <Tooltip title="Replace value with a file's content">
+                <IconButton size="small" component="label" aria-label={`Upload file into ${entry.name}`}>
+                  <UploadFileOutlinedIcon fontSize="small" />
+                  <input
+                    hidden
+                    type="file"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) onUpload(file);
+                      e.target.value = '';
+                    }}
+                  />
+                </IconButton>
+              </Tooltip>
+            )}
+          </Stack>
+          {shown ? (
+            <TextField
+              label={entry.mode === 'binary' ? 'Value (base64)' : 'Value'}
+              size="small"
+              fullWidth
+              multiline
+              minRows={multiline ? 6 : 1}
+              maxRows={18}
+              value={entry.value}
+              onChange={(e) => onValueChange(e.target.value)}
+              disabled={readOnly}
+              error={!!valueProblem}
+              helperText={valueProblem?.message}
+              slotProps={{ input: { sx: { fontFamily: 'monospace', fontSize: 13 } } }}
+            />
+          ) : (
+            <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                Value is hidden.
+              </Typography>
+              <Button size="small" startIcon={<VisibilityOutlinedIcon fontSize="small" />} onClick={onToggleReveal}>
+                Reveal to view or edit
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      </Collapse>
+    </Box>
+  );
+}
+
+/**
+ * Diff + server dry-run gate in front of the apply. Secret values stay masked
+ * in the diff unless the key was revealed or its value was authored by the
+ * user in this draft (an edit must never be invisible in the review).
+ */
+function ReviewDialog({
+  sel,
+  isSecret,
+  latest,
+  entries,
+  revealAll,
+  revealedIds,
+  onClose,
+  onApplied,
+  onConflict,
+}: {
+  sel: DataEditorSelection;
+  isSecret: boolean;
+  latest: KubeObject;
+  entries: DataEntry[];
+  revealAll: boolean;
+  revealedIds: ReadonlySet<number>;
+  onClose: () => void;
+  onApplied: (updated: KubeObject) => void;
+  onConflict: () => void;
+}) {
+  const apply = useApplyResource();
+  const dryRun = useDryRunResource();
+  const [error, setError] = useState<string>();
+
+  const manifest = useMemo(() => buildManifest(latest, entries, isSecret), [latest, entries, isSecret]);
+  const yamlBody = useMemo(() => dumpYaml(manifest, YAML_OPTS), [manifest]);
+  const { left, right } = useMemo(() => {
+    if (!isSecret) return { left: dumpForDiff(latest), right: dumpForDiff(manifest) };
+    const revealed = (e: DataEntry) => !e.originalName || revealAll || revealedIds.has(e.id);
+    const shownOld = new Set(entries.filter((e) => e.originalName && revealed(e)).map((e) => e.originalName));
+    // User-authored values always show — an edit must never be invisible in the diff.
+    const shownNew = new Set(entries.filter((e) => !e.deleted && (revealed(e) || entryDirty(e, isSecret))).map((e) => e.name));
+    return {
+      left: dumpForDiff(maskSecretValues(latest, (name) => shownOld.has(name))),
+      right: dumpForDiff(maskSecretValues(manifest, (name) => shownNew.has(name))),
+    };
+  }, [latest, manifest, entries, isSecret, revealAll, revealedIds]);
+
+  const dryRunMutate = dryRun.mutate;
+  useEffect(() => {
+    dryRunMutate({ ctx: sel.ctx, yamlBody });
+  }, [dryRunMutate, sel.ctx, yamlBody]);
+
+  const doApply = async () => {
+    setError(undefined);
+    try {
+      const updated = await apply.mutateAsync({ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, name: sel.name, namespace: sel.namespace, yamlBody });
+      onApplied(updated);
+    } catch (err) {
+      if ((err as { status?: number }).status === 409) {
+        onConflict();
+        setError(`${(err as Error).message} — the resource changed on the server; the diff has been refreshed, review it and apply again.`);
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const findings = dryRun.data?.findings ?? [];
+  return (
+    <Dialog open onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>
+        Review changes — {sel.namespace ? `${sel.namespace}/` : ''}
+        {sel.name}
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0, display: 'flex', flexDirection: 'column', height: '68vh' }}>
+        {error && (
+          <Alert severity="error" onClose={() => setError(undefined)} sx={{ borderRadius: 0, flexShrink: 0 }}>
+            {error}
+          </Alert>
+        )}
+        {dryRun.isError && (
+          <Alert severity="error" sx={{ borderRadius: 0, flexShrink: 0 }}>
+            Dry-run failed: {dryRun.error instanceof Error ? dryRun.error.message : 'unknown error'}
+          </Alert>
+        )}
+        {findings.map((finding, i) => (
+          <Alert key={`${finding.field ?? ''}:${i}`} severity={finding.severity === 'error' ? 'error' : finding.severity} sx={{ borderRadius: 0, flexShrink: 0 }}>
+            {finding.field ? `${finding.field}: ` : ''}
+            {finding.message}
+          </Alert>
+        ))}
+        {dryRun.data?.ok && findings.length === 0 && (
+          <Alert severity="success" sx={{ borderRadius: 0, flexShrink: 0 }}>
+            Server dry-run accepted this change.
+          </Alert>
+        )}
+        {isSecret && (
+          <Alert severity="info" sx={{ borderRadius: 0, flexShrink: 0 }}>
+            Unrevealed Secret values are shown as {REDACTED} in this diff; the apply uses the real values.
+          </Alert>
+        )}
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <DiffViewer left={left} right={right} />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button variant="contained" disabled={apply.isPending || dryRun.isPending || !dryRun.data?.ok} onClick={() => void doApply()}>
+          {apply.isPending ? 'Applying…' : 'Apply'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/detail/GenericDetail.tsx
+++ b/client/src/components/detail/GenericDetail.tsx
@@ -9,6 +9,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type { KubeObject } from '@kubus/shared';
 import { AgeCell, formatAge } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
@@ -38,12 +39,40 @@ export function KeyValueSection({ title, entries, defaultOpen = true }: { title:
   );
 }
 
+/** Href for values that are plain web links; anything else (other schemes, garbage) stays inert. */
+function safeHref(value: string): string | undefined {
+  if (!/^https?:\/\//i.test(value)) return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function ChipList({ items }: { items: Array<[string, string]> }) {
   return (
     <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
-      {items.map(([k, v]) => (
-        <Chip key={k} label={`${k}=${v}`} variant="outlined" sx={{ maxWidth: 420 }} title={`${k}=${v}`} />
-      ))}
+      {items.map(([k, v]) => {
+        const href = safeHref(v);
+        return href ? (
+          <Chip
+            key={k}
+            component="a"
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            clickable
+            icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+            label={`${k}=${v}`}
+            variant="outlined"
+            sx={{ maxWidth: 420 }}
+            title={`Open ${v}`}
+          />
+        ) : (
+          <Chip key={k} label={`${k}=${v}`} variant="outlined" sx={{ maxWidth: 420 }} title={`${k}=${v}`} />
+        );
+      })}
     </Stack>
   );
 }

--- a/client/src/components/detail/SecretDetail.tsx
+++ b/client/src/components/detail/SecretDetail.tsx
@@ -50,7 +50,7 @@ export function SecretDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
               ))}
             </Stack>
             <Typography variant="caption" color="text.secondary">
-              Values are redacted — use the YAML tab with “Reveal secret data” to inspect them.
+              Values are redacted — reveal, copy or edit them per key in the Data tab.
             </Typography>
           </Box>
         )}

--- a/client/src/components/detail/data-editor.ts
+++ b/client/src/components/detail/data-editor.ts
@@ -1,0 +1,217 @@
+import type { KubeObject } from '@kubus/shared';
+
+/** Mirrors the server's Secret redaction placeholder (server/src/kube/redact.ts). */
+export const REDACTED = '••••••••';
+
+/** Manifest field a key is stored in. ConfigMaps split text/binary; Secrets only use `data`. */
+export type DataField = 'data' | 'binaryData';
+
+export type ValueMode = 'text' | 'binary';
+
+export interface DataEntry {
+  /** Stable identity for React keys across renames. */
+  id: number;
+  /** Current key name (editable). */
+  name: string;
+  /** Key name on the server; undefined for newly added keys. */
+  originalName?: string;
+  /** Server-side value in manifest encoding (base64 for Secret data / binaryData, plain for ConfigMap data). */
+  storedRaw?: string;
+  /** Field the key currently lives in on the server. */
+  storedField?: DataField;
+  /** Editing mode: `text` edits the decoded UTF-8 string, `binary` edits base64. */
+  mode: ValueMode;
+  /** Current value in the mode's encoding. */
+  value: string;
+  deleted: boolean;
+}
+
+export interface EntryProblem {
+  id: number;
+  target: 'name' | 'value';
+  message: string;
+}
+
+// ---- Encoding ----
+
+export function textToB64(text: string): string {
+  return bytesToB64(new TextEncoder().encode(text));
+}
+
+export function b64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+export function bytesToB64(bytes: Uint8Array): string {
+  let bin = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(bin);
+}
+
+export function isValidB64(s: string): boolean {
+  try {
+    atob(s);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Byte size of a base64 payload without decoding it. */
+export function b64ByteLength(b64: string): number {
+  const clean = b64.replace(WHITESPACE_RE, '');
+  if (!clean.length) return 0;
+  const padding = clean.endsWith('==') ? 2 : clean.endsWith('=') ? 1 : 0;
+  return (clean.length / 4) * 3 - padding;
+}
+
+const WHITESPACE_RE = /\s/g;
+const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
+
+/** Control characters other than \t \n \r mean "not editable as text". */
+function hasControlChars(text: string): boolean {
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if ((c < 0x20 && c !== 0x09 && c !== 0x0a && c !== 0x0d) || c === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Decode base64 to a UTF-8 string, or undefined when the payload isn't editable text. */
+export function b64ToText(b64: string): string | undefined {
+  let text: string;
+  try {
+    text = UTF8_DECODER.decode(b64ToBytes(b64));
+  } catch {
+    return undefined;
+  }
+  return hasControlChars(text) ? undefined : text;
+}
+
+// ---- Draft model ----
+
+function dataMap(obj: KubeObject, field: DataField): Array<[string, string]> {
+  const map = obj[field] as Record<string, unknown> | undefined;
+  return Object.entries(map ?? {}).filter((kv): kv is [string, string] => typeof kv[1] === 'string');
+}
+
+/** Build the initial draft from a (revealed, for Secrets) server object. */
+export function entriesFromObject(obj: KubeObject, isSecret: boolean, startId: number): DataEntry[] {
+  const entries: DataEntry[] = [];
+  let id = startId;
+  for (const [name, raw] of dataMap(obj, 'data')) {
+    if (isSecret) {
+      const text = b64ToText(raw);
+      entries.push({ id: id++, name, originalName: name, storedRaw: raw, storedField: 'data', mode: text === undefined ? 'binary' : 'text', value: text ?? raw, deleted: false });
+    } else {
+      entries.push({ id: id++, name, originalName: name, storedRaw: raw, storedField: 'data', mode: 'text', value: raw, deleted: false });
+    }
+  }
+  for (const [name, raw] of dataMap(obj, 'binaryData')) {
+    entries.push({ id: id++, name, originalName: name, storedRaw: raw, storedField: 'binaryData', mode: 'binary', value: raw, deleted: false });
+  }
+  return entries;
+}
+
+/** Current value of an entry in manifest encoding. */
+export function entryRaw(entry: DataEntry, isSecret: boolean): string {
+  if (entry.mode === 'binary') return entry.value.replace(WHITESPACE_RE, '');
+  return isSecret ? textToB64(entry.value) : entry.value;
+}
+
+/** Field the entry will be written to on apply. */
+export function entryField(entry: DataEntry, isSecret: boolean): DataField {
+  if (isSecret) return 'data';
+  return entry.mode === 'binary' ? 'binaryData' : 'data';
+}
+
+export function entryDirty(entry: DataEntry, isSecret: boolean): boolean {
+  if (!entry.originalName) return true;
+  if (entry.deleted) return true;
+  if (entry.name !== entry.originalName) return true;
+  if (entryField(entry, isSecret) !== entry.storedField) return true;
+  return entryRaw(entry, isSecret) !== entry.storedRaw;
+}
+
+export function anyDirty(entries: DataEntry[], isSecret: boolean): boolean {
+  return entries.some((e) => entryDirty(e, isSecret));
+}
+
+const KEY_NAME_RE = /^[-._a-zA-Z0-9]+$/;
+
+export function validateEntries(entries: DataEntry[]): EntryProblem[] {
+  const problems: EntryProblem[] = [];
+  const live = entries.filter((e) => !e.deleted);
+  const nameCounts = new Map<string, number>();
+  for (const e of live) nameCounts.set(e.name, (nameCounts.get(e.name) ?? 0) + 1);
+  for (const e of live) {
+    if (!e.name) {
+      problems.push({ id: e.id, target: 'name', message: 'Key name is required' });
+    } else if (e.name.length > 253) {
+      problems.push({ id: e.id, target: 'name', message: 'Key name must be at most 253 characters' });
+    } else if (!KEY_NAME_RE.test(e.name)) {
+      problems.push({ id: e.id, target: 'name', message: "Key may contain only letters, digits, '-', '_' and '.'" });
+    } else if ((nameCounts.get(e.name) ?? 0) > 1) {
+      problems.push({ id: e.id, target: 'name', message: 'Duplicate key name' });
+    }
+    if (e.mode === 'binary' && !isValidB64(e.value.replace(WHITESPACE_RE, ''))) {
+      problems.push({ id: e.id, target: 'value', message: 'Not valid base64' });
+    }
+  }
+  return problems;
+}
+
+/**
+ * Build the manifest to apply: the latest server object with the draft's
+ * per-key operations replayed onto it. Keys the draft never touched keep the
+ * server's current value, so a concurrent edit of an unrelated key isn't
+ * silently reverted by the PUT replace.
+ */
+export function buildManifest(latest: KubeObject, entries: DataEntry[], isSecret: boolean): KubeObject {
+  const clone = JSON.parse(JSON.stringify(latest)) as KubeObject;
+  const meta = clone.metadata as unknown as Record<string, unknown>;
+  delete meta.managedFields;
+  // stringData is write-only; a read object should never carry it into a PUT.
+  delete clone.stringData;
+
+  const latestValues = { data: new Map(dataMap(latest, 'data')), binaryData: new Map(dataMap(latest, 'binaryData')) };
+  const result = { data: new Map(latestValues.data), binaryData: new Map(latestValues.binaryData) };
+  for (const e of entries) {
+    if (e.originalName && e.storedField) result[e.storedField].delete(e.originalName);
+  }
+  for (const e of entries) {
+    if (e.deleted) continue;
+    const field = entryField(e, isSecret);
+    const untouched = !entryDirty(e, isSecret);
+    const raw = untouched ? (latestValues[field].get(e.name) ?? e.storedRaw ?? '') : entryRaw(e, isSecret);
+    result[field].set(e.name, raw);
+  }
+  for (const field of ['data', 'binaryData'] as const) {
+    if (result[field].size) clone[field] = Object.fromEntries(result[field]);
+    else delete clone[field];
+  }
+  return clone;
+}
+
+/**
+ * Redact Secret values for the diff view. `shown` decides per key; values the
+ * user typed or explicitly revealed stay visible, everything else is masked on
+ * both sides so unchanged keys don't leak and produce no diff noise.
+ */
+export function maskSecretValues(obj: KubeObject, shown: (name: string) => boolean): KubeObject {
+  const clone = JSON.parse(JSON.stringify(obj)) as KubeObject;
+  for (const field of ['data', 'binaryData'] as const) {
+    const map = clone[field] as Record<string, unknown> | undefined;
+    if (!map) continue;
+    for (const key of Object.keys(map)) {
+      if (!shown(key)) map[key] = REDACTED;
+    }
+  }
+  return clone;
+}

--- a/client/src/components/detail/data-editor.ts
+++ b/client/src/components/detail/data-editor.ts
@@ -169,9 +169,10 @@ export function validateEntries(entries: DataEntry[]): EntryProblem[] {
 
 /**
  * Build the manifest to apply: the latest server object with the draft's
- * per-key operations replayed onto it. Keys the draft never touched keep the
- * server's current value, so a concurrent edit of an unrelated key isn't
- * silently reverted by the PUT replace.
+ * per-key operations replayed onto it. Keys the draft never touched mirror
+ * the server's current state — they keep a concurrently edited value and
+ * stay absent when another client deleted them — so the PUT replace only
+ * asserts the keys this draft actually changed.
  */
 export function buildManifest(latest: KubeObject, entries: DataEntry[], isSecret: boolean): KubeObject {
   const clone = JSON.parse(JSON.stringify(latest)) as KubeObject;
@@ -188,9 +189,12 @@ export function buildManifest(latest: KubeObject, entries: DataEntry[], isSecret
   for (const e of entries) {
     if (e.deleted) continue;
     const field = entryField(e, isSecret);
-    const untouched = !entryDirty(e, isSecret);
-    const raw = untouched ? (latestValues[field].get(e.name) ?? e.storedRaw ?? '') : entryRaw(e, isSecret);
-    result[field].set(e.name, raw);
+    if (!entryDirty(e, isSecret)) {
+      const raw = latestValues[field].get(e.name);
+      if (raw !== undefined) result[field].set(e.name, raw);
+      continue;
+    }
+    result[field].set(e.name, entryRaw(e, isSecret));
   }
   for (const field of ['data', 'binaryData'] as const) {
     if (result[field].size) clone[field] = Object.fromEntries(result[field]);

--- a/client/src/state/detail.ts
+++ b/client/src/state/detail.ts
@@ -14,6 +14,10 @@ interface DetailState {
   width: number;
   /** Bumped when keyboard flows want focus moved into the panel. */
   focusSeq: number;
+  /** The Data editor holds staged, unapplied key edits. */
+  dataDirty: boolean;
+  /** Action stalled behind the discard confirmation while dataDirty. */
+  pendingDiscard?: () => void;
   open: (sel: ResourceSelection) => void;
   push: (sel: ResourceSelection) => void;
   back: () => void;
@@ -21,6 +25,11 @@ interface DetailState {
   setCollapsed: (collapsed: boolean) => void;
   setWidth: (width: number) => void;
   requestFocus: () => void;
+  setDataDirty: (dirty: boolean) => void;
+  /** Run now, or stall behind the discard confirmation while the Data editor is dirty. */
+  guard: (action: () => void) => void;
+  confirmDiscard: () => void;
+  cancelDiscard: () => void;
 }
 
 export const DEFAULT_DETAIL_WIDTH = 640;
@@ -29,15 +38,29 @@ export function clampDetailWidth(width: number): number {
   return Math.max(380, Math.min(Math.round(window.innerWidth * 0.7), width));
 }
 
-export const useDetailStore = create<DetailState>((set) => ({
+function selKeyOf(sel: ResourceSelection): string {
+  return `${sel.ctx}|${sel.group}|${sel.version}|${sel.plural}|${sel.namespace ?? ''}|${sel.name}`;
+}
+
+export const useDetailStore = create<DetailState>((set, get) => ({
   stack: [],
   collapsed: false,
   width: DEFAULT_DETAIL_WIDTH,
   focusSeq: 0,
-  open: (sel) => set({ stack: [sel] }),
+  dataDirty: false,
+  // Selection changes come from anywhere (row clicks, topology, events,
+  // search) and replace the mounted detail — guard them so staged Data-tab
+  // edits aren't dropped without confirmation. Re-opening the same resource
+  // doesn't remount the editor, so it passes through.
+  open: (sel) => {
+    const { stack } = get();
+    const sameSel = stack.length === 1 && selKeyOf(stack[0]!) === selKeyOf(sel);
+    if (sameSel) set({ stack: [sel] });
+    else get().guard(() => set({ stack: [sel] }));
+  },
   // Pushes can come from outside the panel (e.g. the API-resource drawer's
   // CRD link), so surface the result even if the panel was collapsed.
-  push: (sel) => set((s) => ({ stack: [...s.stack, sel], collapsed: false })),
+  push: (sel) => get().guard(() => set((s) => ({ stack: [...s.stack, sel], collapsed: false }))),
   back: () => set((s) => ({ stack: s.stack.slice(0, -1) })),
   // Bail when already closed — close() is called liberally (e.g. on page
   // unmounts), and a fresh [] would re-render every stack subscriber.
@@ -45,4 +68,15 @@ export const useDetailStore = create<DetailState>((set) => ({
   setCollapsed: (collapsed) => set({ collapsed }),
   setWidth: (width) => set({ width: clampDetailWidth(width) }),
   requestFocus: () => set((s) => ({ focusSeq: s.focusSeq + 1, collapsed: false })),
+  setDataDirty: (dirty) => set((s) => (s.dataDirty === dirty ? s : { dataDirty: dirty })),
+  guard: (action) => {
+    if (get().dataDirty) set({ pendingDiscard: action });
+    else action();
+  },
+  confirmDiscard: () => {
+    const action = get().pendingDiscard;
+    set({ dataDirty: false, pendingDiscard: undefined });
+    action?.();
+  },
+  cancelDiscard: () => set({ pendingDiscard: undefined }),
 }));


### PR DESCRIPTION
ConfigMaps and Secrets get a **Data** tab in the detail drawer that edits keys individually instead of round-tripping full YAML.

## What's in it

- **Per-key operations**: add, rename, edit and delete are staged locally and applied in a single PUT.
- **Text / multiline / binary modes** with the encoding spelled out — ConfigMap binary keys are stored in `binaryData`, Secret text mode edits the decoded value and re-encodes on apply. Each key also offers copy, download-as-file and replace-from-file.
- **Secret redaction**: values stay masked (`••••••••`) until revealed per key or via a reveal-all switch; editing an existing key requires an explicit reveal. Copy works without on-screen reveal.
- **Diff + validation before apply**: a side-by-side diff gated behind an automatic server dry-run; Apply stays disabled until it passes. Key names (charset, length, duplicates) and base64 payloads are validated while staging. In the Secret diff, unrevealed values are masked on both sides, while user-authored edits always show so a change can never be invisible.
- **Safe apply semantics**: the manifest replays the staged operations onto the latest server object, so untouched keys keep concurrent server-side updates; a 409 refreshes the diff in place for re-review.
- **Dirty-state protection**: switching tabs, going back or closing the drawer with staged edits prompts before discarding; immutable objects render read-only with a banner.
- ConfigMaps get an overview summary of their keys (sizes, immutable badge), and annotation values that parse as http(s) URLs render as clickable links with `rel="noopener noreferrer"`.

## Verification

Typecheck and lint pass. Driven end-to-end headlessly against a kind cluster: staged edit + rename + binary-key delete + add applied in one PUT (multiline value preserved byte-for-byte), Secret key rotated via reveal-to-edit with the untouched key intact, dirty guard and dry-run gate exercised, and a focused check asserting unrevealed Secret values appear only masked in the diff with their base64 absent. All results confirmed cluster-side with kubectl.