### PR TITLE
Performance pass: smoother tables, less background work, desktop freeze fix

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { keepPreviousData, queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, queryOptions, useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePaneActive } from '../layout/pane-context.js';
 import type {
   ClusterMetricsSummary,
@@ -114,10 +114,11 @@ export function useContextsInvalidation() {
 }
 
 /**
- * The shared context list. Poll from long-lived single mounts (the cluster
- * picker); per-cluster instances (section headers) pass poll: false and ride
- * on the cache — each polling observer runs its own interval timer, so N
- * headers would otherwise multiply the refetches.
+ * The shared context list. The always-mounted cluster picker is the sole
+ * poller; every other observer passes poll: false and rides on the cache —
+ * each polling observer runs its own interval timer, so N observers would
+ * otherwise multiply the refetches. Kubeconfig changes reach non-polling
+ * observers anyway via the contexts-changed broadcast invalidation.
  */
 export function useContexts({ poll = true }: { poll?: boolean } = {}) {
   const interval = useRefetchInterval(30_000);
@@ -755,23 +756,46 @@ export function useNodeMetrics(ctx: string) {
   });
 }
 
-/** Per-context usage snapshots for the Pod or Node list views. */
+/**
+ * Per-context usage snapshots for the Pod or Node list views. One cache entry
+ * per context (not per context list), so a single-cluster detail view shares
+ * the multi-cluster list page's snapshot instead of starting a second poll
+ * loop for the same data.
+ *
+ * The observer memoizes the combined result on the `combine` identity and the
+ * raw results, so both are kept stable here (callers pass fresh context
+ * arrays every render): an inline combine would rebuild the Map — new `data`
+ * identity — on every render, cascading into rebuilt metric grid columns on
+ * each watch flush.
+ */
 export function useResourceMetrics(contexts: string[], kind: 'pods' | 'nodes') {
-  return useQuery({
-    queryKey: ['metrics-snapshot', kind, contexts],
-    queryFn: async () => {
-      const result = new Map<string, MetricsSnapshot>();
-      await Promise.all(
-        contexts.map(async (ctx) => {
-          const snap = await apiFetch<MetricsSnapshot>(`/api/contexts/${encodeURIComponent(ctx)}/metrics/${kind}`).catch(() => ({ available: false, items: [] }) as MetricsSnapshot);
-          result.set(ctx, snap);
-        }),
-      );
-      return result;
+  const interval = useRefetchInterval(20_000);
+  const contextsKey = contexts.join('\n');
+  const queries = useMemo(
+    () =>
+      (contextsKey ? contextsKey.split('\n') : []).map((ctx) => ({
+        queryKey: ['metrics-snapshot', kind, ctx] as const,
+        queryFn: () =>
+          apiFetch<MetricsSnapshot>(`/api/contexts/${encodeURIComponent(ctx)}/metrics/${kind}`).catch(
+            () => ({ available: false, items: [] }) as MetricsSnapshot,
+          ),
+        refetchInterval: interval,
+      })),
+    [contextsKey, kind, interval],
+  );
+  const combine = useCallback(
+    (results: Array<{ data?: MetricsSnapshot }>) => {
+      const ctxs = contextsKey ? contextsKey.split('\n') : [];
+      if (!ctxs.length) return { data: undefined as Map<string, MetricsSnapshot> | undefined };
+      const data = new Map<string, MetricsSnapshot>();
+      results.forEach((result, i) => {
+        if (result.data) data.set(ctxs[i]!, result.data);
+      });
+      return { data };
     },
-    enabled: contexts.length > 0,
-    refetchInterval: useRefetchInterval(20_000),
-  });
+    [contextsKey],
+  );
+  return useQueries({ queries, combine });
 }
 
 export function useMetricsHistory(sel: { ctx: string; kind: 'pod' | 'node'; name: string; namespace?: string } | undefined) {
@@ -798,11 +822,18 @@ export function useMetricsSummary(ctx: string) {
 
 // ---- metrics-server install / uninstall ----
 
-export function useMetricsServerStatus(ctx: string, opts?: { refetchMs?: number }) {
+export function useMetricsServerStatus(ctx: string) {
+  const interval = useRefetchInterval(30_000);
   return useQuery({
     queryKey: ['metrics-server-status', ctx],
     queryFn: () => apiFetch<MetricsServerStatus>(`/api/contexts/${encodeURIComponent(ctx)}/metrics-server`),
-    refetchInterval: useRefetchInterval(opts?.refetchMs ?? 30_000),
+    // Install status is near-static; poll fast only while an install is
+    // settling (manifests applied → Deployment ready → metrics flowing).
+    refetchInterval: (query) => {
+      if (interval === false) return false;
+      const s = query.state.data;
+      return s?.installed && (!s.ready || !s.metricsAvailable) ? Math.min(interval, 5_000) : interval;
+    },
     retry: false,
   });
 }
@@ -816,10 +847,10 @@ export function invalidateMetricsServer(qc: ReturnType<typeof useQueryClient>, c
   void qc.invalidateQueries({ queryKey: ctx ? ['metrics-server-status', ctx] : ['metrics-server-status'] });
   void qc.invalidateQueries({ queryKey: ctx ? ['metrics-summary', ctx] : ['metrics-summary'] });
   void qc.invalidateQueries({ queryKey: ctx ? ['metrics-nodes', ctx] : ['metrics-nodes'] });
-  // ctx sits deeper in these keys: snapshots batch a context list, history keys a selector object.
+  // ctx sits deeper in these keys: snapshots key ['metrics-snapshot', kind, ctx], history keys a selector object.
   void qc.invalidateQueries({
     queryKey: ['metrics-snapshot'],
-    predicate: (q) => !ctx || ((q.queryKey[2] as string[] | undefined) ?? []).includes(ctx),
+    predicate: (q) => !ctx || q.queryKey[2] === ctx,
   });
   void qc.invalidateQueries({
     queryKey: ['metrics-history'],
@@ -862,11 +893,19 @@ export function useNetworkSummary(ctx: string) {
   });
 }
 
-export function useNetworkAgentStatus(ctx: string, opts?: { refetchMs?: number }) {
+export function useNetworkAgentStatus(ctx: string) {
+  const interval = useRefetchInterval(30_000);
   return useQuery({
     queryKey: ['network-agent-status', ctx],
     queryFn: () => apiFetch<NetworkAgentStatus>(`/api/contexts/${encodeURIComponent(ctx)}/network-agent`),
-    refetchInterval: useRefetchInterval(opts?.refetchMs ?? 30_000),
+    // Same idea as useMetricsServerStatus: fast cadence only while the
+    // DaemonSet rollout or first traffic samples are still settling.
+    refetchInterval: (query) => {
+      if (interval === false) return false;
+      const s = query.state.data;
+      const settling = !!s?.installed && (!s.ready || !s.metricsAvailable || s.nodesReady < s.nodesDesired);
+      return settling ? Math.min(interval, 5_000) : interval;
+    },
     retry: false,
   });
 }

--- a/client/src/components/CellCopy.tsx
+++ b/client/src/components/CellCopy.tsx
@@ -47,49 +47,58 @@ export const CopyValueButton = memo(function CopyValueButton({ text, label = 'Co
   );
 });
 
+// One of these renders in every non-empty cell, and scrolling mounts them by
+// the hundred — so it is a plain DOM button (styles in copyCellGridSx, copied
+// state flipped as a class) instead of a stateful MUI IconButton.
+const copyResetTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>();
+
+function stopEventPropagation(event: React.SyntheticEvent) {
+  event.stopPropagation();
+}
+
+function suppressFocusSteal(event: React.MouseEvent) {
+  event.stopPropagation();
+  // Keep focus where it was: no cell focus-within outline after copying.
+  event.preventDefault();
+}
+
+const cellCopyIcons = (
+  <>
+    <svg className="kubus-cell-copy-icon" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+      <path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" />
+    </svg>
+    <svg className="kubus-cell-copy-check" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+      <path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+    </svg>
+  </>
+);
+
 const CellCopyButton = memo(function CellCopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const resetRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  useEffect(() => () => clearTimeout(resetRef.current), []);
   return (
-    <IconButton
+    <button
+      type="button"
       className="kubus-cell-copy"
-      size="small"
       tabIndex={-1}
       aria-label="Copy value"
       title="Copy"
       onClick={(event) => {
         event.stopPropagation();
+        const button = event.currentTarget;
         void copyToClipboard(text).then((ok) => {
           if (!ok) return;
-          setCopied(true);
-          clearTimeout(resetRef.current);
-          resetRef.current = setTimeout(() => setCopied(false), 1200);
+          button.classList.add('kubus-cell-copied');
+          clearTimeout(copyResetTimers.get(button));
+          copyResetTimers.set(
+            button,
+            setTimeout(() => button.classList.remove('kubus-cell-copied'), 1200),
+          );
         });
       }}
-      onDoubleClick={(event) => event.stopPropagation()}
-      onMouseDown={(event) => {
-        event.stopPropagation();
-        // Keep focus where it was: no cell focus-within outline after copying.
-        event.preventDefault();
-      }}
-      sx={{
-        position: 'absolute',
-        top: '50%',
-        right: 2,
-        transform: 'translateY(-50%)',
-        p: 0.25,
-        borderRadius: 1,
-        opacity: 0,
-        pointerEvents: 'none',
-        transition: 'opacity 120ms',
-        bgcolor: 'background.paper',
-        boxShadow: 1,
-        '&:hover': { bgcolor: 'background.paper' },
-      }}
+      onDoubleClick={stopEventPropagation}
+      onMouseDown={suppressFocusSteal}
     >
-      {copied ? <CheckIcon sx={{ fontSize: 14 }} color="success" /> : <ContentCopyIcon sx={{ fontSize: 14 }} />}
-    </IconButton>
+      {cellCopyIcons}
+    </button>
   );
 });
 
@@ -144,6 +153,30 @@ export const handleCopyCellKeyDown: GridEventListener<'cellKeyDown'> = (params, 
 /** Grid `sx` styles required by withCellCopy / handleCopyCellKeyDown. */
 export const copyCellGridSx = {
   '& .MuiDataGrid-cell': { position: 'relative' },
+  '& .kubus-cell-copy': {
+    position: 'absolute',
+    top: '50%',
+    right: 2,
+    transform: 'translateY(-50%)',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    p: '3px',
+    m: 0,
+    border: 0,
+    borderRadius: 1,
+    cursor: 'pointer',
+    opacity: 0,
+    pointerEvents: 'none',
+    transition: 'opacity 120ms',
+    bgcolor: 'background.paper',
+    boxShadow: 1,
+    color: 'action.active',
+    '& svg': { width: 14, height: 14, fill: 'currentColor', display: 'block' },
+    '& .kubus-cell-copy-check': { display: 'none', color: 'success.main' },
+    '&.kubus-cell-copied .kubus-cell-copy-icon': { display: 'none' },
+    '&.kubus-cell-copied .kubus-cell-copy-check': { display: 'block' },
+  },
   '& .MuiDataGrid-cell:hover .kubus-cell-copy': { opacity: 1, pointerEvents: 'auto' },
   '& .kubus-cell-text': {
     flex: 1,

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -53,6 +53,8 @@ const labelFilterOptions = createFilterOptions<string>({ limit: 100 });
 
 const DEFAULT_SORT: GridSortModel = [{ field: 'name', sort: 'asc' }];
 
+const EMPTY_LABEL_OPTIONS: { terms: string[]; keys: Set<string> } = { terms: [], keys: new Set() };
+
 /** All `key` and `key=value` selector terms present in the rows. */
 function labelSelectorOptions(rows: ClusterRow[]): { terms: string[]; keys: Set<string> } {
   const keys = new Set<string>();
@@ -192,8 +194,30 @@ export function ResourceTable({
   }, [rows, parsedFilter, kind, metricsForFilter]);
 
   const rowsById = useMemo(() => new Map(filtered.map((row) => [row.obj.metadata.uid, row])), [filtered]);
-  const labelOptions = useMemo(() => labelSelectorOptions(rows), [rows]);
+  // Scanning and sorting every row's labels is only worth doing while the
+  // dropdown is open — not on every watch flush of a large list.
+  const [labelsOpen, setLabelsOpen] = useState(false);
+  const labelOptions = useMemo(() => (labelsOpen ? labelSelectorOptions(rows) : EMPTY_LABEL_OPTIONS), [labelsOpen, rows]);
   const labelTerms = useMemo(() => splitLabelSelector(labelSelector ?? ''), [labelSelector]);
+
+  // The grid re-renders on every watch flush; keep the sx object stable so
+  // emotion doesn't re-serialize it each time.
+  const gridSx = useMemo(
+    () => ({
+      border: 0,
+      flex: 1,
+      minHeight: 0,
+      '& .MuiDataGrid-row': { cursor: onRowClick ? 'pointer' : 'default' },
+      '& .MuiDataGrid-row.kubus-active-resource-row': {
+        bgcolor: 'action.selected',
+        '&:hover': { bgcolor: 'action.selected' },
+      },
+      '& .MuiDataGrid-row.kubus-muted-row': { opacity: 0.55, transition: 'opacity 120ms' },
+      '& .MuiDataGrid-row.kubus-muted-row:hover, & .MuiDataGrid-row.kubus-muted-row:focus-within': { opacity: 1 },
+      ...copyCellGridSx,
+    }),
+    [!!onRowClick], // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   const setTextFilter = (value: string) => {
     setInputValue(value);
@@ -225,6 +249,8 @@ export function ResourceTable({
             limitTags={2}
             options={labelOptions.terms}
             value={labelTerms}
+            onOpen={() => setLabelsOpen(true)}
+            onClose={() => setLabelsOpen(false)}
             filterOptions={labelFilterOptions}
             onChange={(_event, values) => onLabelSelectorChange(joinLabelSelector(values))}
             renderOption={({ key, ...props }, option, { selected }) => (
@@ -333,19 +359,7 @@ export function ResourceTable({
         }}
         sortModel={sortModel}
         onSortModelChange={handleSortChange}
-        sx={{
-          border: 0,
-          flex: 1,
-          minHeight: 0,
-          '& .MuiDataGrid-row': { cursor: onRowClick ? 'pointer' : 'default' },
-          '& .MuiDataGrid-row.kubus-active-resource-row': {
-            bgcolor: 'action.selected',
-            '&:hover': { bgcolor: 'action.selected' },
-          },
-          '& .MuiDataGrid-row.kubus-muted-row': { opacity: 0.55, transition: 'opacity 120ms' },
-          '& .MuiDataGrid-row.kubus-muted-row:hover, & .MuiDataGrid-row.kubus-muted-row:focus-within': { opacity: 1 },
-          ...copyCellGridSx,
-        }}
+        sx={gridSx}
       />
     </Box>
   );

--- a/client/src/components/settings/SettingsDialog.tsx
+++ b/client/src/components/settings/SettingsDialog.tsx
@@ -171,7 +171,7 @@ function ClusterRow({ c, isProtected, onToggleProtected }: { c: ContextInfo; isP
 }
 
 function ClustersSection() {
-  const { data: contexts } = useContexts();
+  const { data: contexts } = useContexts({ poll: false });
   const { data: kubeconfig } = useKubeconfigSettings();
   const contextSettings = useClustersStore((s) => s.contextSettings);
   const setContextSetting = useClustersStore((s) => s.setContextSetting);

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import useMediaQuery from '@mui/material/useMediaQuery';
@@ -26,22 +26,41 @@ export function AppShell() {
   const navOverlay = useMediaQuery(NAV_OVERLAY_MEDIA_QUERY);
   const navCollapsed = useUiPrefsStore((s) => s.navCollapsed);
   const navOverlayOpen = useNavUiStore((s) => s.overlayOpen);
-  const setNavOverlayOpen = useNavUiStore((s) => s.setOverlayOpen);
+  // Stable identity — an inline arrow would defeat NavDrawer's memo.
+  const closeNavOverlay = useCallback(() => useNavUiStore.getState().setOverlayOpen(false), []);
   const dockOpen = useDockStore((s) => s.open);
   const dockHeight = useDockStore((s) => s.height);
   const maximized = useDockStore((s) => s.maximized);
   const sel = useDetailStore((s) => s.stack.at(-1));
+  const selEmbedded = useDetailStore((s) => s.embedded);
   const hasParent = useDetailStore((s) => s.stack.length > 1);
   const back = useDetailStore((s) => s.back);
   const closeDetail = useDetailStore((s) => s.close);
-  // Mounted on first open, kept mounted after so close animations still play.
+  // Mounted on first open, kept mounted through a close so the exit animation
+  // still plays; fully unmounted shortly after (see the watchdog below).
   const [drawerMounted, setDrawerMounted] = useState(false);
   const dockRef = useRef<HTMLDivElement>(null);
   const mainRef = useRef<HTMLElement>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const detailIsEmbedded = location.pathname.startsWith('/r/');
-  if (!drawerMounted && sel && !detailIsEmbedded) setDrawerMounted(true);
+  // Embedded-owned selections never reach the overlay drawer: when leaving a
+  // list page toward another page, the selection outlives the route change by
+  // one commit, and letting the drawer flash open for that commit interrupts
+  // its own transitions — a race that can strand MUI's Modal portal as an
+  // invisible click-eating overlay.
+  const overlaySel = detailIsEmbedded || selEmbedded ? undefined : sel;
+  if (!drawerMounted && overlaySel) setDrawerMounted(true);
+
+  // Watchdog: once the drawer is closed, drop it from the tree after the exit
+  // animation. Unmounting destroys the Modal portal outright, so no stuck
+  // transition state can outlive a close and keep swallowing input.
+  const drawerIdle = drawerMounted && !overlaySel;
+  useEffect(() => {
+    if (!drawerIdle) return;
+    const timer = setTimeout(() => setDrawerMounted(false), 1_000);
+    return () => clearTimeout(timer);
+  }, [drawerIdle]);
 
   // Closing the drawer via X/Escape/backdrop also drops the ?sel deep link
   // from the current tab's URL, so the tab doesn't reopen the drawer on its
@@ -87,7 +106,7 @@ export function AppShell() {
       </ButtonBase>
       <TopBar />
       <Box sx={{ display: 'flex', flex: 1, minHeight: 0 }}>
-        <NavDrawer overlay={navOverlay} hidden={navCollapsed} open={navOverlayOpen} onClose={() => setNavOverlayOpen(false)} />
+        <NavDrawer overlay={navOverlay} hidden={navCollapsed} open={navOverlayOpen} onClose={closeNavOverlay} />
         <Box component="main" ref={mainRef} tabIndex={-1} sx={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', outline: 'none' }}>
           <TabsBar />
           <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
@@ -101,7 +120,7 @@ export function AppShell() {
       {drawerMounted && (
         <ErrorBoundary label="The details panel">
           <Suspense fallback={null}>
-            <ResourceDetailDrawer sel={detailIsEmbedded ? undefined : sel} onClose={handleDrawerClose} onBack={hasParent ? back : undefined} />
+            <ResourceDetailDrawer sel={overlaySel} onClose={handleDrawerClose} onBack={hasParent ? back : undefined} />
           </Suspense>
         </ErrorBoundary>
       )}

--- a/client/src/pages/AuditPage.tsx
+++ b/client/src/pages/AuditPage.tsx
@@ -102,7 +102,9 @@ export function AuditPage() {
   const { data, isLoading, isFetching } = useAudit(selected);
   const queryClient = useQueryClient();
   const openDetail = useDetailStore((s) => s.open);
-  const { dismissedChecks, dismissCheck, restoreCheck } = useAuditPrefsStore();
+  const dismissedChecks = useAuditPrefsStore((s) => s.dismissedChecks);
+  const dismissCheck = useAuditPrefsStore((s) => s.dismissCheck);
+  const restoreCheck = useAuditPrefsStore((s) => s.restoreCheck);
   const [severityFilter, setSeverityFilter] = useState<ReadonlySet<AuditSeverity>>(new Set());
   const [textFilter, setTextFilter] = useState('');
   const deferredTextFilter = useDeferredValue(textFilter);

--- a/client/src/pages/DiffPage.tsx
+++ b/client/src/pages/DiffPage.tsx
@@ -91,7 +91,7 @@ export function DiffPage() {
 }
 
 function SidePicker({ label, side, onChange }: { label: string; side: Side; onChange: (s: Side) => void }) {
-  const { data: contexts } = useContexts();
+  const { data: contexts } = useContexts({ poll: false });
   const activeContexts = (contexts ?? []).filter((c) => c.active).map((c) => c.name);
   const { data: kinds } = useApiResources(side.ctx);
   const { data: namespaces } = useNamespaces(side.ctx ? [side.ctx] : []);

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
@@ -46,6 +46,18 @@ interface EventRow {
   firstSeen?: string;
   lastSeen?: string;
 }
+
+// Hoisted: the grid re-renders on every watch tick, and fresh sx/getRowId
+// identities would make it redo emotion serialization and prop-keyed work.
+const eventsGridSx = {
+  border: 0,
+  flex: 1,
+  minHeight: 0,
+  '& .MuiDataGrid-row': { cursor: 'pointer' },
+  ...copyCellGridSx,
+};
+const eventsGridInitialState = { sorting: { sortModel: [{ field: 'lastSeen', sort: 'desc' as const }] } };
+const getEventRowId = (r: EventRow) => r.id;
 
 function maxTime(...ts: Array<string | null | undefined>): string | undefined {
   return ts
@@ -144,25 +156,41 @@ export function EventsPage() {
     });
   }, [deduped, warningsOnly, kindFilter]);
 
-  const openInvolved = (row: EventRow) => {
-    const o = row.ev.involvedObject;
-    if (!o?.kind || !o.name) return;
-    // Resolve the GVR from discovery (covers CRDs), falling back to builtins.
-    const apiVersion = o.apiVersion ?? '';
-    const [group, version] = apiVersion.includes('/') ? apiVersion.split('/') : ['', apiVersion || 'v1'];
-    const fromDiscovery = (apiResources?.byContext[row.ctx] ?? []).find((r) => r.kind === o.kind && r.group === (group ?? '') && (!version || r.version === version));
-    const gvk = fromDiscovery ?? gvkForKind(o.kind);
-    if (!gvk) return;
-    openDetail({
-      ctx: row.ctx,
-      group: gvk.group,
-      version: gvk.version,
-      plural: gvk.plural,
-      kind: o.kind,
-      name: o.name,
-      namespace: o.namespace,
-    });
-  };
+  const openInvolved = useCallback(
+    (row: EventRow) => {
+      const o = row.ev.involvedObject;
+      if (!o?.kind || !o.name) return;
+      // Resolve the GVR from discovery (covers CRDs), falling back to builtins.
+      const apiVersion = o.apiVersion ?? '';
+      const [group, version] = apiVersion.includes('/') ? apiVersion.split('/') : ['', apiVersion || 'v1'];
+      const fromDiscovery = (apiResources?.byContext[row.ctx] ?? []).find((r) => r.kind === o.kind && r.group === (group ?? '') && (!version || r.version === version));
+      const gvk = fromDiscovery ?? gvkForKind(o.kind);
+      if (!gvk) return;
+      openDetail({
+        ctx: row.ctx,
+        group: gvk.group,
+        version: gvk.version,
+        plural: gvk.plural,
+        kind: o.kind,
+        name: o.name,
+        namespace: o.namespace,
+      });
+    },
+    [apiResources, openDetail],
+  );
+
+  const onRowClick = useCallback((p: { row: EventRow }) => openInvolved(p.row), [openInvolved]);
+  const onCellKeyDown = useCallback<NonNullable<React.ComponentProps<typeof DataGrid<EventRow>>['onCellKeyDown']>>(
+    (params, event, details) => {
+      handleCopyCellKeyDown(params, event, details);
+      // Keyboard equivalent of clicking the row.
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        openInvolved(params.row);
+      }
+    },
+    [openInvolved],
+  );
 
   const columns: GridColDef<EventRow>[] = useMemo(() => {
     const defs: GridColDef<EventRow>[] = [
@@ -252,26 +280,13 @@ export function EventsPage() {
         rows={rows}
         columns={grid.columns}
         loading={Object.values(list.status).some((s) => s.state === 'loading')}
-        getRowId={(r) => r.id}
+        getRowId={getEventRowId}
         density={grid.density}
         onColumnWidthChange={grid.onColumnWidthChange}
-        onRowClick={(p) => openInvolved(p.row as EventRow)}
-        onCellKeyDown={(params, event, details) => {
-          handleCopyCellKeyDown(params, event, details);
-          // Keyboard equivalent of clicking the row.
-          if (event.key === 'Enter') {
-            event.preventDefault();
-            openInvolved(params.row as EventRow);
-          }
-        }}
-        initialState={{ sorting: { sortModel: [{ field: 'lastSeen', sort: 'desc' }] } }}
-        sx={{
-          border: 0,
-          flex: 1,
-          minHeight: 0,
-          '& .MuiDataGrid-row': { cursor: 'pointer' },
-          ...copyCellGridSx,
-        }}
+        onRowClick={onRowClick}
+        onCellKeyDown={onCellKeyDown}
+        initialState={eventsGridInitialState}
+        sx={eventsGridSx}
       />
     </Box>
   );

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -32,6 +32,8 @@ interface Row {
   release: HelmReleaseSummary;
 }
 
+const releasesGridSx = { flex: 1, minHeight: 0, border: 0, '& .MuiDataGrid-row': { cursor: 'pointer' }, ...copyCellGridSx };
+
 export function HelmPage() {
   const selected = useClustersStore((s) => s.selected);
   const namespaces = useClustersStore((s) => s.namespaces);
@@ -203,7 +205,7 @@ export function HelmPage() {
             );
           }
         }}
-        sx={{ flex: 1, minHeight: 0, border: 0, '& .MuiDataGrid-row': { cursor: 'pointer' }, ...copyCellGridSx }}
+        sx={releasesGridSx}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
       />
       {installOpen && (

--- a/client/src/pages/MetricsPage.tsx
+++ b/client/src/pages/MetricsPage.tsx
@@ -60,8 +60,8 @@ export function MetricsPage() {
 }
 
 function ClusterMetricsSection({ ctx }: { ctx: string }) {
-  // Poll status faster than the nav does: this page is where install progress is watched.
-  const { data: status, error: statusError } = useMetricsServerStatus(ctx, { refetchMs: 5_000 });
+  // The hook polls fast on its own while an install is settling.
+  const { data: status, error: statusError } = useMetricsServerStatus(ctx);
   const { data: summary, error: summaryError } = useMetricsSummary(ctx);
   const error = statusError ?? summaryError;
   const qc = useQueryClient();

--- a/client/src/pages/NetworkMetricsPage.tsx
+++ b/client/src/pages/NetworkMetricsPage.tsx
@@ -54,8 +54,8 @@ export function NetworkMetricsPage() {
 }
 
 function ClusterNetworkSection({ ctx }: { ctx: string }) {
-  // Poll status faster than the nav does: this page is where install progress is watched.
-  const { data: status, error: statusError } = useNetworkAgentStatus(ctx, { refetchMs: 5_000 });
+  // The hook polls fast on its own while an install is settling.
+  const { data: status, error: statusError } = useNetworkAgentStatus(ctx);
   const { data: summary, error: summaryError } = useNetworkSummary(ctx);
   const error = statusError ?? summaryError;
 

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -50,7 +50,7 @@ function WelcomeState() {
   // Selecting drives the ClusterSwitcher's keep-healthy effect, which owns
   // connecting — no second connect path here.
   const setSelected = useClustersStore((s) => s.setSelected);
-  const { data: contexts, isLoading } = useContexts();
+  const { data: contexts, isLoading } = useContexts({ poll: false });
   const { data: kubeconfig } = useKubeconfigSettings();
   const [addOpen, setAddOpen] = useState(false);
   const shown = (contexts ?? []).slice(0, 8);

--- a/client/src/pages/PortForwardsPage.tsx
+++ b/client/src/pages/PortForwardsPage.tsx
@@ -18,6 +18,8 @@ import { StatusChip } from '../components/StatusChip.js';
 import { EmptyState } from '../components/EmptyState.js';
 import { PageHeader } from '../components/PageHeader.js';
 
+const forwardsGridSx = { border: 0, ...copyCellGridSx };
+
 export function PortForwardsPage() {
   const { data, isLoading } = usePortForwards();
   const { mutate: stop } = useStopPortForward();
@@ -133,7 +135,7 @@ export function PortForwardsPage() {
           }}
           onColumnWidthChange={grid.onColumnWidthChange}
           onCellKeyDown={handleCopyCellKeyDown}
-          sx={{ border: 0, ...copyCellGridSx }}
+          sx={forwardsGridSx}
         />
       )}
     </Box>

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -68,7 +68,7 @@ function DetailUrlSync({ sel }: { sel: ResourceSelection | undefined }) {
   // and enforces this tab's selection (open its ?sel, or close a leftover).
   useEffect(() => {
     if (!paneActive) return;
-    if (sel) openDetail(sel);
+    if (sel) openDetail(sel, { embedded: true });
     else closeDetail();
   }, [paneActive, sel, openDetail, closeDetail]);
 
@@ -542,7 +542,10 @@ export function ResourceListPage() {
     // Update immediately so the embedded panel responds in the same render
     // cycle; the URL remains the deep-link source of truth. Picking a row is
     // an explicit ask for details, so also undo a collapse.
-    openDetail({ ctx: row.ctx, group, version, plural, kind, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace, custom: isCustomKind });
+    openDetail(
+      { ctx: row.ctx, group, version, plural, kind, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace, custom: isCustomKind },
+      { embedded: true },
+    );
     setDetailCollapsed(false);
     const next = new URLSearchParams(searchParams);
     next.delete('field');

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -760,7 +760,7 @@ export function ResourceListPage() {
           crdSelection
             ? () => {
                 setApiResourceOpen(false);
-                pushDetail(crdSelection);
+                pushDetail(crdSelection, { embedded: true });
               }
             : undefined
         }

--- a/client/src/state/detail.ts
+++ b/client/src/state/detail.ts
@@ -8,6 +8,16 @@ import type { ResourceSelection } from '../components/ResourceDetailDrawer.js';
  */
 interface DetailState {
   stack: ResourceSelection[];
+  /**
+   * The stack belongs to a resource list page's embedded side panel (set by
+   * its opener). The overlay drawer must ignore embedded-owned selections:
+   * when navigating from a list page to another page, the page unmount clears
+   * the selection one commit after the route changes — without this flag the
+   * overlay would mount open for that one commit and immediately close, and
+   * that interrupted enter→exit transition can strand MUI's Modal portal as
+   * an invisible, input-eating overlay (seen in the wild as a frozen app).
+   */
+  embedded: boolean;
   /** Embedded panel shrunk to its handle; the selection stays live. */
   collapsed: boolean;
   /** Embedded panel width in px; user-resizable via the divider. */
@@ -18,7 +28,7 @@ interface DetailState {
   dataDirty: boolean;
   /** Action stalled behind the discard confirmation while dataDirty. */
   pendingDiscard?: () => void;
-  open: (sel: ResourceSelection) => void;
+  open: (sel: ResourceSelection, opts?: { embedded?: boolean }) => void;
   push: (sel: ResourceSelection) => void;
   back: () => void;
   close: () => void;
@@ -44,6 +54,7 @@ function selKeyOf(sel: ResourceSelection): string {
 
 export const useDetailStore = create<DetailState>((set, get) => ({
   stack: [],
+  embedded: false,
   collapsed: false,
   width: DEFAULT_DETAIL_WIDTH,
   focusSeq: 0,
@@ -52,11 +63,12 @@ export const useDetailStore = create<DetailState>((set, get) => ({
   // search) and replace the mounted detail — guard them so staged Data-tab
   // edits aren't dropped without confirmation. Re-opening the same resource
   // doesn't remount the editor, so it passes through.
-  open: (sel) => {
+  open: (sel, opts) => {
+    const embedded = opts?.embedded ?? false;
     const { stack } = get();
     const sameSel = stack.length === 1 && selKeyOf(stack[0]!) === selKeyOf(sel);
-    if (sameSel) set({ stack: [sel] });
-    else get().guard(() => set({ stack: [sel] }));
+    if (sameSel) set({ stack: [sel], embedded });
+    else get().guard(() => set({ stack: [sel], embedded }));
   },
   // Pushes can come from outside the panel (e.g. the API-resource drawer's
   // CRD link), so surface the result even if the panel was collapsed.

--- a/client/src/state/detail.ts
+++ b/client/src/state/detail.ts
@@ -29,7 +29,7 @@ interface DetailState {
   /** Action stalled behind the discard confirmation while dataDirty. */
   pendingDiscard?: () => void;
   open: (sel: ResourceSelection, opts?: { embedded?: boolean }) => void;
-  push: (sel: ResourceSelection) => void;
+  push: (sel: ResourceSelection, opts?: { embedded?: boolean }) => void;
   back: () => void;
   close: () => void;
   setCollapsed: (collapsed: boolean) => void;
@@ -71,8 +71,12 @@ export const useDetailStore = create<DetailState>((set, get) => ({
     else get().guard(() => set({ stack: [sel], embedded }));
   },
   // Pushes can come from outside the panel (e.g. the API-resource drawer's
-  // CRD link), so surface the result even if the panel was collapsed.
-  push: (sel) => get().guard(() => set((s) => ({ stack: [...s.stack, sel], collapsed: false }))),
+  // CRD link), so surface the result even if the panel was collapsed. A push
+  // extends whichever surface owns the stack, so the embedded flag is kept
+  // unless the caller states ownership — needed when a push seeds an empty
+  // stack (list pages can open their CRD with no row selected).
+  push: (sel, opts) =>
+    get().guard(() => set((s) => ({ stack: [...s.stack, sel], collapsed: false, embedded: opts?.embedded ?? s.embedded }))),
   back: () => set((s) => ({ stack: s.stack.slice(0, -1) })),
   // Bail when already closed — close() is called liberally (e.g. on page
   // unmounts), and a fresh [] would re-render every stack subscriber.

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import { usePaneActive } from '../layout/pane-context.js';
 import { kubusStateStorage } from './persist-storage.js';
 
 export type TableDensity = 'compact' | 'comfortable';
@@ -100,9 +101,16 @@ export const useUiPrefsStore = create<UiPrefsState>()(
  * A stable per-mount ±10% jitter decorrelates the timers of components that
  * poll with the same base (e.g. one overview section per cluster), so many
  * clusters don't fire synchronized request bursts.
+ *
+ * Polling pauses while the enclosing tab pane is hidden — pages stay mounted
+ * in inactive panes, and without this every open tab keeps its full request
+ * loop running. On reveal the poll resumes on its normal cadence (watches keep
+ * lists current; polled extras catch up within one interval).
  */
 export function useRefetchInterval(base: number): number | false {
   const rate = useUiPrefsStore((s) => s.refreshRate);
+  const paneActive = usePaneActive();
   const [jitter] = useState(() => 0.9 + Math.random() * 0.2);
-  return rate === 'off' ? false : Math.round(base * REFRESH_FACTOR[rate] * jitter);
+  if (!paneActive || rate === 'off') return false;
+  return Math.round(base * REFRESH_FACTOR[rate] * jitter);
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -31,13 +31,16 @@ export default defineConfig({
               test: /node_modules[\\/]monaco-editor[\\/]/,
               includeDependenciesRecursively: false,
             },
-            // x-charts and x-data-grid stay out of this eager group: they are
-            // only reachable from lazy chunks and should load on demand.
-            // Dependencies (emotion, @mui/system, …) ride along — they are
-            // needed at first paint anyway, and leaving them ungrouped lets
-            // the bundler pack them into arbitrary lazy chunks, which then
-            // become eagerly loaded through the shared-module edge.
-            { name: 'mui', test: /node_modules[\\/]@mui[\\/](material|icons-material)[\\/]/ },
+            // x-charts, x-data-grid and icons-material stay out of this eager
+            // group: the former two are only reachable from lazy chunks, and
+            // icons ride with whichever chunk uses them — icons used only by
+            // lazy routes then stay off the first paint instead of being
+            // packed into the eager mui chunk. Dependencies (emotion,
+            // @mui/system, …) ride along — they are needed at first paint
+            // anyway, and leaving them ungrouped lets the bundler pack them
+            // into arbitrary lazy chunks, which then become eagerly loaded
+            // through the shared-module edge.
+            { name: 'mui', test: /node_modules[\\/]@mui[\\/]material[\\/]/ },
           ],
         },
       },

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -382,36 +382,57 @@ ipcMain.on('kubus:set-titlebar-overlay', (event, options: unknown) => {
   }
 });
 
-ipcMain.on('kubus:state:get-item', (event, name: unknown) => {
-  event.returnValue = isMainWindowSender(event) && typeof name === 'string' ? (loadClientState()[name] ?? null) : null;
+// One sync call, at preload time only: the boot snapshot the bridge serves
+// getItem from. A sync handler must set returnValue on every path — a missed
+// reply parks the renderer main thread forever.
+ipcMain.on('kubus:state:get-all', (event) => {
+  try {
+    event.returnValue = isMainWindowSender(event) ? { ...loadClientState() } : {};
+  } catch {
+    event.returnValue = {};
+  }
 });
 
-ipcMain.on('kubus:state:set-item', (event, name: unknown, value: unknown) => {
-  if (!isMainWindowSender(event) || typeof name !== 'string' || typeof value !== 'string') {
-    event.returnValue = false;
-    return;
+// Steady-state writes are fire-and-forget so the renderer never blocks on
+// persistence; bursts (fast clicking flips several stores at once) coalesce
+// into one disk write.
+let stateFlushTimer: NodeJS.Timeout | undefined;
+let pendingClientState: Record<string, string> | undefined;
+
+function scheduleClientStateFlush(state: Record<string, string>): void {
+  pendingClientState = state;
+  clientStateCache = state;
+  stateFlushTimer ??= setTimeout(() => {
+    stateFlushTimer = undefined;
+    flushClientState();
+  }, 150);
+}
+
+function flushClientState(): void {
+  if (stateFlushTimer !== undefined) {
+    clearTimeout(stateFlushTimer);
+    stateFlushTimer = undefined;
   }
+  if (!pendingClientState) return;
+  const state = pendingClientState;
+  pendingClientState = undefined;
   try {
-    saveClientState({ ...loadClientState(), [name]: value });
-    event.returnValue = true;
+    saveClientState(state);
   } catch {
-    event.returnValue = false;
+    /* nothing actionable — the state lands with the next write */
   }
+}
+
+ipcMain.on('kubus:state:set-item', (event, name: unknown, value: unknown) => {
+  if (!isMainWindowSender(event) || typeof name !== 'string' || typeof value !== 'string') return;
+  scheduleClientStateFlush({ ...loadClientState(), [name]: value });
 });
 
 ipcMain.on('kubus:state:remove-item', (event, name: unknown) => {
-  if (!isMainWindowSender(event) || typeof name !== 'string') {
-    event.returnValue = false;
-    return;
-  }
-  try {
-    const next = { ...loadClientState() };
-    delete next[name];
-    saveClientState(next);
-    event.returnValue = true;
-  } catch {
-    event.returnValue = false;
-  }
+  if (!isMainWindowSender(event) || typeof name !== 'string') return;
+  const next = { ...loadClientState() };
+  delete next[name];
+  scheduleClientStateFlush(next);
 });
 
 // The renderer pulls the pending deep link once its route listener is
@@ -488,6 +509,7 @@ if (!app.requestSingleInstanceLock()) {
   });
 
   app.on('before-quit', (event) => {
+    flushClientState();
     if (!server) return;
     if (!closing) {
       closing = server.close().catch(() => undefined);

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -396,16 +396,18 @@ ipcMain.on('kubus:state:get-all', (event) => {
 // Steady-state writes are fire-and-forget so the renderer never blocks on
 // persistence; bursts (fast clicking flips several stores at once) coalesce
 // into one disk write.
+const STATE_FLUSH_MS = 150;
+const STATE_RETRY_MS = 5_000;
 let stateFlushTimer: NodeJS.Timeout | undefined;
 let pendingClientState: Record<string, string> | undefined;
 
-function scheduleClientStateFlush(state: Record<string, string>): void {
+function scheduleClientStateFlush(state: Record<string, string>, delay = STATE_FLUSH_MS): void {
   pendingClientState = state;
   clientStateCache = state;
   stateFlushTimer ??= setTimeout(() => {
     stateFlushTimer = undefined;
     flushClientState();
-  }, 150);
+  }, delay);
 }
 
 function flushClientState(): void {
@@ -413,13 +415,17 @@ function flushClientState(): void {
     clearTimeout(stateFlushTimer);
     stateFlushTimer = undefined;
   }
-  if (!pendingClientState) return;
   const state = pendingClientState;
-  pendingClientState = undefined;
+  if (!state) return;
   try {
     saveClientState(state);
+    pendingClientState = undefined;
   } catch {
-    /* nothing actionable — the state lands with the next write */
+    // Disk write failed (full disk, permissions …): keep the state pending
+    // and retry with backoff, and tell the renderer so it can mirror the
+    // snapshot into browser storage as a fallback.
+    mainWindow?.webContents.send('kubus:state:write-failed');
+    scheduleClientStateFlush(state, STATE_RETRY_MS);
   }
 }
 

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,17 +1,33 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+// Client state is mirrored here and persisted with fire-and-forget messages.
+// sendSync is deliberately avoided for the steady-state path: it parks the
+// renderer main thread in an untimed wait, and a single lost reply (seen in
+// the wild under rapid-fire writes) freezes the whole UI permanently. The one
+// sync call left is the boot-time snapshot below, before the page loads.
+const stateSnapshot: Record<string, string> = (() => {
+  try {
+    const all = ipcRenderer.sendSync('kubus:state:get-all') as unknown;
+    return all && typeof all === 'object' ? (all as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+})();
+
 // Desktop bridge for stable client state plus native window integrations.
 contextBridge.exposeInMainWorld('kubusDesktop', {
   platform: process.platform,
   stateStorage: {
     getItem(name: string): string | null {
-      return ipcRenderer.sendSync('kubus:state:get-item', name) as string | null;
+      return stateSnapshot[name] ?? null;
     },
     setItem(name: string, value: string): void {
-      if (!ipcRenderer.sendSync('kubus:state:set-item', name, value)) throw new Error('failed to persist desktop state');
+      stateSnapshot[name] = value;
+      ipcRenderer.send('kubus:state:set-item', name, value);
     },
     removeItem(name: string): void {
-      if (!ipcRenderer.sendSync('kubus:state:remove-item', name)) throw new Error('failed to remove desktop state');
+      delete stateSnapshot[name];
+      ipcRenderer.send('kubus:state:remove-item', name);
     },
   },
   setTitleBarOverlay(options: { color: string; symbolColor: string }) {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -14,6 +14,18 @@ const stateSnapshot: Record<string, string> = (() => {
   }
 })();
 
+// The disk-side write failed in the main process: mirror the snapshot into
+// origin-scoped localStorage so a relaunch on the same origin can migrate it
+// back (kubusStateStorage.getItem reads browser storage when the desktop
+// store has no value).
+ipcRenderer.on('kubus:state:write-failed', () => {
+  try {
+    for (const [name, value] of Object.entries(stateSnapshot)) window.localStorage.setItem(name, value);
+  } catch {
+    /* browser storage unavailable — nothing left to fall back to */
+  }
+});
+
 // Desktop bridge for stable client state plus native window integrations.
 contextBridge.exposeInMainWorld('kubusDesktop', {
   platform: process.platform,


### PR DESCRIPTION
## Summary

A performance sweep across the client plus fixes for the desktop app freezing under heavy interaction.

### Table smoothness
- The hover cell-copy button is now a plain DOM button with grid-level styles instead of a stateful MUI IconButton per cell — scrolling mounts hundreds of cells through virtualization, and this was the dominant per-cell mount cost.
- DataGrid `sx` objects, `getRowId`, and row handlers are hoisted/stable so watch-driven re-renders (100ms flushes) stop re-serializing styles and invalidating prop identities (ResourceTable, Events, Helm, Port Forwards).
- Label filter options (full label scan + sort per flush) are computed only while the dropdown is open.

### Background work
- Polled queries pause while their tab pane is hidden — pages stay mounted in inactive panes, and every open tab previously kept its full request loop running indefinitely.
- metrics-server / network-agent status polls run at 30s and accelerate to 5s only while an install is settling (previously flat 5s forever).
- Metrics snapshots are cached per context, so a single-cluster detail view shares the list page's poll instead of starting a duplicate loop; the cluster picker is the sole `/api/contexts` poller.

### Bundle
- `icons-material` no longer forced into the eager `mui` chunk: shell icons stay on first paint, route-only icons (~60) defer into their route chunks (eager chunk 454→426 KB).

### Desktop freeze fixes
Two independent issues found while chasing the "app freezes and needs a restart" reports:
- **Stuck invisible modal (the actual freeze):** navigating from a resource list to another page let the overlay detail drawer mount open for one commit before the list page's cleanup cleared the shared selection. The interrupted enter/exit transition could strand MUI's Modal portal as an invisible, input-eating overlay (`aria-hidden` left on the app root) — UI kept rendering but no clicks landed. List pages now mark their selections embedded-owned so the overlay never flashes open during navigation, and the drawer fully unmounts shortly after closing as a backstop.
- **Renderer-blocking persistence:** every zustand persist write went through `ipcRenderer.sendSync`, a no-timeout blocking round-trip fired rapid-fire under heavy interaction. The bridge now seeds a snapshot at preload and sends writes fire-and-forget, with debounced disk flushes (and a flush on quit) in the main process.

## Testing
- `tsc --noEmit` + production builds for client and electron.
- Headless UI runs against a kind cluster: table rendering, copy-button behavior, label dropdown, events page, rapid page/tab navigation with responsiveness probes.
- Overlay regression harness: 12 select-row→navigate cycles with a MutationObserver asserting zero modal drawer mounts (previously one per cycle), plus overlay open/close on Events verifying full portal cleanup.
- Electron bridge verified in the packaged app flow: 300 rapid state writes without stalls, debounced flush persists the final write, state rehydrates on relaunch.