### PR TITLE
Use kubus-app.dev for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ your local machine. It uses your existing kubeconfig to browse and edit
 resources, stream logs, open shells, forward ports, watch metrics, inspect Helm
 releases, and more.
 
-**The docs are the main entry point:** [flosch62.github.io/Kubus](https://flosch62.github.io/Kubus/)
+**The docs are the main entry point:** [kubus-app.dev](https://kubus-app.dev/)
 
 [![vid](docs/assets/overview-play.png)](https://www.youtube.com/watch?v=b86yKodD5Mw)
 
 ## Start Here
 
-- [Install Kubus](https://flosch62.github.io/Kubus/install/)
-- [Quickstart](https://flosch62.github.io/Kubus/quickstart/)
-- [User guide](https://flosch62.github.io/Kubus/guide/)
-- [Reference](https://flosch62.github.io/Kubus/reference/)
-- [Contributing and development](https://flosch62.github.io/Kubus/community/)
+- [Install Kubus](https://kubus-app.dev/install/)
+- [Quickstart](https://kubus-app.dev/quickstart/)
+- [User guide](https://kubus-app.dev/guide/)
+- [Reference](https://kubus-app.dev/reference/)
+- [Contributing and development](https://kubus-app.dev/community/)
 - [Desktop releases](https://github.com/FloSch62/Kubus/releases)
 
 

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -30,7 +30,7 @@ const isLinux = process.platform === 'linux';
 
 // Must match the client TopBar height: its toolbar doubles as the titlebar.
 const TITLEBAR_HEIGHT = 52;
-const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/Kubus/latest.json';
+const UPDATE_MANIFEST_URL = 'https://kubus-app.dev/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 
 let mainWindow: BrowserWindow | undefined;

--- a/server/src/routes/app.ts
+++ b/server/src/routes/app.ts
@@ -6,7 +6,7 @@ import type { AppInfo, UpdateCheckResult } from '@kubus/shared';
 import type { AppContext } from '../app.js';
 import { engineAvailable } from '../helm/engine.js';
 
-const UPDATE_MANIFEST_URL = 'https://flosch62.github.io/Kubus/latest.json';
+const UPDATE_MANIFEST_URL = 'https://kubus-app.dev/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 
 interface UpdateManifest {

--- a/zensical.toml
+++ b/zensical.toml
@@ -7,7 +7,7 @@
 site_name = "Kubus"
 site_description = "Kubus — a free, open-source Kubernetes GUI. Browse every cluster and resource, stream logs, open shells, forward ports, watch metrics and manage Helm — all from one local web UI."
 site_author = "Kubus authors"
-site_url = "https://flosch62.github.io/Kubus/"
+site_url = "https://kubus-app.dev/"
 
 copyright = """
 Copyright &copy; 2026 the Kubus authors — released under the MIT license.


### PR DESCRIPTION
## Summary

- set the documentation canonical URL and README links to `https://kubus-app.dev/`
- use the custom domain for update-manifest requests in the server and desktop application

## Why

GitHub Pages now serves the project documentation from `kubus-app.dev`. Keeping the old `flosch62.github.io/Kubus` URLs would leave stale canonical metadata and add an unnecessary redirect to update checks.

## Impact

Documentation links, canonical metadata, and update-manifest requests use the custom domain directly. The existing GitHub Pages address remains available through GitHub's redirect.

## Validation

- `pnpm build-docs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- verified the apex and `www` DNS records against multiple public resolvers
- verified the homepage, install page, stylesheet, and update manifest return HTTP 200 from GitHub Pages