### PR TITLE
Topology map fixes, warning-event links, CRD grouping; bump to 0.6.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/StatusChip.tsx
+++ b/client/src/components/StatusChip.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import CircleIcon from '@mui/icons-material/Circle';
 
 const GOOD = new Set(['running', 'succeeded', 'active', 'bound', 'ready', 'available', 'complete', 'completed', 'deployed', 'true', 'healthy', 'synced', 'up', 'attached']);
-const BAD = new Set(['failed', 'crashloopbackoff', 'imagepullbackoff', 'errimagepull', 'error', 'evicted', 'lost', 'notready', 'oomkilled', 'false', 'unhealthy', 'degraded', 'stopped', 'down']);
+const BAD = new Set(['failed', 'crashloopbackoff', 'imagepullbackoff', 'errimagepull', 'error', 'evicted', 'lost', 'notready', 'oomkilled', 'false', 'unhealthy', 'degraded', 'stopped', 'down', 'notestablished', 'nameconflict']);
 const WARN = new Set([
   'pending',
   'terminating',

--- a/client/src/components/TopologyGraphImpl.tsx
+++ b/client/src/components/TopologyGraphImpl.tsx
@@ -416,8 +416,8 @@ export default function TopologyGraphImpl({
   );
 
   const edges = useMemo<TopologyFlowEdge[]>(
-    () =>
-      flow.edges.map((edge) => {
+    () => {
+      const styled = flow.edges.map((edge) => {
         const connected = !activeSelectedNodeId || edge.source === activeSelectedNodeId || edge.target === activeSelectedNodeId;
         return {
           ...edge,
@@ -425,7 +425,13 @@ export default function TopologyGraphImpl({
           style: { ...edge.style, strokeWidth: activeSelectedNodeId && connected ? 2.8 : edge.style?.strokeWidth, opacity: connected ? 1 : 0.1 },
           labelStyle: { ...edge.labelStyle, opacity: connected ? 1 : 0.1 },
         };
-      }),
+      });
+      // Edges paint in array order within the edge layer, and every edge
+      // carries a background-colored halo, so a dimmed edge drawn later would
+      // mask a highlighted one. Keep the selected node's edges on top (stable
+      // sort preserves order within each group).
+      return activeSelectedNodeId ? styled.sort((a, b) => Number(a.selected) - Number(b.selected)) : styled;
+    },
     [activeSelectedNodeId, flow.edges],
   );
   const { warnings, problemNodes } = flow;

--- a/client/src/components/UsageMeter.tsx
+++ b/client/src/components/UsageMeter.tsx
@@ -12,6 +12,11 @@ export function usageColor(pct: number): 'success' | 'warning' | 'error' {
  * utilization bar when a reference total (requests or limits) is known.
  * Shared by the list CPU/Memory cells, PodMiniList and the detail
  * container cards.
+ *
+ * Under budget the track spans the reference total. Over budget it rescales
+ * to actual usage: a tick marks where the request/limit sits and the hatched
+ * segment beyond it is the overshoot, so 154% and 400% look as different as
+ * they are.
  */
 export function UsageMeter({
   value,
@@ -45,7 +50,13 @@ export function UsageMeter({
     );
   }
   const pct = max ? (value / max) * 100 : undefined;
-  const tip = pct !== undefined ? `${text} of ${format(max!)} ${maxHint} (${pct.toFixed(0)}%)` : `${text} · ${emptyHint ?? 'no requests set'}`;
+  const over = pct !== undefined && pct > 100;
+  // Position of the request/limit tick on a track rescaled to `value`.
+  const markerPct = over ? (max! / value) * 100 : undefined;
+  const tip =
+    pct !== undefined
+      ? `${text} of ${format(max!)} ${maxHint} (${pct.toFixed(0)}%)${over ? ` — ${format(value - max!)} over` : ''}`
+      : `${text} · ${emptyHint ?? 'no requests set'}`;
   return (
     <Tooltip title={tip}>
       <Box sx={{ width: '100%', minWidth: 0, display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -53,12 +64,43 @@ export function UsageMeter({
           {text}
         </Typography>
         {pct !== undefined ? (
-          <LinearProgress
-            variant="determinate"
-            value={Math.max(0, Math.min(100, pct))}
-            color={usageColor(pct)}
-            sx={{ flex: 1, minWidth: 36, height: 5, borderRadius: 999, bgcolor: 'action.hover' }}
-          />
+          <Box sx={{ position: 'relative', flex: 1, minWidth: 36 }}>
+            <LinearProgress
+              variant="determinate"
+              value={over ? 100 : Math.max(0, Math.min(100, pct))}
+              color={usageColor(pct)}
+              sx={{ height: 5, borderRadius: 999, bgcolor: 'action.hover' }}
+            />
+            {markerPct !== undefined && (
+              <>
+                <Box
+                  sx={(theme) => ({
+                    position: 'absolute',
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                    left: `${markerPct}%`,
+                    right: 0,
+                    height: 5,
+                    borderRadius: '0 999px 999px 0',
+                    backgroundImage: `repeating-linear-gradient(-45deg, ${theme.palette.error.dark} 0 3px, transparent 3px 6px)`,
+                  })}
+                />
+                <Box
+                  sx={(theme) => ({
+                    position: 'absolute',
+                    top: '50%',
+                    left: `${markerPct}%`,
+                    transform: 'translate(-50%, -50%)',
+                    width: 2,
+                    height: 11,
+                    borderRadius: 1,
+                    bgcolor: 'text.primary',
+                    boxShadow: `0 0 0 1px ${theme.palette.background.paper}`,
+                  })}
+                />
+              </>
+            )}
+          </Box>
         ) : (
           <Box sx={{ flex: 1, minWidth: 36, height: 5, borderRadius: 999, bgcolor: 'action.hover', opacity: 0.5 }} />
         )}

--- a/client/src/components/columns.tsx
+++ b/client/src/components/columns.tsx
@@ -11,7 +11,7 @@ import { AgeCell, RelativeTimeCell } from './AgeCell.js';
 import { ReadyCounter } from './ReadyCounter.js';
 import { StatusChip } from './StatusChip.js';
 import { formatBytes, formatCpu } from './format.js';
-import { dataKeyCount, eventFields, hasRunningDebugContainer, hpaProblems, ingressHosts, jobPhase, jobStatus, nodeAddress, nodeConditions, nodeRoles, nodeStatus, nodeTaints, ownerReference, parseQuantity, podRequestTotals, podSummary, serviceLoadBalancerAddresses, servicePorts, statusLikeName, workloadReady } from '../kube-display.js';
+import { crdStatus, crdVersions, dataKeyCount, eventFields, hasRunningDebugContainer, hpaProblems, ingressHosts, jobPhase, jobStatus, nodeAddress, nodeConditions, nodeRoles, nodeStatus, nodeTaints, ownerReference, parseQuantity, podRequestTotals, podSummary, serviceLoadBalancerAddresses, servicePorts, statusLikeName, workloadReady } from '../kube-display.js';
 import { cronHumanText, cronNextRun } from '../cron.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { UsageMeter } from './UsageMeter.js';
@@ -526,6 +526,42 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
     width: 220,
     valueGetter: (_v, row) => ((obj(row).spec as { providerID?: string })?.providerID ?? ''),
     renderCell: (params) => <TextCell value={String(params.value ?? '')} />,
+  }),
+  crdKind: () => ({
+    field: 'crdKind',
+    headerName: 'Kind',
+    flex: 1,
+    minWidth: 160,
+    valueGetter: (_v, row) => (obj(row).spec as { names?: { kind?: string } })?.names?.kind ?? '',
+  }),
+  crdGroup: () => ({
+    field: 'crdGroup',
+    headerName: 'Group',
+    flex: 1,
+    minWidth: 170,
+    valueGetter: (_v, row) => (obj(row).spec as { group?: string })?.group ?? '',
+    renderCell: (params) => <TextCell value={String(params.value ?? '')} />,
+  }),
+  crdScope: () => ({
+    field: 'crdScope',
+    headerName: 'Scope',
+    width: 105,
+    valueGetter: (_v, row) => (obj(row).spec as { scope?: string })?.scope ?? '',
+  }),
+  crdVersions: () => ({
+    field: 'crdVersions',
+    headerName: 'Versions',
+    description: 'Served versions; * marks the storage version',
+    width: 120,
+    valueGetter: (_v, row) => crdVersions(obj(row)),
+    renderCell: (params) => <TextCell value={String(params.value ?? '')} />,
+  }),
+  crdStatus: () => ({
+    field: 'crdStatus',
+    headerName: 'Status',
+    width: 105,
+    valueGetter: (_v, row) => crdStatus(obj(row)),
+    renderCell: (params) => <StatusChip status={String(params.value ?? '')} />,
   }),
   nsStatus: () => ({
     field: 'nsStatus',

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -71,7 +71,7 @@ export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; nam
 
           <FailingPodsCard ctx={ctx} pods={data.failingPods} hideNamespace={single} />
 
-          <WarningEventsCard events={data.warningEvents} />
+          <WarningEventsCard ctx={ctx} events={data.warningEvents} />
 
           {healthy && (
             <Alert severity="success" variant="outlined">

--- a/client/src/components/overview/cards.tsx
+++ b/client/src/components/overview/cards.tsx
@@ -74,7 +74,8 @@ export function WarningEventsCard({ ctx, events }: { ctx: string; events: Overvi
       <Stack spacing={0.5}>
         {events.slice(0, 15).map((e) => {
           const gvr = e.involvedGvr ?? gvkForKind(e.involvedKind) ?? kindFromDiscovery(e.involvedKind);
-          const label = `${e.involvedKind}/${e.namespace ? `${e.namespace}/` : ''}${e.involvedName}`;
+          const namespace = gvr?.namespaced === false ? undefined : e.namespace || undefined;
+          const label = `${e.involvedKind}/${namespace ? `${namespace}/` : ''}${e.involvedName}`;
           return (
             <Typography key={`${e.namespace}/${e.involvedKind}/${e.involvedName}/${e.reason}/${e.lastTimestamp ?? ''}/${e.message}`} variant="body2">
               <Typography component="span" variant="body2" sx={{ color: 'warning.main', fontWeight: 600 }}>
@@ -92,7 +93,7 @@ export function WarningEventsCard({ ctx, events }: { ctx: string; events: Overvi
               {gvr ? (
                 <Link
                   component={RouterLink}
-                  to={kindListPath(gvr, { sel: { ctx, namespace: e.namespace || undefined, name: e.involvedName } })}
+                  to={kindListPath(gvr, { sel: { ctx, namespace, name: e.involvedName } })}
                   underline="hover"
                   sx={{ fontWeight: 500 }}
                 >

--- a/client/src/components/overview/cards.tsx
+++ b/client/src/components/overview/cards.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Grid from '@mui/material/Grid';
+import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -10,10 +11,11 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { alpha } from '@mui/material/styles';
-import { useNavigate } from 'react-router';
-import type { OverviewProblemPod, OverviewWarningEvent } from '@kubus/shared';
+import { Link as RouterLink, useNavigate } from 'react-router';
+import { gvkForKind, type OverviewProblemPod, type OverviewWarningEvent } from '@kubus/shared';
 import { AgeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
+import { useApiResources } from '../../api/queries.js';
 import { kindListPath } from '../../resource-links.js';
 
 export { kindListPath };
@@ -58,27 +60,51 @@ export function FailingPodsCard({ ctx, pods, hideNamespace }: { ctx: string; pod
   );
 }
 
-export function WarningEventsCard({ events }: { events: OverviewWarningEvent[] }) {
+export function WarningEventsCard({ ctx, events }: { ctx: string; events: OverviewWarningEvent[] }) {
+  const { data: apiResources } = useApiResources(events.length > 0 ? ctx : undefined);
   if (events.length === 0) return null;
+  // Server-side resolution can miss (payload from an older server, discovery
+  // hiccup); fall back to the builtin table, then the cached discovery list.
+  const kindFromDiscovery = (kind: string) => {
+    const byKind = apiResources?.filter((k) => k.kind === kind) ?? [];
+    return byKind.find((k) => !k.custom) ?? byKind[0];
+  };
   return (
     <ProblemCard title="Warning events (1h)">
       <Stack spacing={0.5}>
-        {events.slice(0, 15).map((e) => (
-          <Typography key={`${e.namespace}/${e.involvedKind}/${e.involvedName}/${e.reason}/${e.lastTimestamp ?? ''}/${e.message}`} variant="body2">
-            <Typography component="span" variant="body2" sx={{ color: 'warning.main', fontWeight: 600 }}>
-              {e.reason}
-            </Typography>
-            {e.count > 1 && (
-              <Typography component="span" variant="caption" sx={{ fontWeight: 600 }}>
-                {' '}({e.count}x)
+        {events.slice(0, 15).map((e) => {
+          const gvr = e.involvedGvr ?? gvkForKind(e.involvedKind) ?? kindFromDiscovery(e.involvedKind);
+          const label = `${e.involvedKind}/${e.namespace ? `${e.namespace}/` : ''}${e.involvedName}`;
+          return (
+            <Typography key={`${e.namespace}/${e.involvedKind}/${e.involvedName}/${e.reason}/${e.lastTimestamp ?? ''}/${e.message}`} variant="body2">
+              <Typography component="span" variant="body2" sx={{ color: 'warning.main', fontWeight: 600 }}>
+                {e.reason}
               </Typography>
-            )}{' '}
-            <Typography component="span" variant="caption" color="text.secondary">
-              <AgeCell timestamp={e.lastTimestamp} /> ago
-            </Typography>{' '}
-            — {e.involvedKind}/{e.namespace ? `${e.namespace}/` : ''}{e.involvedName}: {e.message}
-          </Typography>
-        ))}
+              {e.count > 1 && (
+                <Typography component="span" variant="caption" sx={{ fontWeight: 600 }}>
+                  {' '}({e.count}x)
+                </Typography>
+              )}{' '}
+              <Typography component="span" variant="caption" color="text.secondary">
+                <AgeCell timestamp={e.lastTimestamp} /> ago
+              </Typography>{' '}
+              —{' '}
+              {gvr ? (
+                <Link
+                  component={RouterLink}
+                  to={kindListPath(gvr, { sel: { ctx, namespace: e.namespace || undefined, name: e.involvedName } })}
+                  underline="hover"
+                  sx={{ fontWeight: 500 }}
+                >
+                  {label}
+                </Link>
+              ) : (
+                label
+              )}
+              : {e.message}
+            </Typography>
+          );
+        })}
       </Stack>
     </ProblemCard>
   );

--- a/client/src/kube-display.ts
+++ b/client/src/kube-display.ts
@@ -152,6 +152,26 @@ export function dataKeyCount(obj: KubeObject): number {
   return Object.keys((obj.data as Record<string, unknown> | undefined) ?? {}).length;
 }
 
+/** Served CRD versions in spec order, the storage version marked with an asterisk. */
+export function crdVersions(crd: KubeObject): string {
+  const versions = (crd.spec as { versions?: Array<{ name: string; served?: boolean; storage?: boolean }> })?.versions ?? [];
+  const served = versions.filter((v) => v.served !== false);
+  return (served.length ? served : versions).map((v) => `${v.name}${v.storage ? '*' : ''}`).join(', ');
+}
+
+/**
+ * Coarse CRD lifecycle status for the list Status column. Empty until the
+ * apiserver reports conditions so a just-created CRD shows no chip.
+ */
+export function crdStatus(crd: KubeObject): string {
+  if (crd.metadata.deletionTimestamp) return 'Terminating';
+  const conditions = (crd.status as { conditions?: Array<{ type?: string; status?: string }> } | undefined)?.conditions ?? [];
+  const has = (type: string, status: string) => conditions.some((c) => c.type === type && c.status === status);
+  if (has('Established', 'True')) return 'Active';
+  if (has('NamesAccepted', 'False')) return 'NameConflict';
+  return conditions.length ? 'NotEstablished' : '';
+}
+
 /**
  * Coarse Job lifecycle phase for the list Status column. Terminal conditions
  * win; otherwise suspension beats activity so a paused Job doesn't read as

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -43,8 +43,12 @@ import { GROUP_ICONS } from './tab-meta.js';
 const WIDTH = layout.navDrawerWidth;
 // Indent of group items so they line up under the group label (button pl 16px + icon 26px).
 const ITEM_INDENT = '42px';
+// Two deeper steps for the Custom Resources tree (domain → API group → kind).
+const SUB_INDENT = '54px';
+const KIND_INDENT = '66px';
 const FAVORITE_DRAG_TYPE = 'application/x-kubus-favorite';
 const CUSTOM_GROUP_PREFIX = 'custom:';
+const CRD_LIST_PATH = '/r/apiextensions.k8s.io/v1/customresourcedefinitions';
 
 
 /**
@@ -164,6 +168,50 @@ function dedupeCustomNavKinds(kinds: ResourceKindInfo[]): ResourceKindInfo[] {
   return [...byKind.values()];
 }
 
+interface CustomSubgroup {
+  /** Full API group, e.g. `appstore.eda.nokia.com`. */
+  group: string;
+  /** Group with the shared domain stripped, e.g. `appstore.eda`. */
+  label: string;
+  kinds: ResourceKindInfo[];
+}
+
+/**
+ * One top-level entry under Custom Resources: a lone API group shown by its
+ * full name, or a domain (last two dot-labels, e.g. `nokia.com`) folding the
+ * groups that share it. A group named exactly like the domain contributes its
+ * kinds directly to the domain entry rather than an empty-labelled subgroup.
+ */
+interface CustomNavNode {
+  label: string;
+  kinds: ResourceKindInfo[];
+  subgroups: CustomSubgroup[];
+}
+
+function buildCustomNav(customKinds: Array<[string, ResourceKindInfo[]]>): CustomNavNode[] {
+  const byDomain = new Map<string, Array<{ group: string; kinds: ResourceKindInfo[] }>>();
+  for (const [group, kinds] of customKinds) {
+    const domain = group.split('.').slice(-2).join('.');
+    const list = byDomain.get(domain) ?? [];
+    list.push({ group, kinds });
+    byDomain.set(domain, list);
+  }
+  const nodes: CustomNavNode[] = [];
+  for (const [domain, groups] of byDomain) {
+    if (groups.length === 1) {
+      nodes.push({ label: groups[0]!.group, kinds: groups[0]!.kinds, subgroups: [] });
+      continue;
+    }
+    const own = groups.find((g) => g.group === domain);
+    const subgroups = groups
+      .filter((g) => g.group !== domain)
+      .map((g) => ({ group: g.group, label: g.group.slice(0, -(domain.length + 1)), kinds: g.kinds }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    nodes.push({ label: domain, kinds: own?.kinds ?? [], subgroups });
+  }
+  return nodes.sort((a, b) => a.label.localeCompare(b.label));
+}
+
 function NavEntry({
   to,
   label,
@@ -173,6 +221,7 @@ function NavEntry({
   favoriteAction,
   hotkey,
   onIntent,
+  indent,
 }: {
   to: string;
   label: string;
@@ -184,6 +233,8 @@ function NavEntry({
   hotkey?: string;
   /** Fired on hover/focus — used to preload the target's heavy chunks. */
   onIntent?: () => void;
+  /** Left padding override for entries nested below the default group level. */
+  indent?: string;
 }) {
   const location = useLocation();
   const active = location.pathname === to;
@@ -200,7 +251,7 @@ function NavEntry({
       onMouseEnter={onIntent}
       onFocus={onIntent}
       {...newTabHandlers}
-      sx={{ pl: icon ? 1.5 : ITEM_INDENT, py: subtitle ? 0.25 : 0.375, pr: favorite ? (favoriteAction ? 7 : 4) : undefined }}
+      sx={{ pl: icon ? 1.5 : (indent ?? ITEM_INDENT), py: subtitle ? 0.25 : 0.375, pr: favorite ? (favoriteAction ? 7 : 4) : undefined }}
     >
       {icon && (
         <ListItemIcon sx={{ minWidth: 26, color: 'text.secondary', '& svg': { fontSize: 17 } }}>{icon}</ListItemIcon>
@@ -357,6 +408,86 @@ function GroupHeader({
         />
       </ListItemButton>
     </ListItem>
+  );
+}
+
+/** Collapsible domain / API-group header inside the Custom Resources tree. */
+function CustomGroupHeader({
+  label,
+  title,
+  count,
+  indent,
+  open,
+  active,
+  subordinate,
+  onClick,
+}: {
+  label: string;
+  /** Hover hint; defaults to the label (subgroups pass their full API group). */
+  title?: string;
+  count?: number;
+  indent: string;
+  open: boolean;
+  /** The current page lives inside this branch — color it as the active trail. */
+  active?: boolean;
+  /** Nested one level down; rendered lighter than top-level entries. */
+  subordinate?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <ListItemButton
+      dense
+      aria-expanded={open}
+      onClick={onClick}
+      sx={{ pl: indent, pr: 1.5, py: 0.25, mt: 0.5, color: active ? 'primary.main' : open ? 'text.primary' : 'text.secondary' }}
+    >
+      <ListItemText
+        primary={label}
+        slotProps={{ primary: { variant: 'caption', noWrap: true, title: title ?? label, sx: { fontWeight: subordinate ? 600 : 700, lineHeight: 1.4 } } }}
+      />
+      {count !== undefined && (
+        <Typography variant="caption" aria-hidden sx={{ ml: 0.5, color: 'text.disabled', fontVariantNumeric: 'tabular-nums' }}>
+          {count}
+        </Typography>
+      )}
+      <ExpandMoreIcon
+        sx={{ ml: 0.5, fontSize: 15, opacity: 0.6, flexShrink: 0, transform: open ? 'none' : 'rotate(-90deg)', transition: 'transform 120ms ease' }}
+      />
+    </ListItemButton>
+  );
+}
+
+/**
+ * Children of an expanded Custom Resources level: a faint panel tint plus,
+ * on the first level only, an indent guide rail aligned under the parent
+ * label — a second rail per nesting level reads as clutter. The rail takes
+ * the accent color while the branch contains the current page.
+ */
+function TreeChildren({ railLeft, active, children }: { railLeft?: string; active?: boolean; children: ReactNode }) {
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.025)' : 'rgba(0,0,0,0.02)'),
+        ...(railLeft && {
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            left: railLeft,
+            top: 3,
+            bottom: 3,
+            width: '2px',
+            borderRadius: 1,
+            bgcolor: active ? 'primary.main' : 'divider',
+            opacity: active ? 0.55 : 1,
+            pointerEvents: 'none',
+            zIndex: 1,
+          },
+        }),
+      }}
+    >
+      {children}
+    </Box>
   );
 }
 
@@ -548,6 +679,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
     }
     return [...byGroup.entries()].sort(([a], [b]) => a.localeCompare(b));
   }, [apiResources]);
+  const customNav = useMemo(() => buildCustomNav(customKinds), [customKinds]);
 
   // Group chain (outermost first) containing each kind path, used to reveal
   // the entry for the active resource after a cross-kind jump.
@@ -556,13 +688,18 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
     for (const group of BUILTIN_NAV_GROUPS) {
       for (const k of group.kinds) map.set(kindPath(k.group, k.version, k.plural), [group.title]);
     }
-    for (const [groupName, kinds] of customKinds) {
-      for (const k of kinds) {
-        map.set(kindPath(k.group, k.version, k.plural), ['Custom Resources', `${CUSTOM_GROUP_PREFIX}${groupName}`]);
+    map.set(CRD_LIST_PATH, ['Custom Resources']);
+    for (const node of customNav) {
+      const nodeKey = `${CUSTOM_GROUP_PREFIX}${node.label}`;
+      for (const k of node.kinds) map.set(kindPath(k.group, k.version, k.plural), ['Custom Resources', nodeKey]);
+      for (const sg of node.subgroups) {
+        for (const k of sg.kinds) {
+          map.set(kindPath(k.group, k.version, k.plural), ['Custom Resources', nodeKey, `${CUSTOM_GROUP_PREFIX}${sg.group}`]);
+        }
       }
     }
     return map;
-  }, [customKinds]);
+  }, [customNav]);
 
   const listRef = useRef<HTMLUListElement | null>(null);
   // Bring the active entry into view. A just-expanded Collapse animates open,
@@ -655,6 +792,8 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
 
   const f = deferredFilter.toLowerCase();
   const matches = (label: string) => !f || label.toLowerCase().includes(f);
+  // Branch containing the current page, for active-trail coloring in the tree.
+  const activeChain = groupChainByPath.get(location.pathname) ?? [];
   // While filtering, always expand so matches are visible. CRD API groups are
   // discovered dynamically, so they use the set as an explicit open override.
   const isOpen = (title: string) => !!f || (title.startsWith(CUSTOM_GROUP_PREFIX) ? collapsed.has(title) : !collapsed.has(title));
@@ -866,42 +1005,80 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
               favorite={{ active: isFav('category:Custom Resources'), onToggle: () => toggleCategory('Custom Resources') }}
             />
             <Collapse in={isOpen('Custom Resources')}>
-              {customKinds.map(([groupName, kinds]) => {
-                const groupMatches = matches(groupName);
-                const visible = groupMatches ? kinds : kinds.filter((k) => matches(k.kind));
-                if (!visible.length) return null;
-                const collapseKey = `${CUSTOM_GROUP_PREFIX}${groupName}`;
+              {(!f || 'crd definitions customresourcedefinitions'.includes(f)) && (
+                <NavEntry
+                  to={CRD_LIST_PATH}
+                  label="Definitions"
+                  favorite={kindFavorite({
+                    group: 'apiextensions.k8s.io',
+                    version: 'v1',
+                    plural: 'customresourcedefinitions',
+                    kind: 'CustomResourceDefinition',
+                    label: 'CRD Definitions',
+                  })}
+                />
+              )}
+              {customNav.map((node) => {
+                const nodeKey = `${CUSTOM_GROUP_PREFIX}${node.label}`;
+                const nodeMatches = matches(node.label);
+                const ownKinds = nodeMatches ? node.kinds : node.kinds.filter((k) => matches(k.kind));
+                const subgroups = node.subgroups
+                  .map((sg) => ({ ...sg, kinds: nodeMatches || matches(sg.group) ? sg.kinds : sg.kinds.filter((k) => matches(k.kind)) }))
+                  .filter((sg) => sg.kinds.length > 0);
+                if (!ownKinds.length && !subgroups.length) return null;
+                const kindCount = node.kinds.length + node.subgroups.reduce((n, sg) => n + sg.kinds.length, 0);
                 return (
-                  <Box key={groupName}>
-                    <ListItemButton
-                      dense
-                      aria-expanded={isOpen(collapseKey)}
-                      onClick={() => toggleGroup(collapseKey)}
-                      sx={{ pl: ITEM_INDENT, pr: 1.5, py: 0.25, mt: 0.5, color: 'text.secondary' }}
-                    >
-                      <ListItemText
-                        primary={groupName}
-                        slotProps={{ primary: { variant: 'caption', noWrap: true, title: groupName, sx: { fontWeight: 700, lineHeight: 1.4 } } }}
-                      />
-                      <ExpandMoreIcon
-                        sx={{
-                          ml: 0.5,
-                          fontSize: 15,
-                          opacity: 0.6,
-                          transform: isOpen(collapseKey) ? 'none' : 'rotate(-90deg)',
-                          transition: 'transform 120ms ease',
-                        }}
-                      />
-                    </ListItemButton>
-                    <Collapse in={isOpen(collapseKey)}>
-                      {visible.map((k) => (
-                        <NavEntry
-                          key={`${k.group}/${k.version}/${k.plural}`}
-                          to={kindPath(k.group, k.version, k.plural)}
-                          label={k.kind}
-                          favorite={kindFavorite({ group: k.group, version: k.version, plural: k.plural, kind: k.kind, label: k.kind })}
-                        />
-                      ))}
+                  <Box key={node.label}>
+                    <CustomGroupHeader
+                      label={node.label}
+                      count={kindCount}
+                      indent={ITEM_INDENT}
+                      open={isOpen(nodeKey)}
+                      active={activeChain.includes(nodeKey)}
+                      onClick={() => toggleGroup(nodeKey)}
+                    />
+                    <Collapse in={isOpen(nodeKey)}>
+                      <TreeChildren railLeft="45px" active={activeChain.includes(nodeKey)}>
+                        {ownKinds.map((k) => (
+                          <NavEntry
+                            key={`${k.group}/${k.version}/${k.plural}`}
+                            to={kindPath(k.group, k.version, k.plural)}
+                            label={k.kind}
+                            indent={SUB_INDENT}
+                            favorite={kindFavorite({ group: k.group, version: k.version, plural: k.plural, kind: k.kind, label: k.kind })}
+                          />
+                        ))}
+                        {subgroups.map((sg) => {
+                          const sgKey = `${CUSTOM_GROUP_PREFIX}${sg.group}`;
+                          return (
+                            <Box key={sg.group}>
+                              <CustomGroupHeader
+                                label={sg.label}
+                                title={sg.group}
+                                count={sg.kinds.length}
+                                indent={SUB_INDENT}
+                                open={isOpen(sgKey)}
+                                active={activeChain.includes(sgKey)}
+                                subordinate
+                                onClick={() => toggleGroup(sgKey)}
+                              />
+                              <Collapse in={isOpen(sgKey)}>
+                                <TreeChildren>
+                                  {sg.kinds.map((k) => (
+                                    <NavEntry
+                                      key={`${k.group}/${k.version}/${k.plural}`}
+                                      to={kindPath(k.group, k.version, k.plural)}
+                                      label={k.kind}
+                                      indent={KIND_INDENT}
+                                      favorite={kindFavorite({ group: k.group, version: k.version, plural: k.plural, kind: k.kind, label: k.kind })}
+                                    />
+                                  ))}
+                                </TreeChildren>
+                              </Collapse>
+                            </Box>
+                          );
+                        })}
+                      </TreeChildren>
                     </Collapse>
                   </Box>
                 );

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -254,7 +254,7 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
             </ProblemCard>
           )}
 
-          <WarningEventsCard events={data.warningEvents} />
+          <WarningEventsCard ctx={ctx} events={data.warningEvents} />
 
           {data.failingPods.length === 0 &&
             data.unavailableWorkloads.length === 0 &&

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -40,8 +40,10 @@ import { isTextEntryTarget } from '../text-entry.js';
 import { addLabelTerm } from '../label-selector.js';
 import { podContainerNames } from '../kube-display.js';
 
-// Wide, rarely-needed builtin columns start hidden; the column menu re-enables them.
-const BUILTIN_HIDDEN_FIELDS: Record<string, string[]> = { Node: ['nodeProviderID'] };
+// Wide, rarely-needed builtin columns start hidden; the column menu re-enables
+// them. Labels carry no signal on CRDs, so the Kind/Group/Scope columns take
+// their place there.
+const BUILTIN_HIDDEN_FIELDS: Record<string, string[]> = { Node: ['nodeProviderID'], CustomResourceDefinition: ['labels'] };
 
 /**
  * Renderless bridge between this page's URL params and the shared detail

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/server/src/kube/namespace-overview.ts
+++ b/server/src/kube/namespace-overview.ts
@@ -154,7 +154,7 @@ export async function computeNamespaceOverview(handle: ClusterHandle, namespaces
       issues: health.issues,
       failingPods,
       quotas,
-      warningEvents: collectWarningEvents(events, now),
+      warningEvents: collectWarningEvents(events, now, await handle.discovery.getResources().catch(() => [])),
       operators: await computeOperatorRollups(handle, crdsResult.items, scope),
       certificates: await collectCertificates(handle, crdsResult.items, scope),
     };

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -200,7 +200,7 @@ export function collectWarningEvents(events: KubeObject[], now: number, kinds: R
 function resolveInvolvedGvr(
   kinds: ResourceKindInfo[],
   involved: { apiVersion?: string; kind?: string } | undefined,
-): { group: string; version: string; plural: string } | undefined {
+): { group: string; version: string; plural: string; namespaced: boolean } | undefined {
   const kind = involved?.kind;
   if (!kind) return undefined;
   const byKind = kinds.filter((k) => k.kind === kind);
@@ -218,7 +218,7 @@ function resolveInvolvedGvr(
     inGroup[0] ??
     byKind.find((k) => !k.custom) ??
     byKind[0];
-  return match ? { group: match.group, version: match.version, plural: match.plural } : undefined;
+  return match ? { group: match.group, version: match.version, plural: match.plural, namespaced: match.namespaced } : undefined;
 }
 
 function eventTime(e: KubeObject): string {

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -1,4 +1,4 @@
-import type { ClusterOverview, KubeObject, OverviewWarningEvent } from '@kubus/shared';
+import type { ClusterOverview, KubeObject, OverviewWarningEvent, ResourceKindInfo } from '@kubus/shared';
 import { apiServerCertNotAfter, collectCertificates } from './cert-expiry.js';
 import type { ClusterHandle } from './cluster-manager.js';
 import { computeOperatorRollups } from './operator-rollups.js';
@@ -117,7 +117,7 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       }
     }
 
-    overview.warningEvents = collectWarningEvents(events, now);
+    overview.warningEvents = collectWarningEvents(events, now, await handle.discovery.getResources().catch(() => []));
 
     overview.failingPods.sort((a, b) => `${a.namespace}/${a.name}`.localeCompare(`${b.namespace}/${b.name}`));
     overview.recentRestarts.sort((a, b) => (b.finishedAt ?? '').localeCompare(a.finishedAt ?? ''));
@@ -160,7 +160,7 @@ export function podFailure(pod: KubeObject, now: number): { reason: string; mess
 }
 
 /** Warning events within the 1h window, newest first, capped at 50. */
-export function collectWarningEvents(events: KubeObject[], now: number): OverviewWarningEvent[] {
+export function collectWarningEvents(events: KubeObject[], now: number, kinds: ResourceKindInfo[] = []): OverviewWarningEvent[] {
   return events
     .flatMap((e) => {
       if ((e as { type?: string }).type !== 'Warning') return [];
@@ -176,7 +176,7 @@ export function collectWarningEvents(events: KubeObject[], now: number): Overvie
         message?: string;
         count?: number;
         lastTimestamp?: string;
-        involvedObject?: { kind?: string; name?: string };
+        involvedObject?: { apiVersion?: string; kind?: string; name?: string };
       };
       return {
         namespace: e.metadata.namespace ?? '',
@@ -184,10 +184,41 @@ export function collectWarningEvents(events: KubeObject[], now: number): Overvie
         message: ev.message ?? '',
         involvedKind: ev.involvedObject?.kind ?? '',
         involvedName: ev.involvedObject?.name ?? '',
+        involvedGvr: resolveInvolvedGvr(kinds, ev.involvedObject),
         count: ev.count ?? 1,
         lastTimestamp: time || undefined,
       };
     });
+}
+
+/**
+ * Resolve an event's involvedObject to its list GVR via discovery, so the
+ * client can deep-link it. Controllers are sloppy about apiVersion (bare
+ * group, stale version, or missing entirely), so this degrades from an exact
+ * group+version match down to a by-kind lookup rather than giving up.
+ */
+function resolveInvolvedGvr(
+  kinds: ResourceKindInfo[],
+  involved: { apiVersion?: string; kind?: string } | undefined,
+): { group: string; version: string; plural: string } | undefined {
+  const kind = involved?.kind;
+  if (!kind) return undefined;
+  const byKind = kinds.filter((k) => k.kind === kind);
+  if (byKind.length === 0) return undefined;
+  const apiVersion = involved.apiVersion ?? '';
+  let group = '';
+  let version = '';
+  if (apiVersion.includes('/')) [group = '', version = ''] = apiVersion.split('/');
+  else if (apiVersion.includes('.')) group = apiVersion; // bare group, e.g. "core.eda.nokia.com"
+  else version = apiVersion; // core-group version, e.g. "v1"
+  const inGroup = group ? byKind.filter((k) => k.group === group) : byKind;
+  const match =
+    inGroup.find((k) => version && k.version === version) ??
+    inGroup.find((k) => !k.custom) ??
+    inGroup[0] ??
+    byKind.find((k) => !k.custom) ??
+    byKind[0];
+  return match ? { group: match.group, version: match.version, plural: match.plural } : undefined;
 }
 
 function eventTime(e: KubeObject): string {

--- a/server/src/routes/graph.ts
+++ b/server/src/routes/graph.ts
@@ -460,28 +460,40 @@ function focusGraph(graph: RelationshipGraph, query: FocusQuery): RelationshipGr
       : graph;
   }
   const depth = Math.max(1, Math.min(4, Number(query.depth ?? 2)));
-  const adjacency = new Map<string, Set<string>>();
-  const neighborsOf = (id: string): Set<string> => {
-    let set = adjacency.get(id);
-    if (!set) {
-      set = new Set();
-      adjacency.set(id, set);
+  // Walking schedules/mounts edges backwards enumerates every consumer of a
+  // shared resource (all pods on a node, all pods mounting a configmap), which
+  // would flood a focused pod's map with unrelated siblings. Keep such shared
+  // resources as leaves — unless the focus itself is the shared resource,
+  // where listing its consumers is the point.
+  const fanInKinds = new Set<GraphEdge['kind']>(['schedules', 'mounts']);
+  const adjacency = new Map<string, Array<{ id: string; fanIn: boolean }>>();
+  const neighborsOf = (id: string): Array<{ id: string; fanIn: boolean }> => {
+    let list = adjacency.get(id);
+    if (!list) {
+      list = [];
+      adjacency.set(id, list);
     }
-    return set;
+    return list;
   };
   for (const edge of graph.edges) {
-    neighborsOf(edge.source).add(edge.target);
-    neighborsOf(edge.target).add(edge.source);
+    neighborsOf(edge.source).push({ id: edge.target, fanIn: false });
+    neighborsOf(edge.target).push({ id: edge.source, fanIn: fanInKinds.has(edge.kind) });
   }
+  // Cluster nodes are terminal for the same reason: expanding through one
+  // reaches its static pods (mirror pods are owner-referenced by the Node).
+  const infraLeafIds = new Set(
+    graph.nodes.filter((node) => node.id !== focus.id && node.ref.group === '' && node.ref.plural === 'nodes').map((node) => node.id),
+  );
   const keep = new Set<string>([focus.id]);
   let frontier = new Set<string>([focus.id]);
   for (let i = 0; i < depth; i++) {
     const next = new Set<string>();
     for (const id of frontier) {
-      for (const neighbor of adjacency.get(id) ?? []) {
-        if (keep.has(neighbor)) continue;
-        keep.add(neighbor);
-        next.add(neighbor);
+      for (const step of adjacency.get(id) ?? []) {
+        if (step.fanIn && id !== focus.id) continue;
+        if (keep.has(step.id)) continue;
+        keep.add(step.id);
+        if (!infraLeafIds.has(step.id)) next.add(step.id);
       }
     }
     frontier = next;

--- a/server/test/overview.test.mjs
+++ b/server/test/overview.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { collectWarningEvents } from '../dist/kube/overview.js';
+
+const now = Date.parse('2026-07-21T12:00:00Z');
+
+const resources = [
+  { group: '', version: 'v1', kind: 'Node', plural: 'nodes', namespaced: false },
+  { group: '', version: 'v1', kind: 'Pod', plural: 'pods', namespaced: true },
+];
+
+function warningEvent(namespace, involvedObject) {
+  return {
+    apiVersion: 'v1',
+    kind: 'Event',
+    metadata: { name: `${involvedObject.name}.warning`, namespace },
+    type: 'Warning',
+    reason: 'Unhealthy',
+    message: 'probe failed',
+    lastTimestamp: '2026-07-21T11:59:00Z',
+    involvedObject,
+  };
+}
+
+void test('warning-event targets carry resource scope for deep links', () => {
+  const events = collectWarningEvents(
+    [
+      warningEvent('default', { apiVersion: 'v1', kind: 'Node', name: 'worker-1' }),
+      warningEvent('apps', { apiVersion: 'v1', kind: 'Pod', name: 'api-0' }),
+    ],
+    now,
+    resources,
+  );
+
+  assert.deepEqual(events.map((event) => event.involvedGvr), [
+    { group: '', version: 'v1', plural: 'nodes', namespaced: false },
+    { group: '', version: 'v1', plural: 'pods', namespaced: true },
+  ]);
+});

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -741,8 +741,8 @@ export interface OverviewWarningEvent {
   message: string;
   involvedKind: string;
   involvedName: string;
-  /** List GVR of the involved object, resolved via discovery — undefined when the kind is unknown (e.g. uninstalled CRD). */
-  involvedGvr?: { group: string; version: string; plural: string };
+  /** List GVR and scope of the involved object, resolved via discovery — undefined when the kind is unknown (e.g. uninstalled CRD). */
+  involvedGvr?: { group: string; version: string; plural: string; namespaced: boolean };
   count: number;
   lastTimestamp?: string;
 }

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -741,6 +741,8 @@ export interface OverviewWarningEvent {
   message: string;
   involvedKind: string;
   involvedName: string;
+  /** List GVR of the involved object, resolved via discovery — undefined when the kind is unknown (e.g. uninstalled CRD). */
+  involvedGvr?: { group: string; version: string; plural: string };
   count: number;
   lastTimestamp?: string;
 }

--- a/shared/src/resource-meta.ts
+++ b/shared/src/resource-meta.ts
@@ -91,6 +91,15 @@ export const BUILTIN_NAV_GROUPS: NavGroup[] = [
   },
 ];
 
+/**
+ * Builtin kinds reachable outside the nav groups (Overview cards, the
+ * Custom Resources → Definitions entry). Registered in the GVK lookups so
+ * their lists get kind-specific behavior, but not shown as nav groups.
+ */
+const EXTRA_BUILTIN_KINDS: GVK[] = [
+  { group: 'apiextensions.k8s.io', version: 'v1', plural: 'customresourcedefinitions', kind: 'CustomResourceDefinition', namespaced: false },
+];
+
 /** Semantic column ids per kind; the client maps these to renderers. */
 export const KIND_COLUMNS: Record<string, string[]> = {
   Pod: ['name', 'namespace', 'cluster', 'ready', 'podStatus', 'restarts', 'cpu', 'memory', 'node', 'age'],
@@ -127,6 +136,7 @@ export const KIND_COLUMNS: Record<string, string[]> = {
     'nodeProviderID',
   ],
   Namespace: ['name', 'cluster', 'nsStatus', 'age'],
+  CustomResourceDefinition: ['name', 'cluster', 'crdKind', 'crdGroup', 'crdScope', 'crdVersions', 'crdStatus', 'age'],
   Event: ['eventType', 'eventReason', 'eventObject', 'eventMessage', 'namespace', 'cluster', 'eventCount', 'eventLastSeen'],
   HorizontalPodAutoscaler: ['name', 'namespace', 'cluster', 'hpaTarget', 'hpaMinMax', 'hpaReplicas', 'hpaConditions', 'age'],
   ServiceAccount: ['name', 'namespace', 'cluster', 'age'],
@@ -152,12 +162,10 @@ export function pluralLabel(kind: string): string {
 
 const GVK_BY_KIND = new Map<string, GVK>();
 const GVK_BY_RESOURCE = new Map<string, GVK>();
-for (const navGroup of BUILTIN_NAV_GROUPS) {
-  for (const gvk of navGroup.kinds) {
-    if (!GVK_BY_KIND.has(gvk.kind)) GVK_BY_KIND.set(gvk.kind, gvk);
-    const key = `${gvk.group}/${gvk.version}/${gvk.plural}`;
-    if (!GVK_BY_RESOURCE.has(key)) GVK_BY_RESOURCE.set(key, gvk);
-  }
+for (const gvk of [...BUILTIN_NAV_GROUPS.flatMap((navGroup) => navGroup.kinds), ...EXTRA_BUILTIN_KINDS]) {
+  if (!GVK_BY_KIND.has(gvk.kind)) GVK_BY_KIND.set(gvk.kind, gvk);
+  const key = `${gvk.group}/${gvk.version}/${gvk.plural}`;
+  if (!GVK_BY_RESOURCE.has(key)) GVK_BY_RESOURCE.set(key, gvk);
 }
 
 /** Look up the GVK for a builtin kind (e.g. to navigate to a related resource). */


### PR DESCRIPTION
## Changes

- **Resource map: selection z-order** — edges paint in array order within the xyflow edge layer, so dimmed edges drawn after a highlighted one masked it with their background halos. The selected node's edges now always paint on top.
- **Resource map: focused graph scope** — a pod's map no longer pulls in every pod on the same node or every consumer of a shared configmap. The focus BFS treats shared infrastructure (Node via `schedules`/owner-refs, ConfigMaps/Secrets/PVCs via `mounts`) as terminal leaves, unless the shared resource is itself the focus — focusing a Node or ConfigMap still lists all its consumers. Verified against kind: a coredns pod's map shrinks from the whole namespace to its own chain (Service, Deployment, ReplicaSet, sibling pod, ConfigMap, Node).
- **Warning events** — link warning-event resources and mark request overshoot on usage bars.
- **CRD grouping** in the navigation.
- **Bump to 0.6.1.**