### PR TITLE
Improve Kubernetes resource workflows and diagnostics

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from './theme.js';
 import { setTitleBarMode } from './titlebar-overlay.js';
+import { useContextsInvalidation } from './api/queries.js';
 import { useClustersStore } from './state/clusters.js';
 import { AppRouter } from './router.js';
 import { ErrorBoundary } from './components/ErrorBoundary.js';
@@ -12,6 +13,8 @@ import { UpdateNotification } from './components/UpdateNotification.js';
 import { TitleBarAwareBackdrop } from './components/TitleBarAwareBackdrop.js';
 
 export default function App() {
+  // One app-wide subscription keeps context/discovery queries fresh.
+  useContextsInvalidation();
   const themeMode = useClustersStore((s) => s.themeMode);
   const [osTheme, setOsTheme] = useState<'light' | 'dark'>(() =>
     //Check the operating system’s current color scheme and return true if it is dark, false otherwise

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -714,7 +714,7 @@ export function useRolloutHistory(sel: { ctx: string; kind: string; namespace?: 
       const params = new URLSearchParams({ kind: sel!.kind, namespace: sel!.namespace ?? '', name: sel!.name });
       return apiFetch<RolloutRevision[]>(`/api/contexts/${encodeURIComponent(sel!.ctx)}/detail/rollout-history?${params}`);
     },
-    enabled: !!sel && (sel.kind === 'Deployment' || sel.kind === 'StatefulSet'),
+    enabled: !!sel && (sel.kind === 'Deployment' || sel.kind === 'StatefulSet' || sel.kind === 'DaemonSet'),
     refetchInterval: useRefetchInterval(15_000),
   });
 }

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -807,13 +807,24 @@ export function useMetricsServerStatus(ctx: string, opts?: { refetchMs?: number 
   });
 }
 
-/** One-shot refetch of every metrics query — also the "refresh now" action, so it works while polling is paused. */
-export function invalidateMetricsServer(qc: ReturnType<typeof useQueryClient>): void {
-  void qc.invalidateQueries({ queryKey: ['metrics-server-status'] });
-  void qc.invalidateQueries({ queryKey: ['metrics-summary'] });
-  void qc.invalidateQueries({ queryKey: ['metrics-nodes'] });
-  void qc.invalidateQueries({ queryKey: ['metrics-snapshot'] });
-  void qc.invalidateQueries({ queryKey: ['metrics-history'] });
+/**
+ * One-shot refetch of metrics queries — also the "refresh now" action, so it
+ * works while polling is paused. Scoped to one cluster when ctx is given so a
+ * per-cluster refresh doesn't fan out to every selected cluster.
+ */
+export function invalidateMetricsServer(qc: ReturnType<typeof useQueryClient>, ctx?: string): void {
+  void qc.invalidateQueries({ queryKey: ctx ? ['metrics-server-status', ctx] : ['metrics-server-status'] });
+  void qc.invalidateQueries({ queryKey: ctx ? ['metrics-summary', ctx] : ['metrics-summary'] });
+  void qc.invalidateQueries({ queryKey: ctx ? ['metrics-nodes', ctx] : ['metrics-nodes'] });
+  // ctx sits deeper in these keys: snapshots batch a context list, history keys a selector object.
+  void qc.invalidateQueries({
+    queryKey: ['metrics-snapshot'],
+    predicate: (q) => !ctx || ((q.queryKey[2] as string[] | undefined) ?? []).includes(ctx),
+  });
+  void qc.invalidateQueries({
+    queryKey: ['metrics-history'],
+    predicate: (q) => !ctx || (q.queryKey[1] as { ctx?: string } | undefined)?.ctx === ctx,
+  });
 }
 
 export function useInstallMetricsServer() {
@@ -826,7 +837,7 @@ export function useInstallMetricsServer() {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       }),
-    onSuccess: () => invalidateMetricsServer(qc),
+    onSuccess: (_result, { ctx }) => invalidateMetricsServer(qc, ctx),
   });
 }
 
@@ -836,7 +847,7 @@ export function useUninstallMetricsServer() {
     meta: LOCAL_ERROR_HANDLING_META,
     mutationFn: ({ ctx }: { ctx: string }) =>
       apiFetch<MetricsServerUninstallResult>(`/api/contexts/${encodeURIComponent(ctx)}/metrics-server`, { method: 'DELETE' }),
-    onSuccess: () => invalidateMetricsServer(qc),
+    onSuccess: (_result, { ctx }) => invalidateMetricsServer(qc, ctx),
   });
 }
 

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -792,11 +792,13 @@ export function useMetricsServerStatus(ctx: string, opts?: { refetchMs?: number 
   });
 }
 
-function invalidateMetricsServer(qc: ReturnType<typeof useQueryClient>): void {
+/** One-shot refetch of every metrics query — also the "refresh now" action, so it works while polling is paused. */
+export function invalidateMetricsServer(qc: ReturnType<typeof useQueryClient>): void {
   void qc.invalidateQueries({ queryKey: ['metrics-server-status'] });
   void qc.invalidateQueries({ queryKey: ['metrics-summary'] });
   void qc.invalidateQueries({ queryKey: ['metrics-nodes'] });
   void qc.invalidateQueries({ queryKey: ['metrics-snapshot'] });
+  void qc.invalidateQueries({ queryKey: ['metrics-history'] });
 }
 
 export function useInstallMetricsServer() {

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -86,9 +86,14 @@ import { showToast } from '../state/toast.js';
 
 // ---- Contexts ----
 
-export function useContexts() {
+/**
+ * Mounted once at the app root: re-fetches the context list on server
+ * kubeconfig broadcasts and refreshes discovery-derived queries when a
+ * cluster's CRD set changes. One shared subscription serves every
+ * useContexts() observer, so the hook itself stays subscription-free.
+ */
+export function useContextsInvalidation() {
   const qc = useQueryClient();
-  // Re-fetch the context list whenever the server reports kubeconfig changes.
   useEffect(
     () =>
       watchClient.onBroadcast((msg) => {
@@ -106,10 +111,20 @@ export function useContexts() {
       }),
     [qc],
   );
+}
+
+/**
+ * The shared context list. Poll from long-lived single mounts (the cluster
+ * picker); per-cluster instances (section headers) pass poll: false and ride
+ * on the cache — each polling observer runs its own interval timer, so N
+ * headers would otherwise multiply the refetches.
+ */
+export function useContexts({ poll = true }: { poll?: boolean } = {}) {
+  const interval = useRefetchInterval(30_000);
   return useQuery({
     queryKey: ['contexts'],
     queryFn: () => apiFetch<ContextInfo[]>('/api/contexts'),
-    refetchInterval: useRefetchInterval(30_000),
+    refetchInterval: poll ? interval : false,
   });
 }
 

--- a/client/src/clipboard.ts
+++ b/client/src/clipboard.ts
@@ -4,6 +4,20 @@
  * on a LAN address it is undefined, so fall back to a hidden textarea +
  * execCommand. Returns whether the copy succeeded.
  */
+/**
+ * Read text from the clipboard. The async Clipboard API has no legacy read
+ * fallback (execCommand('paste') never worked reliably), so this returns null
+ * when the API is unavailable (plain-http LAN) or the user denied permission.
+ */
+export async function readFromClipboard(): Promise<string | null> {
+  if (!navigator.clipboard?.readText) return null;
+  try {
+    return await navigator.clipboard.readText();
+  } catch {
+    return null;
+  }
+}
+
 export async function copyToClipboard(text: string): Promise<boolean> {
   if (navigator.clipboard?.writeText) {
     try {

--- a/client/src/components/CellCopy.tsx
+++ b/client/src/components/CellCopy.tsx
@@ -21,6 +21,32 @@ export function cellCopyText(value: unknown): string {
   return '';
 }
 
+/** Standalone always-visible copy button for detail views (the grid variant below hides until hover). */
+export const CopyValueButton = memo(function CopyValueButton({ text, label = 'Copy value' }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const resetRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(resetRef.current), []);
+  return (
+    <IconButton
+      size="small"
+      aria-label={label}
+      title="Copy"
+      onClick={(event) => {
+        event.stopPropagation();
+        void copyToClipboard(text).then((ok) => {
+          if (!ok) return;
+          setCopied(true);
+          clearTimeout(resetRef.current);
+          resetRef.current = setTimeout(() => setCopied(false), 1200);
+        });
+      }}
+      sx={{ p: 0.25 }}
+    >
+      {copied ? <CheckIcon sx={{ fontSize: 14 }} color="success" /> : <ContentCopyIcon sx={{ fontSize: 14 }} />}
+    </IconButton>
+  );
+});
+
 const CellCopyButton = memo(function CellCopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   const resetRef = useRef<ReturnType<typeof setTimeout>>(undefined);

--- a/client/src/components/ClusterSectionHeader.tsx
+++ b/client/src/components/ClusterSectionHeader.tsx
@@ -1,13 +1,18 @@
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import HubOutlinedIcon from '@mui/icons-material/HubOutlined';
+import { useContexts } from '../api/queries.js';
+import { ContextHealthDot } from './ContextHealthDot.js';
 
 /** Header for one cluster's section on multi-cluster stacked pages (Overview, Metrics, Network). */
 export function ClusterSectionHeader({ ctx, children }: { ctx: string; children?: React.ReactNode }) {
+  const { data: contexts } = useContexts();
+  const info = contexts?.find((c) => c.name === ctx);
   return (
     <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center', flexWrap: 'wrap', rowGap: 1 }}>
       <HubOutlinedIcon sx={{ fontSize: 18, color: 'primary.main' }} />
       <Typography variant="h6">{ctx}</Typography>
+      <ContextHealthDot info={info} />
       {children}
     </Stack>
   );

--- a/client/src/components/ClusterSectionHeader.tsx
+++ b/client/src/components/ClusterSectionHeader.tsx
@@ -6,7 +6,8 @@ import { ContextHealthDot } from './ContextHealthDot.js';
 
 /** Header for one cluster's section on multi-cluster stacked pages (Overview, Metrics, Network). */
 export function ClusterSectionHeader({ ctx, children }: { ctx: string; children?: React.ReactNode }) {
-  const { data: contexts } = useContexts();
+  // Ride on the cluster picker's polling — one header per cluster mounts here.
+  const { data: contexts } = useContexts({ poll: false });
   const info = contexts?.find((c) => c.name === ctx);
   return (
     <Stack direction="row" spacing={1} sx={{ mb: 1.5, alignItems: 'center', flexWrap: 'wrap', rowGap: 1 }}>

--- a/client/src/components/ContextHealthDot.tsx
+++ b/client/src/components/ContextHealthDot.tsx
@@ -1,0 +1,32 @@
+import CircularProgress from '@mui/material/CircularProgress';
+import Tooltip from '@mui/material/Tooltip';
+import CircleIcon from '@mui/icons-material/Circle';
+import type { ContextHealth, ContextInfo } from '@kubus/shared';
+
+export const HEALTH_COLOR: Record<ContextHealth, 'success' | 'error' | 'warning' | 'disabled'> = {
+  connected: 'success',
+  error: 'error',
+  connecting: 'warning',
+  unknown: 'disabled',
+};
+
+export function healthTitle(c: ContextInfo): string {
+  if (c.health === 'connected') return c.kubernetesVersion ? `Connected · ${c.kubernetesVersion}` : 'Connected';
+  if (c.health === 'connecting') return 'Checking connectivity';
+  if (c.health === 'error') return c.healthMessage ?? 'Connection failed';
+  return 'Not checked yet';
+}
+
+/** Colored connection-state dot for a context; a spinner while connecting. */
+export function ContextHealthDot({ info, size = 12 }: { info: ContextInfo | undefined; size?: number }) {
+  if (!info) return null;
+  return (
+    <Tooltip title={healthTitle(info)}>
+      {info.health === 'connecting' ? (
+        <CircularProgress size={size} sx={{ color: 'warning.main' }} />
+      ) : (
+        <CircleIcon color={HEALTH_COLOR[info.health]} sx={{ fontSize: size }} />
+      )}
+    </Tooltip>
+  );
+}

--- a/client/src/components/HelmOperationErrorAlert.tsx
+++ b/client/src/components/HelmOperationErrorAlert.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { HelmOperationFailure } from '@kubus/shared';
 import type { ApiError } from '../api/http.js';
+import { copyToClipboard } from '../clipboard.js';
 
 function operationDetails(error: Error): HelmOperationFailure | undefined {
   const value = (error as ApiError).body?.details as Partial<HelmOperationFailure> | undefined;
@@ -13,17 +16,40 @@ function operationDetails(error: Error): HelmOperationFailure | undefined {
   return value as HelmOperationFailure;
 }
 
+const FAILED_ITEMS_VISIBLE = 3;
+
 export function HelmOperationErrorAlert({ error, onReview }: { error: Error; onReview?: () => void }) {
   const details = operationDetails(error);
+  const [showAll, setShowAll] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const failed = details?.failed ?? [];
+  const copyText = [
+    error.message,
+    ...(details ? [`phase: ${details.phase}`] : []),
+    ...failed.map((item) => `${item.resource}: ${item.error}`),
+  ].join('\n');
   return (
     <Alert
       severity="error"
       action={
-        onReview && details?.revision ? (
-          <Button color="inherit" size="small" onClick={onReview}>
-            Review history
+        <>
+          <Button
+            color="inherit"
+            size="small"
+            onClick={() =>
+              void copyToClipboard(copyText).then((ok) => {
+                if (ok) setCopied(true);
+              })
+            }
+          >
+            {copied ? 'Copied' : 'Copy details'}
           </Button>
-        ) : undefined
+          {onReview && details?.revision ? (
+            <Button color="inherit" size="small" onClick={onReview}>
+              Review history
+            </Button>
+          ) : undefined}
+        </>
       }
     >
       <AlertTitle>{details?.revision ? `${details.operation} revision ${details.revision} failed` : 'Helm operation failed'}</AlertTitle>
@@ -35,12 +61,17 @@ export function HelmOperationErrorAlert({ error, onReview }: { error: Error; onR
             {details.applied.length ? <Chip size="small" label={`${details.applied.length} resources changed`} /> : null}
             {details.recoveryRevision ? <Chip size="small" color="info" label={`last good: rev ${details.recoveryRevision}`} /> : null}
           </Stack>
-          {details.failed.length ? (
+          {failed.length ? (
             <Typography component="div" variant="caption" sx={{ display: 'block', mt: 1 }}>
-              {details.failed
-                .slice(0, 3)
-                .map((item) => `${item.resource}: ${item.error}`)
-                .join('; ')}
+              {(showAll ? failed : failed.slice(0, FAILED_ITEMS_VISIBLE)).map((item) => `${item.resource}: ${item.error}`).join('; ')}
+              {failed.length > FAILED_ITEMS_VISIBLE && (
+                <>
+                  {' '}
+                  <Link component="button" variant="caption" color="inherit" sx={{ fontWeight: 600 }} onClick={() => setShowAll((v) => !v)}>
+                    {showAll ? 'show less' : `show all ${failed.length}`}
+                  </Link>
+                </>
+              )}
             </Typography>
           ) : null}
           <Typography component="ul" variant="caption" sx={{ mt: 1, mb: 0, pl: 2.25 }}>

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -125,7 +125,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   const schemaSource = isCrd ? obj : backingCrd;
   const versions = useMemo(() => crdVersions(schemaSource), [schemaSource]);
   const hasMetrics = behaviorKind === 'Pod' || behaviorKind === 'Node';
-  const hasRolloutHistory = behaviorKind === 'Deployment' || behaviorKind === 'StatefulSet';
+  const hasRolloutHistory = behaviorKind === 'Deployment' || behaviorKind === 'StatefulSet' || behaviorKind === 'DaemonSet';
   const showMap = !isCrd;
   const drawerTopOffset = layout.topBarHeight;
   const drawerPaperSx = {
@@ -326,7 +326,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
               <MetricsChart ctx={sel.ctx} kind={behaviorKind === 'Pod' ? 'pod' : 'node'} name={sel.name} namespace={sel.namespace} />
             )}
             {tab === 'history' && hasRolloutHistory && obj && (
-              <RolloutHistory ctx={sel.ctx} kind={sel.kind as 'Deployment' | 'StatefulSet'} obj={obj} />
+              <RolloutHistory ctx={sel.ctx} kind={sel.kind as 'Deployment' | 'StatefulSet' | 'DaemonSet'} obj={obj} />
             )}
           </Box>
           <ConfirmDialog

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -110,15 +110,17 @@ export function ResourceTable({
   // Visibility and sort are driven straight from the prefs store (keyed by
   // tableId), so instance reuse across tables resolves the right model and
   // external writes — a saved-view restore — apply to a mounted table
-  // immediately. A saved model wins over the default-hidden set. Tables
+  // immediately. A saved model wins per field, but default-hidden columns it
+  // has never seen (added after the model was saved) stay hidden. Tables
   // without a tableId fall back to local state.
   const storedVisibility = useUiPrefsStore((s) => (tableId ? s.columnVisibility[tableId] : undefined));
   const setStoredVisibility = useUiPrefsStore((s) => s.setColumnVisibility);
   const [localVisibility, setLocalVisibility] = useState<GridColumnVisibilityModel | undefined>(undefined);
-  const visibility = useMemo<GridColumnVisibilityModel>(
-    () => (tableId ? storedVisibility : localVisibility) ?? Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []),
-    [tableId, storedVisibility, localVisibility, hiddenKey],
-  );
+  const visibility = useMemo<GridColumnVisibilityModel>(() => {
+    const defaults: GridColumnVisibilityModel = Object.fromEntries(hiddenKey ? hiddenKey.split(',').map((f) => [f, false]) : []);
+    const saved = tableId ? storedVisibility : localVisibility;
+    return saved ? { ...defaults, ...saved } : defaults;
+  }, [tableId, storedVisibility, localVisibility, hiddenKey]);
   const handleVisibilityChange = useCallback(
     (model: GridColumnVisibilityModel) => {
       if (tableId) setStoredVisibility(tableId, model);

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -14,6 +14,7 @@ import { joinLabelSelector, splitLabelSelector } from '../label-selector.js';
 import { SmartFilterInput } from './SmartFilterInput.js';
 import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from './CellCopy.js';
 import type { MetricsLookup } from './columns.js';
+import { podSummary } from '../kube-display.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { useQuickSearchShortcut } from './quick-search.js';
 
@@ -261,7 +262,17 @@ export function ResourceTable({
         columns={gridColumns}
         loading={loading}
         getRowId={(r) => r.obj.metadata.uid}
-        getRowClassName={(params) => (params.id === activeRowId ? 'kubus-active-resource-row' : '')}
+        getRowClassName={(params) => {
+          const classes: string[] = [];
+          if (params.id === activeRowId) classes.push('kubus-active-resource-row');
+          // Finished pods stay listed (and filterable) but recede visually so
+          // the running set stands out; hover restores full contrast.
+          if (kind === 'Pod') {
+            const status = podSummary(params.row.obj).status;
+            if (status === 'Succeeded' || status === 'Completed') classes.push('kubus-muted-row');
+          }
+          return classes.join(' ');
+        }}
         density={tableDensity === 'comfortable' ? 'standard' : 'compact'}
         // On overlay-scrollbar platforms the grid measures the native
         // scrollbar as 0px and floats its own on top of the last column;
@@ -329,6 +340,8 @@ export function ResourceTable({
             bgcolor: 'action.selected',
             '&:hover': { bgcolor: 'action.selected' },
           },
+          '& .MuiDataGrid-row.kubus-muted-row': { opacity: 0.55, transition: 'opacity 120ms' },
+          '& .MuiDataGrid-row.kubus-muted-row:hover, & .MuiDataGrid-row.kubus-muted-row:focus-within': { opacity: 1 },
           ...copyCellGridSx,
         }}
       />

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -64,7 +64,7 @@ import { watchClient } from '../api/ws/watch-client.js';
 import { useDockStore, dockTabId, type DockTab } from '../state/dock.js';
 import { useIsProtected } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
-import { showToast } from '../state/toast.js';
+import { showErrorToast, showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 import { FileCopyDialog } from './FileCopyDialog.js';
 import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
@@ -205,7 +205,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const removeFavorite = useNavigationStore((s) => s.removeFavorite);
 
   const ok = (text: string) => showToast('success', text);
-  const fail = (err: unknown) => showToast('error', err instanceof Error ? err.message : String(err));
+  const fail = (err: unknown) => showErrorToast(err);
 
   const scalable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'ReplicaSet';
   const navigate = useNavigate();

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -20,6 +20,8 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import TextField from '@mui/material/TextField';
+import ToggleButton from '@mui/material/ToggleButton';
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -65,6 +67,7 @@ import { FileCopyDialog } from './FileCopyDialog.js';
 import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
 import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
 import { podContainerNames } from '../kube-display.js';
+import { splitImageRef } from '../image-ref.js';
 import { kindListPath } from '../resource-links.js';
 
 export interface RowActionTarget {
@@ -770,16 +773,33 @@ interface PodTemplateContainer {
   image?: string;
 }
 
-function SetImageDialog({ target, onClose, onDone, onError }: { target: RowActionTarget; onClose: () => void; onDone: (t: string) => void; onError: (e: unknown) => void }) {
+export function SetImageDialog({
+  target,
+  initialContainer,
+  onClose,
+  onDone,
+  onError,
+}: {
+  target: RowActionTarget;
+  initialContainer?: string;
+  onClose: () => void;
+  onDone: (t: string) => void;
+  onError: (e: unknown) => void;
+}) {
   const setImage = useSetImage();
   const podSpec = (target.obj.spec as { template?: { spec?: { containers?: PodTemplateContainer[]; initContainers?: PodTemplateContainer[] } } })?.template?.spec;
   const containers = [
     ...(podSpec?.containers ?? []).map((c) => ({ ...c, init: false })),
     ...(podSpec?.initContainers ?? []).map((c) => ({ ...c, init: true })),
   ];
-  const [selected, setSelected] = useState(containers[0]?.name ?? '');
+  const first = containers.find((c) => c.name === initialContainer) ?? containers[0];
+  const [selected, setSelected] = useState(first?.name ?? '');
   const chosen = containers.find((c) => c.name === selected);
-  const [image, setImageValue] = useState(chosen?.image ?? '');
+  const parsed = chosen?.image ? splitImageRef(chosen.image) : undefined;
+  const [mode, setMode] = useState<'tag' | 'image'>(first?.image ? 'tag' : 'image');
+  const [tag, setTag] = useState(first?.image ? splitImageRef(first.image).tag ?? '' : '');
+  const [image, setImageValue] = useState(first?.image ?? '');
+  const finalImage = mode === 'tag' && parsed ? (tag.trim() ? `${parsed.repo}:${tag.trim()}` : '') : image.trim();
   return (
     <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Set image — {target.obj.metadata.name}</DialogTitle>
@@ -793,7 +813,10 @@ function SetImageDialog({ target, onClose, onDone, onError }: { target: RowActio
             onChange={(e) => {
               const name = e.target.value;
               setSelected(name);
-              setImageValue(containers.find((c) => c.name === name)?.image ?? '');
+              const img = containers.find((c) => c.name === name)?.image;
+              setImageValue(img ?? '');
+              setTag(img ? splitImageRef(img).tag ?? '' : '');
+              if (!img) setMode('image');
             }}
           >
             {containers.map((c) => (
@@ -804,13 +827,37 @@ function SetImageDialog({ target, onClose, onDone, onError }: { target: RowActio
             ))}
           </Select>
         </FormControl>
-        <TextField autoFocus fullWidth label="Image" value={image} onChange={(e) => setImageValue(e.target.value)} helperText={chosen?.image ? `Current: ${chosen.image}` : undefined} />
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={mode}
+          onChange={(_e, v) => {
+            if (v) setMode(v as 'tag' | 'image');
+          }}
+        >
+          <ToggleButton value="tag" disabled={!parsed}>
+            Tag only
+          </ToggleButton>
+          <ToggleButton value="image">Full image</ToggleButton>
+        </ToggleButtonGroup>
+        {mode === 'tag' && parsed ? (
+          <TextField
+            autoFocus
+            fullWidth
+            label="Tag"
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+            helperText={`Applies ${parsed.repo}:${tag.trim() || '<tag>'}${parsed.digest ? ' — replaces the digest pin' : ''}`}
+          />
+        ) : (
+          <TextField autoFocus fullWidth label="Image" value={image} onChange={(e) => setImageValue(e.target.value)} helperText={chosen?.image ? `Current: ${chosen.image}` : undefined} />
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
         <Button
           variant="contained"
-          disabled={setImage.isPending || !image.trim() || !chosen}
+          disabled={setImage.isPending || !finalImage || !chosen}
           onClick={() =>
             setImage.mutate(
               {
@@ -820,14 +867,14 @@ function SetImageDialog({ target, onClose, onDone, onError }: { target: RowActio
                   namespace: target.obj.metadata.namespace ?? '',
                   name: target.obj.metadata.name,
                   container: selected,
-                  image: image.trim(),
+                  image: finalImage,
                   initContainer: chosen?.init || undefined,
                 },
               },
               {
                 onSuccess: () => {
                   onClose();
-                  onDone(`Set ${selected} image to ${image.trim()}`);
+                  onDone(`Set ${selected} image to ${finalImage}`);
                 },
                 onError: (e) => {
                   onClose();

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -43,6 +43,8 @@ import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import BlockIcon from '@mui/icons-material/Block';
 import DownhillSkiingIcon from '@mui/icons-material/DownhillSkiing';
 import SpeedIcon from '@mui/icons-material/Speed';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
 import { gvkForResource, type DebugProfile, type KubeObject, type LogTargetKind } from '@kubus/shared';
 import {
   resolveLogTargetPods,
@@ -61,6 +63,7 @@ import {
 import { watchClient } from '../api/ws/watch-client.js';
 import { useDockStore, dockTabId, type DockTab } from '../state/dock.js';
 import { useIsProtected } from '../state/clusters.js';
+import { useNavigationStore } from '../state/navigation.js';
 import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 import { FileCopyDialog } from './FileCopyDialog.js';
@@ -68,7 +71,7 @@ import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
 import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
 import { podContainerNames } from '../kube-display.js';
 import { splitImageRef } from '../image-ref.js';
-import { kindListPath } from '../resource-links.js';
+import { favoriteForRef, kindListPath } from '../resource-links.js';
 
 export interface RowActionTarget {
   ctx: string;
@@ -195,6 +198,11 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const namespace = obj.metadata.namespace;
   const isProtected = useIsProtected(ctx);
   const close = onClose;
+
+  const favorite = favoriteForRef({ ctx, group: target.group, version: target.version, plural: target.plural, kind, name, namespace });
+  const isFav = useNavigationStore((s) => s.isFavorite(favorite.id));
+  const addFavorite = useNavigationStore((s) => s.addFavorite);
+  const removeFavorite = useNavigationStore((s) => s.removeFavorite);
 
   const ok = (text: string) => showToast('success', text);
   const fail = (err: unknown) => showToast('error', err instanceof Error ? err.message : String(err));
@@ -480,6 +488,16 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
             <ListItemText>Drain…</ListItemText>
           </MenuItem>
         )}
+        <MenuItem
+          onClick={() => {
+            if (isFav) removeFavorite(favorite.id);
+            else addFavorite(favorite);
+            close();
+          }}
+        >
+          <ListItemIcon>{isFav ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}</ListItemIcon>
+          <ListItemText>{isFav ? 'Remove favorite' : 'Add to favorites'}</ListItemText>
+        </MenuItem>
         <Divider />
         <MenuItem
           onClick={() => {

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -45,6 +45,7 @@ import DownhillSkiingIcon from '@mui/icons-material/DownhillSkiing';
 import SpeedIcon from '@mui/icons-material/Speed';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
+import LinkIcon from '@mui/icons-material/Link';
 import { gvkForResource, type DebugProfile, type KubeObject, type LogTargetKind } from '@kubus/shared';
 import {
   resolveLogTargetPods,
@@ -71,7 +72,8 @@ import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
 import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
 import { podContainerNames } from '../kube-display.js';
 import { splitImageRef } from '../image-ref.js';
-import { favoriteForRef, kindListPath } from '../resource-links.js';
+import { copyToClipboard } from '../clipboard.js';
+import { detailPathForRef, favoriteForRef, kindListPath, shareLinkForPath } from '../resource-links.js';
 
 export interface RowActionTarget {
   ctx: string;
@@ -199,7 +201,8 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const isProtected = useIsProtected(ctx);
   const close = onClose;
 
-  const favorite = favoriteForRef({ ctx, group: target.group, version: target.version, plural: target.plural, kind, name, namespace });
+  const resourceRef = { ctx, group: target.group, version: target.version, plural: target.plural, kind, name, namespace };
+  const favorite = favoriteForRef(resourceRef);
   const isFav = useNavigationStore((s) => s.isFavorite(favorite.id));
   const addFavorite = useNavigationStore((s) => s.addFavorite);
   const removeFavorite = useNavigationStore((s) => s.removeFavorite);
@@ -497,6 +500,19 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
         >
           <ListItemIcon>{isFav ? <StarIcon fontSize="small" /> : <StarBorderIcon fontSize="small" />}</ListItemIcon>
           <ListItemText>{isFav ? 'Remove favorite' : 'Add to favorites'}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            void copyToClipboard(shareLinkForPath(detailPathForRef(resourceRef))).then((copied) =>
+              copied ? ok('Link copied') : showToast('error', 'Copy to clipboard failed'),
+            );
+            close();
+          }}
+        >
+          <ListItemIcon>
+            <LinkIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy link</ListItemText>
         </MenuItem>
         <Divider />
         <MenuItem

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -43,7 +43,7 @@ import FolderOpenOutlinedIcon from '@mui/icons-material/FolderOpenOutlined';
 import BlockIcon from '@mui/icons-material/Block';
 import DownhillSkiingIcon from '@mui/icons-material/DownhillSkiing';
 import SpeedIcon from '@mui/icons-material/Speed';
-import { gvkForResource, type KubeObject, type LogTargetKind } from '@kubus/shared';
+import { gvkForResource, type DebugProfile, type KubeObject, type LogTargetKind } from '@kubus/shared';
 import {
   resolveLogTargetPods,
   useCordon,
@@ -891,12 +891,20 @@ export function SetImageDialog({
   );
 }
 
+const DEBUG_PROFILES: Array<{ value: DebugProfile; label: string; hint: string }> = [
+  { value: 'general', label: 'General', hint: 'No extra privileges — inherits the namespace defaults.' },
+  { value: 'restricted', label: 'Restricted', hint: 'Non-root, all capabilities dropped — for PodSecurity-restricted namespaces (needs a non-root image).' },
+  { value: 'netadmin', label: 'Network admin', hint: 'Adds NET_ADMIN and NET_RAW — tcpdump, iptables, ping.' },
+  { value: 'sysadmin', label: 'System admin', hint: 'Privileged container — full access, rejected in restricted namespaces.' },
+];
+
 function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTarget; onClose: () => void; onDone: (t: string) => void; onError: (e: unknown) => void }) {
   const debug = useDebugPod();
   const addTab = useDockStore((s) => s.addTab);
   const containers = podContainerNames(target.obj);
   const [image, setImage] = useState('busybox:1.36');
   const [targetContainer, setTargetContainer] = useState(containers[0] ?? '');
+  const [profile, setProfile] = useState<DebugProfile>('general');
   const name = target.obj.metadata.name;
   return (
     <Dialog open onClose={debug.isPending ? undefined : onClose} maxWidth="sm" fullWidth>
@@ -918,6 +926,19 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
             ))}
           </Select>
         </FormControl>
+        <FormControl size="small" fullWidth>
+          <InputLabel id="debug-profile">Profile</InputLabel>
+          <Select labelId="debug-profile" label="Profile" value={profile} onChange={(e) => setProfile(e.target.value as DebugProfile)}>
+            {DEBUG_PROFILES.map((p) => (
+              <MenuItem key={p.value} value={p.value}>
+                {p.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
+          {DEBUG_PROFILES.find((p) => p.value === profile)?.hint}
+        </Typography>
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose} disabled={debug.isPending}>
@@ -928,7 +949,7 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
           disabled={debug.isPending || !image.trim()}
           onClick={() =>
             debug.mutate(
-              { ctx: target.ctx, body: { namespace: target.obj.metadata.namespace ?? '', pod: name, image: image.trim(), target: targetContainer || undefined } },
+              { ctx: target.ctx, body: { namespace: target.obj.metadata.namespace ?? '', pod: name, image: image.trim(), target: targetContainer || undefined, profile } },
               {
                 onSuccess: ({ containerName }) => {
                   onClose();

--- a/client/src/components/TerminalPaneImpl.tsx
+++ b/client/src/components/TerminalPaneImpl.tsx
@@ -6,13 +6,39 @@ import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import type { ExecServerControl } from '@kubus/shared';
 import { wsUrl } from '../api/http.js';
+import { copyToClipboard, readFromClipboard } from '../clipboard.js';
 import type { NodeShellTab, TerminalTab } from '../state/dock.js';
 import { useUiPrefsStore } from '../state/prefs.js';
+import { showToast } from '../state/toast.js';
 
 export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | NodeShellTab; active: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  const termRef = useRef<Terminal | null>(null);
   const theme = useTheme();
+
+  // Right-click copies the selection when there is one, otherwise pastes —
+  // the common terminal-emulator convention. Paste goes through term.paste()
+  // so bracketed-paste mode reaches the remote shell intact.
+  const onContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const term = termRef.current;
+    if (!term) return;
+    const selection = term.getSelection();
+    if (selection) {
+      void copyToClipboard(selection).then((ok) => {
+        if (ok) term.clearSelection();
+      });
+      return;
+    }
+    void readFromClipboard().then((text) => {
+      if (text === null) {
+        showToast('warning', 'Clipboard read unavailable or denied — allow clipboard access, or paste with the keyboard.');
+        return;
+      }
+      if (text) term.paste(text);
+    });
+  };
 
   useEffect(() => {
     const el = containerRef.current;
@@ -27,6 +53,7 @@ export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | N
     });
     const fit = new FitAddon();
     fitRef.current = fit;
+    termRef.current = term;
     term.loadAddon(fit);
     term.open(el);
     fit.fit();
@@ -82,6 +109,7 @@ export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | N
       onResize.dispose();
       ws.close();
       term.dispose();
+      termRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab.id]);
@@ -95,6 +123,7 @@ export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | N
     <Box sx={{ height: '100%', p: 1, pt: 0.75 }}>
       <Box
         ref={containerRef}
+        onContextMenu={onContextMenu}
         sx={{
           height: '100%',
           bgcolor: '#16161e',

--- a/client/src/components/ToastHost.tsx
+++ b/client/src/components/ToastHost.tsx
@@ -1,21 +1,81 @@
+import { useEffect, useState } from 'react';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
 import Snackbar from '@mui/material/Snackbar';
+import CloseIcon from '@mui/icons-material/Close';
+import { copyToClipboard } from '../clipboard.js';
 import { useToastStore } from '../state/toast.js';
 
 /** The single snackbar for all `showToast` notifications; mounted once in App. */
 export function ToastHost() {
   const toast = useToastStore((s) => s.toast);
   const dismiss = useToastStore((s) => s.dismiss);
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setExpanded(false);
+    setCopied(false);
+  }, [toast?.id]);
+
+  const copyable = !!toast && (toast.severity === 'error' || toast.severity === 'warning');
+  const copyText = toast ? [toast.message, toast.details].filter(Boolean).join('\n\n') : '';
   return (
     <Snackbar
       key={toast?.id}
       open={!!toast}
-      autoHideDuration={5000}
-      onClose={dismiss}
+      // Reading expanded details must not race the auto-hide timer.
+      autoHideDuration={expanded ? null : 5000}
+      onClose={(_e, reason) => {
+        if (reason === 'clickaway' && expanded) return;
+        dismiss();
+      }}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
     >
-      <Alert severity={toast?.severity ?? 'info'} variant="filled" onClose={dismiss}>
+      <Alert
+        severity={toast?.severity ?? 'info'}
+        variant="filled"
+        sx={{ maxWidth: 560 }}
+        action={
+          <>
+            {copyable && (
+              <Button
+                color="inherit"
+                size="small"
+                onClick={() =>
+                  void copyToClipboard(copyText).then((ok) => {
+                    if (ok) setCopied(true);
+                  })
+                }
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </Button>
+            )}
+            {toast?.details && (
+              <Button color="inherit" size="small" onClick={() => setExpanded((v) => !v)}>
+                {expanded ? 'Less' : 'Details'}
+              </Button>
+            )}
+            <IconButton size="small" color="inherit" onClick={dismiss} aria-label="Close notification">
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </>
+        }
+      >
         {toast?.message}
+        {toast?.details && (
+          <Collapse in={expanded}>
+            <Box
+              component="pre"
+              sx={{ m: 0, mt: 1, maxHeight: 240, overflow: 'auto', fontSize: 11, fontFamily: 'monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+            >
+              {toast.details}
+            </Box>
+          </Collapse>
+        )}
       </Alert>
     </Snackbar>
   );

--- a/client/src/components/YamlEditorImpl.tsx
+++ b/client/src/components/YamlEditorImpl.tsx
@@ -3,6 +3,7 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import Editor from '@monaco-editor/react';
 import { useTheme } from '@mui/material/styles';
@@ -22,6 +23,7 @@ export default function YamlEditorImpl({ value, readOnly, onApply, onDryRun, app
   const [dryRunText, setDryRunText] = useState<string>();
   const [dryRun, setDryRun] = useState<ResourceDryRunResponse>();
   const [copied, setCopied] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
   const copyResetRef = useRef<number | undefined>(undefined);
   const schemaRef = useYamlSchema(schema);
   // Per-mount model path under the schema's glob prefix, so the registered
@@ -93,8 +95,52 @@ export default function YamlEditorImpl({ value, readOnly, onApply, onDryRun, app
     }
   };
 
+  // A dropped YAML file replaces the editor content and goes through the
+  // normal edit flow (dirty → dry-run gate → apply). Capture-phase handlers
+  // keep Monaco's own text drag-and-drop from swallowing file drops.
+  const editable = !(readOnly ?? !onApply);
+  const MAX_DROP_BYTES = 2 * 1024 * 1024;
+
+  const loadDroppedFile = async (file: File) => {
+    if (file.size > MAX_DROP_BYTES) {
+      setError(`${file.name} is too large to load (${Math.round(file.size / 1024)} KiB)`);
+      return;
+    }
+    try {
+      const content = await file.text();
+      setText(content);
+      onChange?.(content);
+      setCopied(false);
+      setDryRun(undefined);
+      setDryRunText(undefined);
+      setError(undefined);
+    } catch {
+      setError(`Could not read ${file.name}`);
+    }
+  };
+
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+    <Box
+      sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}
+      onDragOverCapture={(e) => {
+        if (!editable || !e.dataTransfer.types.includes('Files')) return;
+        e.preventDefault();
+        e.stopPropagation();
+        e.dataTransfer.dropEffect = 'copy';
+        setDragOver(true);
+      }}
+      onDragLeaveCapture={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOver(false);
+      }}
+      onDropCapture={(e) => {
+        const file = e.dataTransfer.files[0];
+        if (!editable || !file) return;
+        e.preventDefault();
+        e.stopPropagation();
+        setDragOver(false);
+        void loadDroppedFile(file);
+      }}
+    >
       <Stack direction="row" spacing={1} sx={{ p: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center', flexShrink: 0 }}>
         {toolbar}
         <Box sx={{ flex: 1 }} />
@@ -139,7 +185,28 @@ export default function YamlEditorImpl({ value, readOnly, onApply, onDryRun, app
           Server dry-run accepted this manifest.
         </Alert>
       ) : null}
-      <Box sx={{ flex: 1, minHeight: 0 }}>
+      <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        {dragOver && (
+          <Box
+            sx={{
+              position: 'absolute',
+              inset: 0,
+              zIndex: 10,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              bgcolor: 'action.hover',
+              border: 2,
+              borderStyle: 'dashed',
+              borderColor: 'primary.main',
+              pointerEvents: 'none',
+            }}
+          >
+            <Typography variant="subtitle2" sx={{ bgcolor: 'background.paper', px: 1.5, py: 0.5, borderRadius: 1, boxShadow: 1 }}>
+              Drop YAML file to load
+            </Typography>
+          </Box>
+        )}
         <Editor
           language="yaml"
           path={modelPath}

--- a/client/src/components/columns.tsx
+++ b/client/src/components/columns.tsx
@@ -11,7 +11,7 @@ import { AgeCell, RelativeTimeCell } from './AgeCell.js';
 import { ReadyCounter } from './ReadyCounter.js';
 import { StatusChip } from './StatusChip.js';
 import { formatBytes, formatCpu } from './format.js';
-import { dataKeyCount, eventFields, hasRunningDebugContainer, ingressHosts, jobPhase, jobStatus, nodeAddress, nodeConditions, nodeRoles, nodeStatus, nodeTaints, ownerReference, parseQuantity, podRequestTotals, podSummary, serviceLoadBalancerAddresses, servicePorts, statusLikeName, workloadReady } from '../kube-display.js';
+import { dataKeyCount, eventFields, hasRunningDebugContainer, hpaProblems, ingressHosts, jobPhase, jobStatus, nodeAddress, nodeConditions, nodeRoles, nodeStatus, nodeTaints, ownerReference, parseQuantity, podRequestTotals, podSummary, serviceLoadBalancerAddresses, servicePorts, statusLikeName, workloadReady } from '../kube-display.js';
 import { cronHumanText, cronNextRun } from '../cron.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { UsageMeter } from './UsageMeter.js';
@@ -520,6 +520,13 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
     valueGetter: (_v, row) => nodeConditions(obj(row)),
     renderCell: (params) => <TextCell value={String(params.value ?? '')} />,
   }),
+  nodeProviderID: () => ({
+    field: 'nodeProviderID',
+    headerName: 'Provider ID',
+    width: 220,
+    valueGetter: (_v, row) => ((obj(row).spec as { providerID?: string })?.providerID ?? ''),
+    renderCell: (params) => <TextCell value={String(params.value ?? '')} />,
+  }),
   nsStatus: () => ({
     field: 'nsStatus',
     headerName: 'Status',
@@ -591,6 +598,27 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
     headerName: 'Replicas',
     width: 80,
     valueGetter: (_v, row) => ((obj(row).status as { currentReplicas?: number })?.currentReplicas ?? 0).toString(),
+  }),
+  hpaConditions: () => ({
+    field: 'hpaConditions',
+    headerName: 'Conditions',
+    flex: 1,
+    minWidth: 160,
+    valueGetter: (_v, row) => hpaProblems(obj(row)),
+    renderCell: (params) => {
+      const text = String(params.value ?? '');
+      return text ? (
+        <Tooltip title={text}>
+          <Typography variant="body2" color="warning.main" noWrap sx={{ minWidth: 0 }}>
+            {text}
+          </Typography>
+        </Tooltip>
+      ) : (
+        <Typography variant="body2" color="text.disabled">
+          —
+        </Typography>
+      );
+    },
   }),
 };
 

--- a/client/src/components/detail/ContainerCards.tsx
+++ b/client/src/components/detail/ContainerCards.tsx
@@ -1,8 +1,10 @@
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
+import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import { AgeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
 import { UsageMeter } from '../UsageMeter.js';
@@ -28,18 +30,26 @@ export interface ContainerCardData {
 }
 
 /** Card grid for a pod's (or workload template's) containers. */
-export function ContainerCards({ items, onForwardPort }: { items: ContainerCardData[]; onForwardPort?: (port: number) => void }) {
+export function ContainerCards({
+  items,
+  onForwardPort,
+  onEditImage,
+}: {
+  items: ContainerCardData[];
+  onForwardPort?: (port: number) => void;
+  onEditImage?: (container: string) => void;
+}) {
   if (!items.length) return null;
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(270px, 1fr))', gap: 1.5 }}>
       {items.map((c) => (
-        <ContainerCard key={`${c.kind ?? 'app'}:${c.name}`} c={c} onForwardPort={onForwardPort} />
+        <ContainerCard key={`${c.kind ?? 'app'}:${c.name}`} c={c} onForwardPort={onForwardPort} onEditImage={onEditImage} />
       ))}
     </Box>
   );
 }
 
-function ContainerCard({ c, onForwardPort }: { c: ContainerCardData; onForwardPort?: (port: number) => void }) {
+function ContainerCard({ c, onForwardPort, onEditImage }: { c: ContainerCardData; onForwardPort?: (port: number) => void; onEditImage?: (container: string) => void }) {
   const showRestarts = (c.restarts ?? 0) > 0 || c.lastRestart;
   return (
     <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.5, minWidth: 0 }}>
@@ -56,15 +66,23 @@ function ContainerCard({ c, onForwardPort }: { c: ContainerCardData; onForwardPo
         )}
       </Stack>
       {c.image && (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          noWrap
-          title={c.image}
-          sx={{ display: 'block', fontFamily: 'monospace', fontSize: 11, mt: 0.25 }}
-        >
-          {c.image}
-        </Typography>
+        <Stack direction="row" sx={{ alignItems: 'center', gap: 0.25, minWidth: 0, mt: 0.25 }}>
+          <Typography variant="caption" color="text.secondary" noWrap title={c.image} sx={{ fontFamily: 'monospace', fontSize: 11, minWidth: 0 }}>
+            {c.image}
+          </Typography>
+          {onEditImage && (
+            <Tooltip title="Change image">
+              <IconButton
+                size="small"
+                aria-label={`Change image of ${c.name}`}
+                onClick={() => onEditImage(c.name)}
+                sx={{ p: 0.25, flexShrink: 0 }}
+              >
+                <EditOutlinedIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
       )}
       {c.stateMessage && (
         <Typography

--- a/client/src/components/detail/ContainerCards.tsx
+++ b/client/src/components/detail/ContainerCards.tsx
@@ -161,6 +161,13 @@ function ContainerCard({ c, onForwardPort, onEditImage }: { c: ContainerCardData
           podCount={c.podCount}
         />
       </Box>
+      {(c.resources.ephemeralRequestBytes !== undefined || c.resources.ephemeralLimitBytes !== undefined) && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+          {`Ephemeral storage · req ${c.resources.ephemeralRequestBytes !== undefined ? formatBytes(c.resources.ephemeralRequestBytes) : '—'} · lim ${
+            c.resources.ephemeralLimitBytes !== undefined ? formatBytes(c.resources.ephemeralLimitBytes) : '—'
+          }`}
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/client/src/components/detail/DeploymentDetail.tsx
+++ b/client/src/components/detail/DeploymentDetail.tsx
@@ -4,8 +4,10 @@ import Tooltip from '@mui/material/Tooltip';
 import type { ContainerUsage, KubeObject } from '@kubus/shared';
 import { useMemo, useState } from 'react';
 import { PortForwardDialog } from '../PortForwardDialog.js';
+import { SetImageDialog } from '../RowActions.js';
 import { useResourceList, useResourceMetrics } from '../../api/queries.js';
 import { containerResources, workloadReady } from '../../kube-display.js';
+import { showToast } from '../../state/toast.js';
 import { ReadyCounter } from '../ReadyCounter.js';
 import { ConditionChips, ConditionRows, KeyValueSection, MetadataSection, hasUnhealthyCondition } from './GenericDetail.js';
 import { ContainerCards, type ContainerCardData } from './ContainerCards.js';
@@ -54,6 +56,7 @@ const deploymentGoodWhen = (type: string): 'True' | 'False' => (type === 'Replic
 
 export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
   const [forwardPort, setForwardPort] = useState<number>();
+  const [editImageContainer, setEditImageContainer] = useState<string>();
   const namespace = obj.metadata.namespace;
   const spec = obj.spec as DeploymentSpec | undefined;
   const labelSelector = selectorToString(spec?.selector);
@@ -130,7 +133,7 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
         <ConditionChips obj={obj} goodWhen={deploymentGoodWhen} />
       </Stack>
       <Section title="Containers" count={cards.length}>
-        <ContainerCards items={cards} onForwardPort={setForwardPort} />
+        <ContainerCards items={cards} onForwardPort={setForwardPort} onEditImage={setEditImageContainer} />
       </Section>
       <Section title="Pods" count={pods.length}>
         <PodMiniList
@@ -154,6 +157,15 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
       <MetadataSection obj={obj} ctx={ctx} defaultOpen={false} />
       {forwardPort !== undefined && (
         <PortForwardDialog ctx={ctx} kind="Deployment" obj={obj} initialRemotePort={forwardPort} onClose={() => setForwardPort(undefined)} />
+      )}
+      {editImageContainer !== undefined && (
+        <SetImageDialog
+          target={{ ctx, group: 'apps', version: 'v1', plural: 'deployments', kind: 'Deployment', obj }}
+          initialContainer={editImageContainer}
+          onClose={() => setEditImageContainer(undefined)}
+          onDone={(t) => showToast('success', t)}
+          onError={(e) => showToast('error', e instanceof Error ? e.message : String(e))}
+        />
       )}
     </Stack>
   );

--- a/client/src/components/detail/NodeDetail.tsx
+++ b/client/src/components/detail/NodeDetail.tsx
@@ -11,6 +11,7 @@ import Typography from '@mui/material/Typography';
 import type { KubeObject } from '@kubus/shared';
 import { GenericDetail, ConditionsTable } from './GenericDetail.js';
 import { PodMiniList } from './PodMiniList.js';
+import { CopyValueButton } from '../CellCopy.js';
 import { StatusChip } from '../StatusChip.js';
 import { formatBytes } from '../format.js';
 import { nodeRoles, nodeStatus, parseQuantity } from '../../kube-display.js';
@@ -37,6 +38,7 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
   const status = (obj.status ?? {}) as NodeStatus;
   const name = obj.metadata.name;
   const roles = nodeRoles(obj);
+  const providerID = (obj.spec as { providerID?: string } | undefined)?.providerID;
   const podsQuery = useResourceList({ ctx, group: '', version: 'v1', plural: 'pods', fieldSelector: `spec.nodeName=${name}` });
 
   const resourceKeys = ['cpu', 'memory', 'pods', 'ephemeral-storage'].filter((k) => status.capacity?.[k] !== undefined || status.allocatable?.[k] !== undefined);
@@ -52,19 +54,27 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
         {status.nodeInfo?.containerRuntimeVersion && <Chip label={status.nodeInfo.containerRuntimeVersion} variant="outlined" />}
       </Stack>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
-        {!!status.addresses?.length && (
+        {(!!status.addresses?.length || providerID) && (
           <Box>
             <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
               Addresses
             </Typography>
             <Table size="small">
               <TableBody>
-                {status.addresses.map((a) => (
+                {(status.addresses ?? []).map((a) => (
                   <TableRow key={`${a.type}:${a.address}`}>
                     <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{a.type}</TableCell>
                     <TableCell sx={{ border: 0 }}>{a.address}</TableCell>
                   </TableRow>
                 ))}
+                {providerID && (
+                  <TableRow>
+                    <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>Provider ID</TableCell>
+                    <TableCell sx={{ border: 0, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all' }}>
+                      {providerID} <CopyValueButton text={providerID} label="Copy provider ID" />
+                    </TableCell>
+                  </TableRow>
+                )}
               </TableBody>
             </Table>
           </Box>

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -31,6 +31,17 @@ import { useDetailStore } from '../../state/detail.js';
 import { showToast } from '../../state/toast.js';
 import { useDockStore, dockTabId } from '../../state/dock.js';
 
+interface Probe {
+  httpGet?: { path?: string; port?: number | string; scheme?: string };
+  tcpSocket?: { port?: number | string };
+  exec?: { command?: string[] };
+  grpc?: { port?: number; service?: string };
+  initialDelaySeconds?: number;
+  periodSeconds?: number;
+  timeoutSeconds?: number;
+  failureThreshold?: number;
+}
+
 interface ContainerSpec {
   name: string;
   image?: string;
@@ -38,11 +49,15 @@ interface ContainerSpec {
   ports?: Array<{ containerPort: number; protocol?: string; name?: string }>;
   volumeMounts?: Array<{ name: string; mountPath: string; readOnly?: boolean; subPath?: string }>;
   resources?: { requests?: Record<string, string>; limits?: Record<string, string> };
+  livenessProbe?: Probe;
+  readinessProbe?: Probe;
+  startupProbe?: Probe;
 }
 
 interface ContainerStatus {
   name: string;
   ready?: boolean;
+  started?: boolean;
   restartCount?: number;
   state?: Record<string, { reason?: string; message?: string }>;
   lastState?: { terminated?: { reason?: string; finishedAt?: string } };
@@ -153,6 +168,7 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
         </Section>
       )}
       <DebugContainersSection obj={obj} ctx={ctx} />
+      <ProbesSection spec={spec} statusByName={new Map([...initStatusByName, ...statusByName])} terminal={terminal} />
       {namespace && <EnvSection ctx={ctx} namespace={namespace} pod={obj.metadata.name} onOpenRef={openRelated} />}
       <VolumesSection spec={spec} onOpenRef={openRelated} />
       <SchedulingSection spec={spec} />
@@ -242,6 +258,81 @@ function DebugContainersSection({ obj, ctx }: { obj: KubeObject; ctx: string }) 
 }
 
 type RefOpener = (kind: RelatedKind, name: string) => void;
+
+const PROBE_KINDS = [
+  ['readiness', 'readinessProbe'],
+  ['liveness', 'livenessProbe'],
+  ['startup', 'startupProbe'],
+] as const;
+
+function probeTarget(p: Probe): string {
+  if (p.httpGet) return `${(p.httpGet.scheme ?? 'HTTP') === 'HTTPS' ? 'HTTPS' : 'HTTP'} ${p.httpGet.path ?? '/'} :${p.httpGet.port ?? ''}`;
+  if (p.tcpSocket) return `TCP :${p.tcpSocket.port ?? ''}`;
+  if (p.grpc) return `gRPC :${p.grpc.port ?? ''}${p.grpc.service ? ` ${p.grpc.service}` : ''}`;
+  if (p.exec) return `exec ${(p.exec.command ?? []).join(' ')}`;
+  return '';
+}
+
+function probeTiming(p: Probe): string {
+  return `delay ${p.initialDelaySeconds ?? 0}s · period ${p.periodSeconds ?? 10}s · timeout ${p.timeoutSeconds ?? 1}s · fail ${p.failureThreshold ?? 3}×`;
+}
+
+function ProbesSection({ spec, statusByName, terminal }: { spec: PodSpec | undefined; statusByName: Map<string, ContainerStatus>; terminal: boolean }) {
+  const rows: Array<{ container: string; kind: string; target: string; timing: string; state?: string }> = [];
+  for (const c of [...(spec?.containers ?? []), ...(spec?.initContainers ?? [])]) {
+    const st = statusByName.get(c.name);
+    for (const [label, key] of PROBE_KINDS) {
+      const probe = c[key];
+      if (!probe) continue;
+      // Live probe outcome where the API surfaces one: readiness → `ready`,
+      // startup → `started`. Liveness failures only show up as restarts.
+      // Finished pods are expectedly NotReady, so no state is shown there.
+      const state = terminal
+        ? undefined
+        : label === 'readiness' && st
+          ? st.ready
+            ? 'Ready'
+            : 'NotReady'
+          : label === 'startup' && st
+            ? st.started
+              ? 'Started'
+              : 'Pending'
+            : undefined;
+      rows.push({ container: c.name, kind: label, target: probeTarget(probe), timing: probeTiming(probe), state });
+    }
+  }
+  if (!rows.length) return null;
+  return (
+    <Section title="Probes" count={rows.length}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Container</TableCell>
+            <TableCell>Probe</TableCell>
+            <TableCell>Target</TableCell>
+            <TableCell>Timing</TableCell>
+            <TableCell>State</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((r) => (
+            <TableRow key={`${r.container}:${r.kind}`}>
+              <TableCell sx={{ wordBreak: 'break-all' }}>{r.container}</TableCell>
+              <TableCell>{r.kind}</TableCell>
+              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all' }}>{r.target}</TableCell>
+              <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                <Typography variant="caption" color="text.secondary">
+                  {r.timing}
+                </Typography>
+              </TableCell>
+              <TableCell>{r.state ? <StatusChip status={r.state} /> : ''}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Section>
+  );
+}
 
 function envSourceLabel(env: PodEnvVar): { text: string; refKind?: 'ConfigMap' | 'Secret'; refName?: string } {
   const s = env.source;
@@ -334,6 +425,10 @@ function volumeInfo(v: VolumeSpec): { type: string; detail?: string; refKind?: '
     return { type: 'secret', detail: name, refKind: 'Secret', refName: name };
   }
   if (v.hostPath) return { type: 'hostPath', detail: (v.hostPath as { path?: string }).path };
+  if (v.image) {
+    const img = v.image as { reference?: string; pullPolicy?: string };
+    return { type: 'image', detail: `${img.reference ?? ''}${img.pullPolicy ? ` (${img.pullPolicy})` : ''}` };
+  }
   const type = Object.keys(v).find((k) => k !== 'name') ?? 'unknown';
   return { type };
 }

--- a/client/src/components/detail/RolloutHistory.tsx
+++ b/client/src/components/detail/RolloutHistory.tsx
@@ -16,7 +16,7 @@ import { showToast } from '../../state/toast.js';
 import { AgeCell } from '../AgeCell.js';
 import { ConfirmDialog } from '../ConfirmDialog.js';
 
-export function RolloutHistory({ ctx, kind, obj }: { ctx: string; kind: 'Deployment' | 'StatefulSet'; obj: KubeObject }) {
+export function RolloutHistory({ ctx, kind, obj }: { ctx: string; kind: 'Deployment' | 'StatefulSet' | 'DaemonSet'; obj: KubeObject }) {
   const name = obj.metadata.name;
   const namespace = obj.metadata.namespace ?? '';
   const { data: history, isLoading, error } = useRolloutHistory({ ctx, kind, namespace, name });

--- a/client/src/components/detail/SecretDetail.tsx
+++ b/client/src/components/detail/SecretDetail.tsx
@@ -56,13 +56,14 @@ export function SecretDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
         )}
         {isTls &&
           (tls.data?.certificates ?? []).map((cert, i) => (
-            <Card key={cert.serialNumber || i} variant="outlined">
+            <Card key={`${cert.source ?? ''}:${cert.serialNumber || i}`} variant="outlined">
               <CardContent sx={{ '&:last-child': { pb: 2 } }}>
                 <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: 'wrap', alignItems: 'center' }}>
                   <Typography variant="subtitle2">{commonName(cert.subject)}</Typography>
                   {expiryChip(cert)}
                   {cert.isCA && <Chip label="CA" variant="outlined" />}
                   {cert.selfSigned && <Chip label="self-signed" variant="outlined" />}
+                  {cert.source && cert.source !== 'tls.crt' && <Chip label={cert.source} variant="outlined" color="secondary" />}
                 </Stack>
                 <Typography variant="body2" color="text.secondary">
                   Issuer: {commonName(cert.issuer)}
@@ -70,6 +71,11 @@ export function SecretDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                 <Typography variant="body2" color="text.secondary">
                   Valid: {new Date(cert.notBefore).toLocaleDateString()} → {new Date(cert.notAfter).toLocaleDateString()}
                 </Typography>
+                {cert.publicKeyAlgorithm && (
+                  <Typography variant="body2" color="text.secondary">
+                    Algorithm: {cert.publicKeyAlgorithm}
+                  </Typography>
+                )}
                 <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-all' }}>
                   Serial: {cert.serialNumber}
                 </Typography>

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -18,6 +18,8 @@ declare global {
       onCloseTab(callback: () => void): () => void;
       /** Subscribe to the tab-cycling chords (Ctrl+Tab & friends); backwards=true cycles left. */
       onCycleTab(callback: (backwards: boolean) => void): () => void;
+      /** Subscribe to kubus:// deep links; the payload is an in-app route. Returns unsubscribe. */
+      onOpenRoute(callback: (route: string) => void): () => void;
       /** Close the main window (fallback when no dock tab is open). */
       closeWindow(): void;
     };

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -20,6 +20,8 @@ declare global {
       onCycleTab(callback: (backwards: boolean) => void): () => void;
       /** Subscribe to kubus:// deep links; the payload is an in-app route. Returns unsubscribe. */
       onOpenRoute(callback: (route: string) => void): () => void;
+      /** Fetch a deep link delivered before the UI was ready (cold start); marks the renderer ready for pushes. */
+      getPendingRoute(): Promise<string | null>;
       /** Close the main window (fallback when no dock tab is open). */
       closeWindow(): void;
     };

--- a/client/src/image-ref.ts
+++ b/client/src/image-ref.ts
@@ -1,0 +1,24 @@
+export interface ImageRef {
+  /** Registry + repository, e.g. `ghcr.io/acme/app`. */
+  repo: string;
+  tag?: string;
+  digest?: string;
+}
+
+/**
+ * Split an image reference into repo, tag and digest. A `:` only counts as the
+ * tag separator when it appears after the last `/`, so registry ports
+ * (`localhost:5000/app`) stay part of the repo.
+ */
+export function splitImageRef(image: string): ImageRef {
+  const at = image.indexOf('@');
+  const digest = at >= 0 ? image.slice(at + 1) : undefined;
+  let repo = at >= 0 ? image.slice(0, at) : image;
+  let tag: string | undefined;
+  const colon = repo.lastIndexOf(':');
+  if (colon > repo.lastIndexOf('/')) {
+    tag = repo.slice(colon + 1);
+    repo = repo.slice(0, colon);
+  }
+  return { repo, tag, digest };
+}

--- a/client/src/kube-display.ts
+++ b/client/src/kube-display.ts
@@ -304,6 +304,8 @@ export interface ContainerResources {
   memRequestBytes?: number;
   cpuLimitMilli?: number;
   memLimitBytes?: number;
+  ephemeralRequestBytes?: number;
+  ephemeralLimitBytes?: number;
 }
 
 export function containerResources(c: ContainerWithResources): ContainerResources {
@@ -312,6 +314,8 @@ export function containerResources(c: ContainerWithResources): ContainerResource
     memRequestBytes: quantityBytes(c.resources?.requests?.memory),
     cpuLimitMilli: quantityMilli(c.resources?.limits?.cpu),
     memLimitBytes: quantityBytes(c.resources?.limits?.memory),
+    ephemeralRequestBytes: quantityBytes(c.resources?.requests?.['ephemeral-storage']),
+    ephemeralLimitBytes: quantityBytes(c.resources?.limits?.['ephemeral-storage']),
   };
 }
 

--- a/client/src/kube-display.ts
+++ b/client/src/kube-display.ts
@@ -117,6 +117,21 @@ function nodeGoodConditionStatus(type: string): string {
   return type === 'Ready' ? 'True' : 'False';
 }
 
+/**
+ * HPA conditions that indicate scaling is blocked or capped (empty when
+ * healthy): AbleToScale/ScalingActive are bad when False, ScalingLimited is
+ * bad when True (replica count pinned at min/max).
+ */
+export function hpaProblems(hpa: KubeObject): string {
+  const conditions = (hpa.status as { conditions?: Array<{ type?: string; status?: string; reason?: string }> } | undefined)?.conditions ?? [];
+  return conditions
+    .flatMap((c) => {
+      const bad = c.type === 'ScalingLimited' ? c.status === 'True' : c.status === 'False';
+      return bad && c.type ? [`${c.type}${c.reason ? ` (${c.reason})` : ''}`] : [];
+    })
+    .join(', ');
+}
+
 export function servicePorts(svc: KubeObject): string {
   const ports = (svc.spec as { ports?: Array<{ port: number; protocol?: string; nodePort?: number }> })?.ports ?? [];
   return ports.map((p) => `${p.port}${p.nodePort ? `:${p.nodePort}` : ''}/${p.protocol ?? 'TCP'}`).join(', ');

--- a/client/src/layout/ClusterSwitcher.tsx
+++ b/client/src/layout/ClusterSwitcher.tsx
@@ -28,27 +28,14 @@ import TuneIcon from '@mui/icons-material/Tune';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import type { ContextHealth, ContextInfo } from '@kubus/shared';
 import { useConnectContext, useContexts, useReconnectContext } from '../api/queries.js';
+import { HEALTH_COLOR, healthTitle } from '../components/ContextHealthDot.js';
 import { fuzzyMatch } from '../fuzzy.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
 import { useClustersStore, type ContextSettings } from '../state/clusters.js';
 
-const HEALTH_COLOR: Record<ContextHealth, 'success' | 'error' | 'warning' | 'disabled'> = {
-  connected: 'success',
-  error: 'error',
-  connecting: 'warning',
-  unknown: 'disabled',
-};
-
 const GRID_COLS = 3;
 
 const PRESET_ICONS = ['🔴', '🟠', '🟡', '🟢', '🔵', '🟣', '🏭', '🧪', '🛠️', '🚀', '🏠', '🌍', '☁️', '⚡', '📦', '🔒', '🐳', '🎯'];
-
-function healthTitle(c: ContextInfo): string {
-  if (c.health === 'connected') return c.kubernetesVersion ? `Connected · ${c.kubernetesVersion}` : 'Connected';
-  if (c.health === 'connecting') return 'Checking connectivity';
-  if (c.health === 'error') return c.healthMessage ?? 'Connection failed';
-  return 'Not checked yet';
-}
 
 function selectedHealth(contexts: ContextInfo[] | undefined, selected: string[]): ContextHealth | undefined {
   if (!selected.length) return undefined;

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -17,8 +17,8 @@ import StarBorderIcon from '@mui/icons-material/StarBorder';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import KeyboardCommandKeyIcon from '@mui/icons-material/KeyboardCommandKey';
 import type { FavoriteItem, ResourceRef, SearchResult, SearchResultKind } from '@kubus/shared';
-import { groupToPath } from '@kubus/shared';
 import { useNavigate } from 'react-router';
+import { detailPathForRef } from '../resource-links.js';
 import { useGlobalSearch } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
@@ -29,15 +29,6 @@ import { toggleNavRail } from '../shortcuts.js';
 import { showToast } from '../state/toast.js';
 import { actionsForRef, usePaletteRunner, type PaletteAction } from '../actions/resource-actions.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
-
-function pathForRef(ref: ResourceRef): string {
-  return `/r/${groupToPath(ref.group)}/${ref.version}/${ref.plural}`;
-}
-
-function detailPathForRef(ref: ResourceRef): string {
-  const sel = `${ref.ctx}|${ref.namespace ?? ''}|${ref.name}`;
-  return `${pathForRef(ref)}?sel=${encodeURIComponent(sel)}`;
-}
 
 function favoriteFromResult(result: SearchResult): FavoriteItem {
   return {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,7 +4,7 @@ import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react
 import { BrowserRouter } from 'react-router';
 import { ApiError, initAuthToken } from './api/http.js';
 import { isMutationErrorHandledLocally } from './api/mutation-errors.js';
-import { showToast } from './state/toast.js';
+import { showErrorToast } from './state/toast.js';
 import App from './App.js';
 
 initAuthToken();
@@ -18,7 +18,7 @@ const queryClient = new QueryClient({
       if (mutation.options.onError) return;
       if (isMutationErrorHandledLocally(mutation.meta)) return;
       if (error instanceof ApiError && (error.status === 0 || error.status === 401)) return;
-      showToast('error', error instanceof Error ? error.message : String(error));
+      showErrorToast(error);
     },
   }),
   defaultOptions: {

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -211,6 +211,7 @@ export function EventsPage() {
   }
 
   const errors = Object.entries(list.status).filter(([, s]) => s.state === 'error');
+  const reconnecting = Object.entries(list.status).filter(([, s]) => s.state === 'reconnecting');
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
@@ -221,6 +222,11 @@ export function EventsPage() {
         {errors.map(([ctx, s]) => (
           <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>
             {ctx}: {s.message ?? 'watch error'}
+          </Alert>
+        ))}
+        {reconnecting.map(([ctx]) => (
+          <Alert key={ctx} severity="warning" sx={{ mt: 0.5 }}>
+            {ctx}: connection lost — reconnecting, events may be stale.
           </Alert>
         ))}
       </Box>

--- a/client/src/pages/MetricsPage.tsx
+++ b/client/src/pages/MetricsPage.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
@@ -16,6 +19,7 @@ import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import { alpha, useTheme } from '@mui/material/styles';
 import QueryStatsOutlinedIcon from '@mui/icons-material/QueryStatsOutlined';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import MemoryOutlinedIcon from '@mui/icons-material/MemoryOutlined';
 import SdStorageOutlinedIcon from '@mui/icons-material/SdStorageOutlined';
 import DnsOutlinedIcon from '@mui/icons-material/DnsOutlined';
@@ -23,7 +27,7 @@ import ViewInArOutlinedIcon from '@mui/icons-material/ViewInArOutlined';
 import { BarChart } from '@mui/x-charts/BarChart';
 import { LineChart } from '@mui/x-charts/LineChart';
 import type { ClusterMetricsSummary, MetricsSeriesEntry } from '@kubus/shared';
-import { useMetricsServerStatus, useMetricsSummary } from '../api/queries.js';
+import { invalidateMetricsServer, useMetricsServerStatus, useMetricsSummary } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { NoClustersState } from '../components/NoClustersState.js';
@@ -60,6 +64,7 @@ function ClusterMetricsSection({ ctx }: { ctx: string }) {
   const { data: status, error: statusError } = useMetricsServerStatus(ctx, { refetchMs: 5_000 });
   const { data: summary, error: summaryError } = useMetricsSummary(ctx);
   const error = statusError ?? summaryError;
+  const qc = useQueryClient();
 
   const installed = status?.installed ?? false;
   const available = summary?.available ?? false;
@@ -76,6 +81,12 @@ function ClusterMetricsSection({ ctx }: { ctx: string }) {
             label={available ? 'collecting' : status?.ready ? 'waiting for samples' : 'starting'}
           />
         )}
+        {/* One-shot refetch, independent of the cadence preset — works while polling is paused. */}
+        <Tooltip title="Refresh metrics now">
+          <IconButton size="small" aria-label={`Refresh metrics for ${ctx}`} onClick={() => invalidateMetricsServer(qc)}>
+            <RefreshIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
         <Box sx={{ flex: 1 }} />
         {installed && <UninstallMetricsServerButton ctx={ctx} status={status} />}
       </ClusterSectionHeader>

--- a/client/src/pages/MetricsPage.tsx
+++ b/client/src/pages/MetricsPage.tsx
@@ -83,7 +83,7 @@ function ClusterMetricsSection({ ctx }: { ctx: string }) {
         )}
         {/* One-shot refetch, independent of the cadence preset — works while polling is paused. */}
         <Tooltip title="Refresh metrics now">
-          <IconButton size="small" aria-label={`Refresh metrics for ${ctx}`} onClick={() => invalidateMetricsServer(qc)}>
+          <IconButton size="small" aria-label={`Refresh metrics for ${ctx}`} onClick={() => invalidateMetricsServer(qc, ctx)}>
             <RefreshIcon fontSize="small" />
           </IconButton>
         </Tooltip>

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -523,6 +523,7 @@ export function ResourceListPage() {
   const unavailableContexts = new Set(unavailable.map(([ctx]) => ctx));
   const discoveryOnlyMissing = discoveryMissing.filter((ctx) => !unavailableContexts.has(ctx));
   const errors = Object.entries(list.status).filter(([, s]) => s.state === 'error');
+  const reconnecting = Object.entries(list.status).filter(([, s]) => s.state === 'reconnecting');
   const activeRowId = useMemo(() => {
     if (!sel) return undefined;
     return list.rows.find(
@@ -596,6 +597,11 @@ export function ResourceListPage() {
         {errors.map(([ctx, s]) => (
           <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>
             {ctx}: {s.message ?? 'watch error'}
+          </Alert>
+        ))}
+        {reconnecting.map(([ctx]) => (
+          <Alert key={ctx} severity="warning" sx={{ mt: 0.5 }}>
+            {ctx}: connection lost — reconnecting, the list may be stale.
           </Alert>
         ))}
         {unavailable.map(([ctx, s]) => (

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -40,6 +40,9 @@ import { isTextEntryTarget } from '../text-entry.js';
 import { addLabelTerm } from '../label-selector.js';
 import { podContainerNames } from '../kube-display.js';
 
+// Wide, rarely-needed builtin columns start hidden; the column menu re-enables them.
+const BUILTIN_HIDDEN_FIELDS: Record<string, string[]> = { Node: ['nodeProviderID'] };
+
 /**
  * Renderless bridge between this page's URL params and the shared detail
  * selection. Pages stay mounted (and live) in hidden tab panes, so everything
@@ -504,7 +507,10 @@ export function ResourceListPage() {
     }
     return merged;
   }, [staticColumns, metricColumns, columnIds]);
-  const hiddenFields = useMemo(() => (isCustomKind && printerCols?.length ? crdHiddenFields(printerCols) : []), [isCustomKind, printerCols]);
+  const hiddenFields = useMemo(
+    () => (isCustomKind && printerCols?.length ? crdHiddenFields(printerCols) : (BUILTIN_HIDDEN_FIELDS[behaviorKind ?? ''] ?? [])),
+    [isCustomKind, printerCols, behaviorKind],
+  );
 
   const discoveryMissing = useMemo(() => {
     if (!apiResources) return [];

--- a/client/src/resource-links.ts
+++ b/client/src/resource-links.ts
@@ -1,4 +1,4 @@
-import { groupToPath } from '@kubus/shared';
+import { groupToPath, type FavoriteItem, type ResourceRef } from '@kubus/shared';
 
 /** List-page path for a kind, optionally deep-linking a selection via ?sel=. */
 export function kindListPath(
@@ -9,4 +9,23 @@ export function kindListPath(
   if (opts?.sel) params.set('sel', `${opts.sel.ctx}|${opts.sel.namespace ?? ''}|${opts.sel.name}`);
   const q = params.toString();
   return `/r/${groupToPath(gvr.group)}/${gvr.version}/${gvr.plural}${q ? `?${q}` : ''}`;
+}
+
+/** Detail deep link for a resource ref (its list page + ?sel=). */
+export function detailPathForRef(ref: ResourceRef): string {
+  return kindListPath(ref, { sel: { ctx: ref.ctx, namespace: ref.namespace, name: ref.name } });
+}
+
+/**
+ * Favorite entry for a resource. The id matches the server's search-result
+ * ids so the grid star and the search-palette star toggle the same favorite.
+ */
+export function favoriteForRef(ref: ResourceRef): FavoriteItem {
+  return {
+    id: `resource:${ref.ctx}:${ref.group}/${ref.version}/${ref.plural}:${ref.namespace ?? ''}:${ref.name}`,
+    title: `${ref.kind}/${ref.name}`,
+    subtitle: `${ref.ctx}${ref.namespace ? ` · ${ref.namespace}` : ''}`,
+    path: detailPathForRef(ref),
+    ref,
+  };
 }

--- a/client/src/resource-links.ts
+++ b/client/src/resource-links.ts
@@ -17,6 +17,15 @@ export function detailPathForRef(ref: ResourceRef): string {
 }
 
 /**
+ * Absolute shareable link for an in-app path. The desktop app is served from
+ * a random localhost port, so there the link uses the kubus:// protocol the
+ * OS hands back to the app; browsers get a plain origin URL.
+ */
+export function shareLinkForPath(path: string): string {
+  return window.kubusDesktop ? `kubus://${path.startsWith('/') ? path.slice(1) : path}` : window.location.origin + path;
+}
+
+/**
  * Favorite entry for a resource. The id matches the server's search-result
  * ids so the grid star and the search-palette star toggle the same favorite.
  */

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -350,11 +350,14 @@ export function GlobalShortcuts() {
     const desktop = window.kubusDesktop;
     const offClose = desktop?.onCloseTab?.(closeActiveTab);
     const offCycle = desktop?.onCycleTab?.((backwards) => cycleTab(backwards ? -1 : 1));
+    // kubus:// deep links land here as in-app routes.
+    const offRoute = desktop?.onOpenRoute?.((route) => void navRef.current(route));
     return () => {
       window.removeEventListener('keydown', onCapture, true);
       window.removeEventListener('keydown', onBubble);
       offClose?.();
       offCycle?.();
+      offRoute?.();
     };
   }, []);
 

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -350,8 +350,13 @@ export function GlobalShortcuts() {
     const desktop = window.kubusDesktop;
     const offClose = desktop?.onCloseTab?.(closeActiveTab);
     const offCycle = desktop?.onCycleTab?.((backwards) => cycleTab(backwards ? -1 : 1));
-    // kubus:// deep links land here as in-app routes.
+    // kubus:// deep links land here as in-app routes. With the listener
+    // attached, drain any link the OS delivered before the UI was ready
+    // (cold start) — the pull also tells the main process pushes are safe now.
     const offRoute = desktop?.onOpenRoute?.((route) => void navRef.current(route));
+    void desktop?.getPendingRoute?.().then((route) => {
+      if (route) void navRef.current(route);
+    });
     return () => {
       window.removeEventListener('keydown', onCapture, true);
       window.removeEventListener('keydown', onBubble);

--- a/client/src/state/toast.ts
+++ b/client/src/state/toast.ts
@@ -7,11 +7,13 @@ interface Toast {
   id: number;
   severity: ToastSeverity;
   message: string;
+  /** Full error text behind the toast's Details expander / Copy button. */
+  details?: string;
 }
 
 interface ToastState {
   toast: Toast | null;
-  show: (severity: ToastSeverity, message: string) => void;
+  show: (severity: ToastSeverity, message: string, details?: string) => void;
   dismiss: () => void;
 }
 
@@ -19,11 +21,39 @@ let nextId = 1;
 
 export const useToastStore = create<ToastState>()((set) => ({
   toast: null,
-  show: (severity, message) => set({ toast: { id: nextId++, severity, message } }),
+  show: (severity, message, details) => set({ toast: { id: nextId++, severity, message, details } }),
   dismiss: () => set({ toast: null }),
 }));
 
 /** Show a transient notification from anywhere (components, mutation callbacks). */
-export function showToast(severity: ToastSeverity, message: string): void {
-  useToastStore.getState().show(severity, message);
+export function showToast(severity: ToastSeverity, message: string, details?: string): void {
+  useToastStore.getState().show(severity, message, details);
+}
+
+/**
+ * Structured detail text for an error toast: HTTP status and response body
+ * where present (duck-typed so this stays decoupled from ApiError), else the
+ * stack. Returns undefined when there is nothing beyond the message.
+ */
+export function errorDetails(err: unknown): string | undefined {
+  if (!(err instanceof Error)) return undefined;
+  const parts: string[] = [];
+  const status = (err as { status?: unknown }).status;
+  if (typeof status === 'number' && status > 0) parts.push(`HTTP ${status}`);
+  const body = (err as { body?: unknown }).body;
+  if (body !== undefined) {
+    try {
+      parts.push(JSON.stringify(body, null, 2));
+    } catch {
+      // unserializable body — skip
+    }
+  }
+  if (!parts.length && err.stack) parts.push(err.stack);
+  const text = parts.join('\n');
+  return text && text !== err.message ? text : undefined;
+}
+
+/** Error toast for a caught value, attaching structured details when available. */
+export function showErrorToast(err: unknown): void {
+  showToast('error', err instanceof Error ? err.message : String(err), errorDetails(err));
 }

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -17,6 +17,9 @@ extraResources:
     to: icon.png
 icon: build/icon.png
 artifactName: kubus-${version}-${os}-${arch}.${ext}
+protocols:
+  - name: Kubus
+    schemes: [kubus]
 npmRebuild: false
 afterPack: scripts/after-pack.cjs
 win:

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -38,6 +38,49 @@ let server: RunningServer | undefined;
 let closing: Promise<void> | undefined;
 let updateCheck: Promise<UpdateCheckResult> | undefined;
 
+// ---- kubus:// deep links -------------------------------------------------
+// The client is served from a random localhost port, so shareable links use
+// the kubus:// scheme and carry only the in-app route; the renderer's router
+// resolves it against whatever origin this instance runs on.
+
+const PROTOCOL = 'kubus';
+let pendingRoute: string | undefined;
+
+/** kubus://r/apps/v1/deployments?sel=… → "/r/apps/v1/deployments?sel=…". */
+function routeFromDeepLink(raw: string): string | undefined {
+  if (!raw.startsWith(`${PROTOCOL}://`)) return undefined;
+  const rest = raw.slice(`${PROTOCOL}://`.length);
+  const route = rest.startsWith('/') ? rest : `/${rest}`;
+  // Reject protocol-relative smuggling — only same-app routes may pass.
+  return route.startsWith('//') ? undefined : route;
+}
+
+function openRoute(route: string): void {
+  const win = mainWindow;
+  if (win && !win.webContents.isLoading()) {
+    win.webContents.send('kubus:open-route', route);
+    if (win.isMinimized()) win.restore();
+    win.focus();
+  } else {
+    // Cold start: delivered once the renderer finishes loading.
+    pendingRoute = route;
+  }
+}
+
+if (app.isPackaged) {
+  app.setAsDefaultProtocolClient(PROTOCOL);
+} else if (process.argv[1]) {
+  // Dev: register with explicit args so the OS can relaunch this checkout.
+  app.setAsDefaultProtocolClient(PROTOCOL, process.execPath, [path.resolve(process.argv[1])]);
+}
+
+// macOS delivers deep links via open-url (cold starts queue until the window loads).
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  const route = routeFromDeepLink(url);
+  if (route) openRoute(route);
+});
+
 interface WindowState {
   width: number;
   height: number;
@@ -307,6 +350,12 @@ function createWindow(url: string): void {
       mainWindow?.webContents.send('kubus:cycle-tab', input.code === 'BracketLeft');
     }
   });
+  mainWindow.webContents.on('did-finish-load', () => {
+    if (pendingRoute) {
+      mainWindow?.webContents.send('kubus:open-route', pendingRoute);
+      pendingRoute = undefined;
+    }
+  });
   void mainWindow.loadURL(url);
 }
 
@@ -378,14 +427,22 @@ ipcMain.handle('kubus:check-for-update', async (event, options?: { force?: unkno
 if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
-  app.on('second-instance', () => {
+  app.on('second-instance', (_event, argv) => {
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();
     }
+    // Windows/Linux deliver a deep link to the running instance as an argv
+    // entry of the second process.
+    const link = argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
+    const route = link ? routeFromDeepLink(link) : undefined;
+    if (route) openRoute(route);
   });
 
   void app.whenReady().then(async () => {
+    // Windows/Linux cold start via a deep link: the URL arrives in our own argv.
+    const link = process.argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
+    if (link) pendingRoute = routeFromDeepLink(link);
     // The esbuild bundle breaks the server's import.meta.url asset lookup, so
     // point it at the packaged (or repo) helm engine explicitly.
     process.env.KUBUS_HELM_ENGINE ??= app.isPackaged

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -45,6 +45,10 @@ let updateCheck: Promise<UpdateCheckResult> | undefined;
 
 const PROTOCOL = 'kubus';
 let pendingRoute: string | undefined;
+// True once the renderer has called kubus:get-pending-route, i.e. its route
+// listener is attached. Pushing before that (did-finish-load fires before the
+// SPA mounts) would drop the link on cold start.
+let rendererRouteReady = false;
 
 /** kubus://r/apps/v1/deployments?sel=… → "/r/apps/v1/deployments?sel=…". */
 function routeFromDeepLink(raw: string): string | undefined {
@@ -57,13 +61,15 @@ function routeFromDeepLink(raw: string): string | undefined {
 
 function openRoute(route: string): void {
   const win = mainWindow;
-  if (win && !win.webContents.isLoading()) {
+  if (win && rendererRouteReady) {
     win.webContents.send('kubus:open-route', route);
+  } else {
+    // Cold start or mid-boot: held until the renderer pulls it.
+    pendingRoute = route;
+  }
+  if (win) {
     if (win.isMinimized()) win.restore();
     win.focus();
-  } else {
-    // Cold start: delivered once the renderer finishes loading.
-    pendingRoute = route;
   }
 }
 
@@ -321,6 +327,11 @@ function createWindow(url: string): void {
   });
   mainWindow.on('closed', () => {
     mainWindow = undefined;
+    rendererRouteReady = false;
+  });
+  // A reload restarts the SPA; hold routes until it re-registers.
+  mainWindow.webContents.on('did-start-loading', () => {
+    rendererRouteReady = false;
   });
   mainWindow.webContents.setWindowOpenHandler(({ url: external }) => {
     void shell.openExternal(external);
@@ -348,12 +359,6 @@ function createWindow(url: string): void {
     if (isMac && input.meta && input.shift && !input.control && !input.alt && (input.code === 'BracketLeft' || input.code === 'BracketRight')) {
       event.preventDefault();
       mainWindow?.webContents.send('kubus:cycle-tab', input.code === 'BracketLeft');
-    }
-  });
-  mainWindow.webContents.on('did-finish-load', () => {
-    if (pendingRoute) {
-      mainWindow?.webContents.send('kubus:open-route', pendingRoute);
-      pendingRoute = undefined;
     }
   });
   void mainWindow.loadURL(url);
@@ -407,6 +412,16 @@ ipcMain.on('kubus:state:remove-item', (event, name: unknown) => {
   } catch {
     event.returnValue = false;
   }
+});
+
+// The renderer pulls the pending deep link once its route listener is
+// attached; from then on links are pushed over kubus:open-route.
+ipcMain.handle('kubus:get-pending-route', (event): string | null => {
+  if (!isMainWindowSender(event)) return null;
+  rendererRouteReady = true;
+  const route = pendingRoute ?? null;
+  pendingRoute = undefined;
+  return route;
 });
 
 ipcMain.handle('kubus:get-app-info', (event): AppInfo | undefined => {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -47,6 +47,11 @@ contextBridge.exposeInMainWorld('kubusDesktop', {
     ipcRenderer.on('kubus:open-route', listener);
     return () => ipcRenderer.removeListener('kubus:open-route', listener);
   },
+  // Call once after onOpenRoute: marks the renderer ready for pushed links and
+  // returns any deep link the OS delivered before the UI was up.
+  getPendingRoute(): Promise<string | null> {
+    return ipcRenderer.invoke('kubus:get-pending-route') as Promise<string | null>;
+  },
   closeWindow(): void {
     ipcRenderer.send('kubus:close-window');
   },

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -38,6 +38,15 @@ contextBridge.exposeInMainWorld('kubusDesktop', {
     ipcRenderer.on('kubus:cycle-tab', listener);
     return () => ipcRenderer.removeListener('kubus:cycle-tab', listener);
   },
+  // Fires when the OS opens a kubus:// deep link; the payload is an in-app
+  // route ("/r/apps/v1/deployments?sel=…"). Returns an unsubscribe.
+  onOpenRoute(callback: (route: string) => void): () => void {
+    const listener = (_event: unknown, route: unknown): void => {
+      if (typeof route === 'string') callback(route);
+    };
+    ipcRenderer.on('kubus:open-route', listener);
+    return () => ipcRenderer.removeListener('kubus:open-route', listener);
+  },
   closeWindow(): void {
     ipcRenderer.send('kubus:close-window');
   },

--- a/server/src/kube/debug.ts
+++ b/server/src/kube/debug.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import type { DebugPodRequest, DebugPodResponse, StopDebugRequest } from '@kubus/shared';
+import type { DebugPodRequest, DebugPodResponse, DebugProfile, StopDebugRequest } from '@kubus/shared';
 import type { ClusterHandle } from './cluster-manager.js';
 import { resourcePath } from './raw-client.js';
 import { runCommand } from './file-copy.js';
@@ -18,6 +18,18 @@ const STOP_FILE = '/tmp/.kubus-stop';
 const DEBUG_IDLE_COMMAND = ['sh', '-c', `trap "exit 0" TERM INT; i=0; while [ ! -e ${STOP_FILE} ] && [ "$i" -lt 3600 ]; do sleep 1; i=$((i+1)); done`];
 
 /**
+ * Security context per kubectl-debug profile. `general` stays unset so the
+ * container inherits namespace/PodSecurity defaults; `restricted` matches the
+ * PodSecurity restricted policy so debugging works in enforced namespaces.
+ */
+const PROFILE_SECURITY_CONTEXT: Record<DebugProfile, object | undefined> = {
+  general: undefined,
+  restricted: { runAsNonRoot: true, allowPrivilegeEscalation: false, capabilities: { drop: ['ALL'] }, seccompProfile: { type: 'RuntimeDefault' } },
+  netadmin: { capabilities: { add: ['NET_ADMIN', 'NET_RAW'] } },
+  sysadmin: { privileged: true },
+};
+
+/**
  * kubectl-debug equivalent: append an ephemeral container to a running pod
  * (pods/ephemeralcontainers subresource) and wait until it runs, so the
  * caller can exec into it. Ephemeral containers are append-only and
@@ -27,6 +39,8 @@ export async function addDebugContainer(handle: ClusterHandle, req: DebugPodRequ
   const containerName = `debug-${nanoid(6).toLowerCase().replace(/[^a-z0-9]/g, 'x')}`;
   const image = req.image?.trim() || DEFAULT_DEBUG_IMAGE;
   if (/\s/.test(image)) throw new HttpProblem(422, 'image must be a reference without whitespace');
+  const profile = req.profile ?? 'general';
+  if (!(profile in PROFILE_SECURITY_CONTEXT)) throw new HttpProblem(422, `unknown debug profile ${String(profile)}`);
   const patch = {
     spec: {
       ephemeralContainers: [
@@ -38,6 +52,7 @@ export async function addDebugContainer(handle: ClusterHandle, req: DebugPodRequ
           tty: true,
           targetContainerName: req.target || undefined,
           terminationMessagePolicy: 'File',
+          securityContext: PROFILE_SECURITY_CONTEXT[profile],
         },
       ],
     },

--- a/server/src/kube/rollout.ts
+++ b/server/src/kube/rollout.ts
@@ -3,7 +3,9 @@ import type { ClusterHandle } from './cluster-manager.js';
 import { resourcePath } from './raw-client.js';
 import { HttpProblem } from '../util/errors.js';
 
-type RolloutKind = 'Deployment' | 'StatefulSet';
+type RolloutKind = 'Deployment' | 'StatefulSet' | 'DaemonSet';
+
+const ROLLOUT_PLURALS: Record<RolloutKind, string> = { Deployment: 'deployments', StatefulSet: 'statefulsets', DaemonSet: 'daemonsets' };
 
 interface WorkloadSpec {
   selector?: { matchLabels?: Record<string, string> };
@@ -12,8 +14,7 @@ interface WorkloadSpec {
 }
 
 async function getWorkload(handle: ClusterHandle, kind: RolloutKind, namespace: string, name: string): Promise<KubeObject> {
-  const plural = kind === 'Deployment' ? 'deployments' : 'statefulsets';
-  return handle.raw.json<KubeObject>(resourcePath('apps', 'v1', plural, { namespace, name }));
+  return handle.raw.json<KubeObject>(resourcePath('apps', 'v1', ROLLOUT_PLURALS[kind], { namespace, name }));
 }
 
 /** List children (ReplicaSets / ControllerRevisions) owned by the workload. */
@@ -54,20 +55,24 @@ export async function getRolloutHistory(handle: ClusterHandle, kind: RolloutKind
       })
       .sort((a, b) => b.revision - a.revision);
   }
-  // StatefulSet: ControllerRevisions carry the revision as a first-class field
-  // and the pod template inside .data (a strategic-merge patch).
-  const updateRevisionName = (workload.status as { updateRevision?: string })?.updateRevision;
+  // StatefulSet / DaemonSet: ControllerRevisions carry the revision as a
+  // first-class field and the pod template inside .data (a strategic-merge
+  // patch). StatefulSets name their live revision in status.updateRevision;
+  // DaemonSets don't, so there the newest revision is the current one.
+  const updateRevisionName = kind === 'StatefulSet' ? (workload.status as { updateRevision?: string })?.updateRevision : undefined;
   const children = await listOwnedChildren(handle, workload, namespace, 'controllerrevisions');
+  const maxRevision = children.reduce((max, cr) => Math.max(max, Number((cr as { revision?: number }).revision ?? 0)), 0);
   return children
     .map((cr): RolloutRevision => {
       const data = (cr as { data?: { spec?: { template?: WorkloadSpec['template'] } } }).data;
+      const revision = Number((cr as { revision?: number }).revision ?? 0);
       return {
-        revision: Number((cr as { revision?: number }).revision ?? 0),
+        revision,
         name: cr.metadata.name,
         createdAt: cr.metadata.creationTimestamp,
         images: templateImages(data?.spec?.template as WorkloadSpec['template']),
         changeCause: cr.metadata.annotations?.['kubernetes.io/change-cause'],
-        current: cr.metadata.name === updateRevisionName,
+        current: updateRevisionName ? cr.metadata.name === updateRevisionName : revision === maxRevision,
         replicas: undefined,
       };
     })
@@ -104,10 +109,10 @@ export async function rolloutUndo(handle: ClusterHandle, kind: RolloutKind, name
     return;
   }
 
-  // StatefulSet: the ControllerRevision's .data is itself the patch to apply.
+  // StatefulSet / DaemonSet: the ControllerRevision's .data is itself the patch to apply.
   const cr = await handle.raw.json<KubeObject & { data?: unknown }>(resourcePath('apps', 'v1', 'controllerrevisions', { namespace, name: target.name }));
   if (!cr.data) throw new HttpProblem(422, 'controller revision has no data');
-  await handle.raw.json(resourcePath('apps', 'v1', 'statefulsets', { namespace, name }), {
+  await handle.raw.json(resourcePath('apps', 'v1', ROLLOUT_PLURALS[kind], { namespace, name }), {
     method: 'PATCH',
     headers: { 'content-type': 'application/strategic-merge-patch+json' },
     body: JSON.stringify(cr.data),

--- a/server/src/routes/detail.ts
+++ b/server/src/routes/detail.ts
@@ -11,6 +11,23 @@ import { HttpProblem, sendError } from '../util/errors.js';
 
 const CERT_BLOCK_RE = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
 
+/** Secret data keys that may hold public certificate chains. */
+const TLS_CERT_KEYS = ['tls.crt', 'ca.crt', 'ca.tls'];
+
+function publicKeyAlgorithm(cert: X509Certificate): string | undefined {
+  try {
+    const key = cert.publicKey;
+    const details = key.asymmetricKeyDetails;
+    if (key.asymmetricKeyType === 'rsa' || key.asymmetricKeyType === 'rsa-pss') {
+      return details?.modulusLength ? `RSA ${details.modulusLength}` : 'RSA';
+    }
+    if (key.asymmetricKeyType === 'ec') return details?.namedCurve ? `ECDSA ${details.namedCurve}` : 'ECDSA';
+    return key.asymmetricKeyType?.toUpperCase();
+  } catch {
+    return undefined;
+  }
+}
+
 export function registerDetailRoutes(app: FastifyInstance, ctx: AppContext): void {
   app.get<{ Params: { ctx: string }; Querystring: { namespace?: string; name?: string; reveal?: string } }>(
     '/api/contexts/:ctx/detail/pod-env',
@@ -79,24 +96,31 @@ export function registerDetailRoutes(app: FastifyInstance, ctx: AppContext): voi
         const handle = ctx.clusters.get(req.params.ctx);
         const secret = await handle.raw.json<KubeObject>(resourcePath('', 'v1', 'secrets', { namespace, name }));
         if (secret.type !== 'kubernetes.io/tls') throw new HttpProblem(422, 'secret is not of type kubernetes.io/tls');
-        const crt = (secret.data as Record<string, string> | undefined)?.['tls.crt'];
-        if (!crt) throw new HttpProblem(422, 'secret has no tls.crt');
-        // Only the public certificate chain is parsed; tls.key is never read.
-        const pem = Buffer.from(crt, 'base64').toString('utf8');
-        const blocks = pem.match(CERT_BLOCK_RE) ?? [];
-        const certificates: TlsCertInfo[] = blocks.map((block) => {
-          const cert = new X509Certificate(block);
-          return {
-            subject: cert.subject,
-            issuer: cert.issuer,
-            serialNumber: cert.serialNumber,
-            notBefore: new Date(cert.validFrom).toISOString(),
-            notAfter: new Date(cert.validTo).toISOString(),
-            sans: cert.subjectAltName ? cert.subjectAltName.split(',').map((s) => s.trim()) : [],
-            isCA: cert.ca,
-            selfSigned: cert.subject === cert.issuer,
-          };
-        });
+        const data = secret.data as Record<string, string> | undefined;
+        if (!data?.['tls.crt']) throw new HttpProblem(422, 'secret has no tls.crt');
+        // Only public certificate chains are parsed; tls.key is never read.
+        // Additional CA entries (ca.crt, or ca.tls as some tools write) ride along.
+        const certificates: TlsCertInfo[] = [];
+        for (const key of TLS_CERT_KEYS) {
+          const encoded = data[key];
+          if (!encoded) continue;
+          const pem = Buffer.from(encoded, 'base64').toString('utf8');
+          for (const block of pem.match(CERT_BLOCK_RE) ?? []) {
+            const cert = new X509Certificate(block);
+            certificates.push({
+              subject: cert.subject,
+              issuer: cert.issuer,
+              serialNumber: cert.serialNumber,
+              notBefore: new Date(cert.validFrom).toISOString(),
+              notAfter: new Date(cert.validTo).toISOString(),
+              sans: cert.subjectAltName ? cert.subjectAltName.split(',').map((s) => s.trim()) : [],
+              isCA: cert.ca,
+              selfSigned: cert.subject === cert.issuer,
+              publicKeyAlgorithm: publicKeyAlgorithm(cert),
+              source: key,
+            });
+          }
+        }
         const response: SecretTlsResponse = { certificates };
         return response;
       } catch (err) {

--- a/server/src/routes/detail.ts
+++ b/server/src/routes/detail.ts
@@ -60,7 +60,7 @@ export function registerDetailRoutes(app: FastifyInstance, ctx: AppContext): voi
       try {
         const { kind, namespace, name } = req.query;
         if (!kind || !namespace || !name) throw new HttpProblem(422, 'kind, namespace and name are required');
-        if (kind !== 'Deployment' && kind !== 'StatefulSet') throw new HttpProblem(422, 'kind must be Deployment or StatefulSet');
+        if (kind !== 'Deployment' && kind !== 'StatefulSet' && kind !== 'DaemonSet') throw new HttpProblem(422, 'kind must be Deployment, StatefulSet or DaemonSet');
         const handle = ctx.clusters.get(req.params.ctx);
         return await getRolloutHistory(handle, kind, namespace, name);
       } catch (err) {

--- a/server/src/routes/detail.ts
+++ b/server/src/routes/detail.ts
@@ -106,7 +106,14 @@ export function registerDetailRoutes(app: FastifyInstance, ctx: AppContext): voi
           if (!encoded) continue;
           const pem = Buffer.from(encoded, 'base64').toString('utf8');
           for (const block of pem.match(CERT_BLOCK_RE) ?? []) {
-            const cert = new X509Certificate(block);
+            let cert: X509Certificate;
+            try {
+              cert = new X509Certificate(block);
+            } catch {
+              // A malformed block (often a hand-edited ca.crt) must not hide
+              // the certificates that did parse.
+              continue;
+            }
             certificates.push({
               subject: cert.subject,
               issuer: cert.issuer,

--- a/server/src/routes/resources.ts
+++ b/server/src/routes/resources.ts
@@ -142,13 +142,31 @@ export function registerResourceRoutes(app: FastifyInstance, ctx: AppContext): v
       try {
         const handle = ctx.clusters.get(req.params.ctx);
         const manifest = parseManifest(req.body);
+        // replace() derives its target from the manifest, so a body pasted or
+        // dropped for a different resource would silently overwrite that other
+        // resource. Require the manifest to identify the resource in the URL.
+        const group = groupFromPath(req.params.group);
+        const kind = await kindForManifest(await handle.discovery.getResources(), manifest);
+        if (kind.group !== group || kind.plural !== req.params.plural) {
+          throw new HttpProblem(422, `manifest is a ${manifest.apiVersion}/${manifest.kind}, not the ${req.params.plural}${group ? `.${group}` : ''} this editor is for`, 'ResourceMismatch');
+        }
+        if (manifest.metadata!.name !== req.params.name) {
+          throw new HttpProblem(422, `manifest is named "${manifest.metadata!.name}", not "${req.params.name}"`, 'ResourceMismatch');
+        }
+        const namespace = req.query.namespace || undefined;
+        if (kind.namespaced) {
+          if (manifest.metadata!.namespace && namespace && manifest.metadata!.namespace !== namespace) {
+            throw new HttpProblem(422, `manifest targets namespace "${manifest.metadata!.namespace}", not "${namespace}"`, 'ResourceMismatch');
+          }
+          // Without a namespace, replace() would route to "default".
+          manifest.metadata!.namespace ??= namespace;
+        }
         try {
           return await handle.objects.replace(manifest);
         } catch (err) {
           // On conflict, hand back the server's current object so the
           // client can offer a re-read/merge flow.
           if (err instanceof ApiException && err.code === 409) {
-            const group = groupFromPath(req.params.group);
             const path = resourcePath(group, req.params.version, req.params.plural, {
               namespace: req.query.namespace || undefined,
               name: req.params.name,

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -462,6 +462,10 @@ export interface TlsCertInfo {
   sans: string[];
   isCA: boolean;
   selfSigned: boolean;
+  /** Public key algorithm and strength, e.g. "RSA 2048" / "ECDSA prime256v1". */
+  publicKeyAlgorithm?: string;
+  /** Secret data key the certificate came from (tls.crt, ca.crt or ca.tls). */
+  source?: string;
 }
 
 export interface SecretTlsResponse {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -368,7 +368,7 @@ export interface RerunJobRequest {
 }
 
 export interface RolloutUndoRequest {
-  kind: 'Deployment' | 'StatefulSet';
+  kind: 'Deployment' | 'StatefulSet' | 'DaemonSet';
   namespace: string;
   name: string;
   /** Omitted: roll back to the latest non-current revision. */

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -393,6 +393,9 @@ export interface RolloutRevision {
   replicas?: number;
 }
 
+/** kubectl-debug style security profile applied to the ephemeral container. */
+export type DebugProfile = 'general' | 'restricted' | 'netadmin' | 'sysadmin';
+
 export interface DebugPodRequest {
   namespace: string;
   pod: string;
@@ -400,6 +403,8 @@ export interface DebugPodRequest {
   image?: string;
   /** Container whose process namespace the debug container targets. */
   target?: string;
+  /** Security profile; defaults to general (no extra privileges). */
+  profile?: DebugProfile;
 }
 
 export interface DebugPodResponse {

--- a/shared/src/resource-meta.ts
+++ b/shared/src/resource-meta.ts
@@ -124,10 +124,11 @@ export const KIND_COLUMNS: Record<string, string[]> = {
     'nodeExternalIp',
     'nodeTaints',
     'nodeConditions',
+    'nodeProviderID',
   ],
   Namespace: ['name', 'cluster', 'nsStatus', 'age'],
   Event: ['eventType', 'eventReason', 'eventObject', 'eventMessage', 'namespace', 'cluster', 'eventCount', 'eventLastSeen'],
-  HorizontalPodAutoscaler: ['name', 'namespace', 'cluster', 'hpaTarget', 'hpaMinMax', 'hpaReplicas', 'age'],
+  HorizontalPodAutoscaler: ['name', 'namespace', 'cluster', 'hpaTarget', 'hpaMinMax', 'hpaReplicas', 'hpaConditions', 'age'],
   ServiceAccount: ['name', 'namespace', 'cluster', 'age'],
 };
 


### PR DESCRIPTION
## Summary

- Streamline resource workflows with container image editing, favorites, DaemonSet rollout history and rollback, and YAML file drops.
- Expand diagnostics with Pod probes, image volumes, ephemeral storage, Node Provider IDs, HPA conditions, and TLS key metadata.
- Improve day-to-day usability with configurable Pod debug profiles, de-emphasized completed Pods, terminal clipboard actions, copyable error details, manual metrics refresh, and per-context connection state.
- Add shareable resource links and desktop protocol handling.

## Why

These changes reduce context switching during common Kubernetes operations and make resource state, connectivity, and failures easier to understand directly in Kubus.

## User impact

Users can perform more routine actions from resource views, inspect additional workload and certificate details, recognize cluster connectivity issues sooner, and share direct links to resources.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm lint:perf` (advisory warnings only)
- `pnpm build`
- `pnpm --filter @kubus/server test` (13/13 passing)
- `git diff --check main...HEAD`
- Focused Playwright coverage for favorites, resource links, image editing, YAML drops, and DaemonSet rollout history
