### PR TITLE
Polish visual consistency and UX details

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,12 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kubus</title>
     <link rel="icon" type="image/svg+xml" href="/kubus.svg" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Inter/JetBrains Mono are bundled via @fontsource (see main.tsx) so the
+         desktop app renders identically offline. -->
     <style>
       html, body, #root { height: 100%; margin: 0; }
     </style>

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource/jetbrains-mono": "^5.3.0",
     "@kubus/shared": "workspace:*",
     "@monaco-editor/react": "^4.7.0",
     "@mui/icons-material": "^9.2.0",

--- a/client/src/components/ApiResourceDrawer.tsx
+++ b/client/src/components/ApiResourceDrawer.tsx
@@ -54,7 +54,7 @@ export function ApiResourceDrawer({ open, ctx, resource, onClose, onOpenCrd }: P
             <Typography variant="caption" color="text.secondary" noWrap sx={{ display: 'block' }}>
               {ctx ? `${ctx} · ` : ''}API Resource
             </Typography>
-            <Typography variant="subtitle1" noWrap sx={{ fontWeight: 650, lineHeight: 1.3 }}>
+            <Typography variant="subtitle1" noWrap sx={{ fontWeight: 600, lineHeight: 1.3 }}>
               {pluralLabel(resource.kind)}
             </Typography>
           </Box>
@@ -145,7 +145,7 @@ function InfoRow({ label, value }: { label: string; value: string | undefined })
   return (
     <TableRow>
       <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{label}</TableCell>
-      <TableCell sx={{ border: 0, wordBreak: 'break-all' }}>{value}</TableCell>
+      <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>{value}</TableCell>
     </TableRow>
   );
 }

--- a/client/src/components/CellCopy.tsx
+++ b/client/src/components/CellCopy.tsx
@@ -4,6 +4,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import type { GridColDef, GridEventListener, GridValidRowModel } from '@mui/x-data-grid';
 import { copyToClipboard } from '../clipboard.js';
+import { TruncationTooltip } from './truncation.js';
 
 /** The text a cell copies: the raw (unformatted) value the grid computed. */
 export function cellCopyText(value: unknown): string {
@@ -116,14 +117,17 @@ export function withCellCopy<R extends GridValidRowModel>(column: GridColDef<R>)
     display: column.display ?? 'flex',
     renderCell: (params) => {
       const text = cellCopyText(params.value);
+      const display = String(params.formattedValue ?? params.value ?? '');
       return (
         <>
           {original ? (
             original(params)
           ) : (
-            <span className="kubus-cell-text" style={{ textAlign: align }}>
-              {String(params.formattedValue ?? params.value ?? '')}
-            </span>
+            <TruncationTooltip text={display}>
+              <span className="kubus-cell-text" style={{ textAlign: align }}>
+                {display}
+              </span>
+            </TruncationTooltip>
           )}
           {text ? <CellCopyButton text={text} /> : null}
         </>

--- a/client/src/components/GoHint.tsx
+++ b/client/src/components/GoHint.tsx
@@ -59,14 +59,14 @@ export function GoHint() {
           transform: 'translateX(-50%)',
           zIndex: (theme) => theme.zIndex.snackbar,
           p: 1.25,
-          borderRadius: 2,
+          borderRadius: 1.5,
           border: 1,
           borderColor: 'divider',
           maxWidth: 'min(760px, calc(100vw - 32px))',
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1, mb: 0.75, px: 0.5 }}>
-          <Typography variant="caption" sx={{ fontWeight: 650 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600 }}>
             Go to
           </Typography>
           <Typography variant="caption" color="text.secondary">

--- a/client/src/components/HelmOperationStatus.tsx
+++ b/client/src/components/HelmOperationStatus.tsx
@@ -107,7 +107,7 @@ export function HelmOperationStatus({
 
       {running && operation.waitingFor?.length ? (
         <Box sx={{ mt: 0.75 }}>
-          <Typography variant="caption" sx={{ fontWeight: 650 }}>
+          <Typography variant="caption" sx={{ fontWeight: 600 }}>
             Waiting for
           </Typography>
           {operation.waitingFor.slice(0, compact ? 3 : 8).map((item) => (

--- a/client/src/components/LogViewer.tsx
+++ b/client/src/components/LogViewer.tsx
@@ -118,6 +118,14 @@ const LEVEL_STYLE: Record<LogLevel, { letter: string; color: string }> = {
   trace: { letter: 'T', color: '#6b7089' },
 };
 
+/** Toolbar chip accents. The log body is always dark, but the toolbar follows
+ *  the app theme — the dark-tuned LEVEL_STYLE hues wash out on the light
+ *  toolbar, so light mode uses darker equivalents. */
+const LEVEL_CHIP_COLOR: Record<'light' | 'dark', Record<LogLevel, string>> = {
+  dark: { error: '#f7768e', warn: '#e0af68', info: '#7aa2f7', debug: '#9aa0b5', trace: '#6b7089' },
+  light: { error: '#b91c1c', warn: '#8f6209', info: '#1d4ed8', debug: '#52525b', trace: '#71717a' },
+};
+
 /** Row tint for lines that demand attention while scanning. */
 const LEVEL_ROW_TINT: Partial<Record<LogLevel, string>> = {
   error: 'rgba(247,118,142,0.08)',
@@ -860,7 +868,7 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
         )}
         {LOG_LEVELS.filter((level) => levelCounts[level] > 0 || levelFilter.has(level)).map((level) => {
           const active = levelFilter.has(level);
-          const { letter, color } = LEVEL_STYLE[level];
+          const { letter } = LEVEL_STYLE[level];
           return (
             <Tooltip key={level} title={`${active ? 'Stop filtering by' : 'Only show'} ${level} lines`}>
               <Chip
@@ -869,13 +877,16 @@ export function LogViewer({ tab }: { tab: LogsTab }) {
                 variant={active ? 'filled' : 'outlined'}
                 onClick={() => toggleLevel(level)}
                 aria-label={`Filter ${level} logs`}
-                sx={{
-                  fontFamily: 'monospace',
-                  fontWeight: 600,
-                  color: active ? '#1a1a1e' : color,
-                  bgcolor: active ? color : undefined,
-                  borderColor: color,
-                  '&:hover': { bgcolor: active ? color : undefined },
+                sx={(theme) => {
+                  const color = LEVEL_CHIP_COLOR[theme.palette.mode][level];
+                  return {
+                    fontFamily: 'monospace',
+                    fontWeight: 600,
+                    color: active ? (theme.palette.mode === 'dark' ? '#1a1a1e' : '#ffffff') : color,
+                    bgcolor: active ? color : undefined,
+                    borderColor: color,
+                    '&:hover': { bgcolor: active ? color : undefined },
+                  };
                 }}
               />
             </Tooltip>

--- a/client/src/components/MetricsChartImpl.tsx
+++ b/client/src/components/MetricsChartImpl.tsx
@@ -1,14 +1,17 @@
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import { useTheme } from '@mui/material/styles';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { useMetricsHistory } from '../api/queries.js';
 import { formatBytes, formatCpu } from './format.js';
+import { SERIES_DARK, SERIES_LIGHT, timeTickFormatter } from './chart-theme.js';
 
 import type { MetricsChartProps } from './MetricsChart.js';
 
 export default function MetricsChartImpl({ ctx, kind, name, namespace }: MetricsChartProps) {
   const { data } = useMetricsHistory({ ctx, kind, name, namespace });
+  const series = useTheme().palette.mode === 'dark' ? SERIES_DARK : SERIES_LIGHT;
 
   if (!data?.available) {
     return (
@@ -41,18 +44,20 @@ export default function MetricsChartImpl({ ctx, kind, name, namespace }: Metrics
         <Typography variant="subtitle2">CPU — {formatCpu(latest.cpuMilli)}</Typography>
         <LineChart
           height={180}
-          series={[{ data: cpuValues, label: 'mCPU', area: true, showMark: false, color: '#7aa2f7' }]}
-          xAxis={[{ data: times, scaleType: 'time' }]}
+          series={[{ data: cpuValues, label: 'mCPU', area: true, showMark: false, color: series[0] }]}
+          xAxis={[{ data: times, scaleType: 'time', valueFormatter: timeTickFormatter(times) }]}
           hideLegend
+          sx={{ '& .MuiLineChart-area': { fillOpacity: 0.25 } }}
         />
       </Box>
       <Box>
         <Typography variant="subtitle2">Memory — {formatBytes(latest.memBytes)}</Typography>
         <LineChart
           height={180}
-          series={[{ data: memValues, label: 'MiB', area: true, showMark: false, color: '#9ece6a' }]}
-          xAxis={[{ data: times, scaleType: 'time' }]}
+          series={[{ data: memValues, label: 'MiB', area: true, showMark: false, color: series[1] }]}
+          xAxis={[{ data: times, scaleType: 'time', valueFormatter: timeTickFormatter(times) }]}
           hideLegend
+          sx={{ '& .MuiLineChart-area': { fillOpacity: 0.25 } }}
         />
       </Box>
     </Stack>

--- a/client/src/components/MetricsServerControls.tsx
+++ b/client/src/components/MetricsServerControls.tsx
@@ -15,6 +15,7 @@ import { useInstallMetricsServer, useUninstallMetricsServer } from '../api/queri
 import { useIsProtected } from '../state/clusters.js';
 import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
+import { statusTextColor } from '../theme.js';
 
 /**
  * One-click metrics-server install for a cluster: confirmation dialog with
@@ -52,7 +53,7 @@ export function InstallMetricsServerButton({ ctx, size = 'small' }: { ctx: strin
             }
           />
           {isProtected && (
-            <Typography variant="body2" color="warning.main" sx={{ mt: 1 }}>
+            <Typography variant="body2" sx={{ mt: 1, color: statusTextColor('warning') }}>
               This cluster is marked protected — make sure installing cluster components here is intended.
             </Typography>
           )}

--- a/client/src/components/NetworkAgentControls.tsx
+++ b/client/src/components/NetworkAgentControls.tsx
@@ -13,6 +13,7 @@ import { useInstallNetworkAgent, useUninstallNetworkAgent } from '../api/queries
 import { useIsProtected } from '../state/clusters.js';
 import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
+import { statusTextColor } from '../theme.js';
 
 /**
  * One-click network-agent install for a cluster: a confirmation dialog that
@@ -42,7 +43,7 @@ export function InstallNetworkAgentButton({ ctx, size = 'small' }: { ctx: string
             Linux nodes. Traffic rates appear about a minute after the pods are ready.
           </Typography>
           {isProtected && (
-            <Typography variant="body2" color="warning.main" sx={{ mt: 1 }}>
+            <Typography variant="body2" sx={{ mt: 1, color: statusTextColor('warning') }}>
               This cluster is marked protected — make sure installing cluster components here is intended.
             </Typography>
           )}

--- a/client/src/components/PageHeader.tsx
+++ b/client/src/components/PageHeader.tsx
@@ -18,7 +18,7 @@ export function PageHeader({ title, icon, children }: Props) {
           sx={(theme) => ({
             width: 32,
             height: 32,
-            borderRadius: 2,
+            borderRadius: 1.5,
             display: 'grid',
             placeItems: 'center',
             color: 'primary.main',

--- a/client/src/components/ReadyCounter.tsx
+++ b/client/src/components/ReadyCounter.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box';
+import { statusTextColor } from '../theme.js';
 
 const READY_RE = /^(\d+)\/(\d+)$/;
 
@@ -8,9 +9,11 @@ function isNotReady(value: string): boolean {
   return Number(match[1]) < Number(match[2]);
 }
 
-export function ReadyCounter({ value }: { value: string }) {
+/** `muted` suppresses the not-ready highlight, e.g. for Succeeded pods
+ *  where 0/1 is the expected terminal state, not a problem. */
+export function ReadyCounter({ value, muted = false }: { value: string; muted?: boolean }) {
   return (
-    <Box component="span" sx={{ color: isNotReady(value) ? 'warning.main' : 'inherit' }}>
+    <Box component="span" sx={{ color: !muted && isNotReady(value) ? statusTextColor('warning') : 'inherit' }}>
       {value}
     </Box>
   );

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -38,6 +38,7 @@ import { RolloutHistory } from './detail/RolloutHistory.js';
 import { AgeCell } from './AgeCell.js';
 import { MetricsChart } from './MetricsChart.js';
 import { RowActions, RowLogsButton } from './RowActions.js';
+import { TruncationTooltip } from './truncation.js';
 import { TopologyGraph } from './TopologyGraph.js';
 import { useDetailStore } from '../state/detail.js';
 
@@ -203,7 +204,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
         >
           <Stack direction="row" sx={{ px: 2, py: 1, borderBottom: 1, borderColor: 'divider', alignItems: 'center' }}>
             {onBack && (
-              <IconButton onClick={() => guardLeave(onBack)} sx={{ mr: 1 }}>
+              <IconButton aria-label="Back" onClick={() => guardLeave(onBack)} sx={{ mr: 1 }}>
                 <ArrowBackIcon />
               </IconButton>
             )}
@@ -233,14 +234,16 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
                   </>
                 )}
               </Typography>
-              <Typography variant="subtitle1" noWrap sx={{ fontWeight: 650, lineHeight: 1.3 }}>
-                {sel.namespace && (
-                  <Typography component="span" variant="subtitle1" color="text.secondary" sx={{ fontWeight: 500 }}>
-                    {sel.namespace}{' / '}
-                  </Typography>
-                )}
-                {sel.name}
-              </Typography>
+              <TruncationTooltip text={sel.namespace ? `${sel.namespace} / ${sel.name}` : sel.name}>
+                <Typography variant="subtitle1" noWrap sx={{ fontWeight: 600, lineHeight: 1.3 }}>
+                  {sel.namespace && (
+                    <Typography component="span" variant="subtitle1" color="text.secondary" sx={{ fontWeight: 500 }}>
+                      {sel.namespace}{' / '}
+                    </Typography>
+                  )}
+                  {sel.name}
+                </Typography>
+              </TruncationTooltip>
             </Box>
             <Box sx={{ flex: 1 }} />
             {obj && <RowLogsButton target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
@@ -389,7 +392,7 @@ function EventsList({ events }: { events: KubeObject[] }) {
       {events.map((e) => {
         const ev = e as KubeObject & { type?: string; reason?: string; message?: string; count?: number; lastTimestamp?: string };
         return (
-          <Box key={e.metadata.uid} sx={{ borderLeft: 3, borderColor: ev.type === 'Warning' ? 'error.main' : 'success.main', pl: 1.5, py: 0.25 }}>
+          <Box key={e.metadata.uid} sx={{ borderLeft: 3, borderColor: ev.type === 'Warning' ? 'warning.main' : 'success.main', pl: 1.5, py: 0.25 }}>
             <Typography variant="body2" sx={{ fontWeight: 600 }}>
               {ev.reason} {ev.count && ev.count > 1 ? `×${ev.count}` : ''}{' '}
               <Typography component="span" variant="caption" color="text.secondary">

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { layout } from '../theme.js';
+import { layout, statusTextColor } from '../theme.js';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
 import Checkbox from '@mui/material/Checkbox';
@@ -17,6 +17,8 @@ import type { MetricsLookup } from './columns.js';
 import { podSummary } from '../kube-display.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { useQuickSearchShortcut } from './quick-search.js';
+import { countLabel } from './format.js';
+import InboxOutlinedIcon from '@mui/icons-material/InboxOutlined';
 
 interface Props {
   rows: ClusterRow[];
@@ -231,6 +233,27 @@ export function ResourceTable({
 
   useQuickSearchShortcut(searchInputRef);
 
+  // Friendlier stand-in for the DataGrid's bare "No rows", telling apart an
+  // empty scope from filters hiding everything.
+  const filteredOut = rows.length - filtered.length;
+  const NoRowsOverlay = useCallback(
+    () => (
+      <Stack sx={{ height: '100%', alignItems: 'center', justifyContent: 'center', gap: 0.75 }}>
+        <InboxOutlinedIcon sx={{ fontSize: 34, color: 'text.secondary', opacity: 0.55 }} />
+        <Typography variant="body2" color="text.secondary">
+          {filteredOut > 0
+            ? `No matches — ${countLabel(filteredOut, 'item')} hidden by the current filters`
+            : // `kind` falls back to the literal 'Resource' for plain custom
+              // resources — that would read "No Resource resources".
+              kind && kind !== 'Resource'
+              ? `No ${kind} resources in the current scope`
+              : 'No resources in the current scope'}
+        </Typography>
+      </Stack>
+    ),
+    [filteredOut, kind],
+  );
+
   return (
     <Box className="kubus-table" sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Stack direction="row" spacing={1} useFlexGap sx={{ px: 1.5, py: 1, flexShrink: 0, alignItems: 'center', flexWrap: 'wrap' }}>
@@ -276,9 +299,9 @@ export function ResourceTable({
             sx={{ width: 320 }}
           />
         )}
-        <Chip label={`${filtered.length} items`} variant="outlined" />
+        <Chip label={countLabel(filtered.length, 'item')} variant="outlined" />
         {statusText && (
-          <Typography variant="caption" color="warning.main">
+          <Typography variant="caption" sx={{ color: statusTextColor('warning') }}>
             {statusText}
           </Typography>
         )}
@@ -308,6 +331,7 @@ export function ResourceTable({
         // reserve a real gutter instead.
         scrollbarSize={layout.scrollbarSize}
         checkboxSelection={checkboxSelection}
+        slots={{ noRowsOverlay: NoRowsOverlay }}
         onRowSelectionModelChange={
           onSelectionChange
             ? (model) => {

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -234,8 +234,11 @@ export function ResourceTable({
   useQuickSearchShortcut(searchInputRef);
 
   // Friendlier stand-in for the DataGrid's bare "No rows", telling apart an
-  // empty scope from filters hiding everything.
+  // empty scope from filters hiding everything. A label selector filters
+  // server-side — the excluded objects never reach `rows`, so it gets a
+  // no-matches message without a hidden count.
   const filteredOut = rows.length - filtered.length;
+  const labelFiltered = labelTerms.length > 0;
   const NoRowsOverlay = useCallback(
     () => (
       <Stack sx={{ height: '100%', alignItems: 'center', justifyContent: 'center', gap: 0.75 }}>
@@ -243,15 +246,17 @@ export function ResourceTable({
         <Typography variant="body2" color="text.secondary">
           {filteredOut > 0
             ? `No matches — ${countLabel(filteredOut, 'item')} hidden by the current filters`
-            : // `kind` falls back to the literal 'Resource' for plain custom
-              // resources — that would read "No Resource resources".
-              kind && kind !== 'Resource'
-              ? `No ${kind} resources in the current scope`
-              : 'No resources in the current scope'}
+            : labelFiltered
+              ? 'No matches for the current label selector'
+              : // `kind` falls back to the literal 'Resource' for plain custom
+                // resources — that would read "No Resource resources".
+                kind && kind !== 'Resource'
+                ? `No ${kind} resources in the current scope`
+                : 'No resources in the current scope'}
         </Typography>
       </Stack>
     ),
-    [filteredOut, kind],
+    [filteredOut, labelFiltered, kind],
   );
 
   return (

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -169,6 +169,7 @@ export function RowActions({ target }: { target: RowActionTarget }) {
     <>
       <IconButton
         size="small"
+        aria-label={`Actions for ${target.obj.metadata.name}`}
         onClick={(e) => {
           e.stopPropagation();
           setAnchor(e.currentTarget);

--- a/client/src/components/SmartFilterInput.tsx
+++ b/client/src/components/SmartFilterInput.tsx
@@ -223,8 +223,10 @@ export function SmartFilterInput({ value, onChange, kind, rows, inputRef }: Prop
                             maxWidth: 'calc(100vw - 24px)',
                             border: '1px solid',
                             borderColor: 'divider',
+                            // Same shadow as the Menu/Autocomplete theme token
+                            // so adjacent dropdowns cast identical shadows.
                             boxShadow: (theme) =>
-                              theme.palette.mode === 'dark' ? '0 16px 48px rgba(0, 0, 0, 0.55)' : '0 16px 40px rgba(20, 20, 30, 0.16)',
+                              theme.palette.mode === 'dark' ? '0 8px 28px rgba(0, 0, 0, 0.5)' : '0 8px 28px rgba(0, 0, 0, 0.12)',
                           },
                         },
                       }}
@@ -255,7 +257,7 @@ function FilterHelpPanel() {
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
         {HELP_SECTIONS.map((section) => (
           <Box key={section.title}>
-            <Typography variant="caption" sx={{ display: 'block', mb: 0.5, fontWeight: 650, color: 'text.primary' }}>
+            <Typography variant="caption" sx={{ display: 'block', mb: 0.5, fontWeight: 600, color: 'text.primary' }}>
               {section.title}
             </Typography>
             <Box

--- a/client/src/components/StatusChip.tsx
+++ b/client/src/components/StatusChip.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import CircleIcon from '@mui/icons-material/Circle';
+import { statusTextColor } from '../theme.js';
 
 const GOOD = new Set(['running', 'succeeded', 'active', 'bound', 'ready', 'available', 'complete', 'completed', 'deployed', 'true', 'healthy', 'synced', 'up', 'attached']);
 const BAD = new Set(['failed', 'crashloopbackoff', 'imagepullbackoff', 'errimagepull', 'error', 'evicted', 'lost', 'notready', 'oomkilled', 'false', 'unhealthy', 'degraded', 'stopped', 'down', 'notestablished', 'nameconflict']);
@@ -10,6 +11,7 @@ const WARN = new Set([
   'podinitializing',
   'released',
   'unknown',
+  'warning',
   'schedulingdisabled',
   'pending-install',
   'pending-upgrade',
@@ -39,7 +41,7 @@ export function StatusChip({ status, label }: { status: string; label?: string }
         fontSize: 12.5,
         fontWeight: 550,
         lineHeight: 1.6,
-        color: color === 'default' ? 'text.secondary' : `${color}.main`,
+        color: color === 'default' ? 'text.secondary' : statusTextColor(color),
       }}
     >
       <CircleIcon sx={{ fontSize: 7, opacity: color === 'default' ? 0.6 : 1 }} />

--- a/client/src/components/ToastHost.tsx
+++ b/client/src/components/ToastHost.tsx
@@ -8,11 +8,15 @@ import Snackbar from '@mui/material/Snackbar';
 import CloseIcon from '@mui/icons-material/Close';
 import { copyToClipboard } from '../clipboard.js';
 import { useToastStore } from '../state/toast.js';
+import { useDockStore } from '../state/dock.js';
 
 /** The single snackbar for all `showToast` notifications; mounted once in App. */
 export function ToastHost() {
   const toast = useToastStore((s) => s.toast);
   const dismiss = useToastStore((s) => s.dismiss);
+  const dockOpen = useDockStore((s) => s.open);
+  const dockHeight = useDockStore((s) => s.height);
+  const dockMaximized = useDockStore((s) => s.maximized);
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -34,6 +38,10 @@ export function ToastHost() {
         dismiss();
       }}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      // Sit above the terminal/logs dock instead of covering the very lines
+      // the toast is talking about (a maximized dock leaves no room, so the
+      // default overlay position stands there).
+      sx={dockOpen && !dockMaximized ? { bottom: `${dockHeight + 12}px` } : undefined}
     >
       <Alert
         severity={toast?.severity ?? 'info'}

--- a/client/src/components/TopologyGraphImpl.tsx
+++ b/client/src/components/TopologyGraphImpl.tsx
@@ -5,7 +5,7 @@ import Chip from '@mui/material/Chip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
+import { useTheme, type Theme } from '@mui/material/styles';
 import {
   applyNodeChanges,
   Background,
@@ -26,6 +26,7 @@ import {
 import type { GraphEdge, GraphNode, GraphNodeStatus, RelationshipGraph } from '@kubus/shared';
 import { useTopologyGraphs } from '../api/queries.js';
 import { useDetailStore } from '../state/detail.js';
+import { statusTextColor } from '../theme.js';
 import { cachedTopologyLayout, layoutTopology, routeEdges, topologyNodeBox, type RoutePoint, type TopologyLayout } from './topology-layout.js';
 import type { TopologyGraphProps } from './TopologyGraph.js';
 
@@ -36,31 +37,45 @@ interface TopologyNodeData extends Record<string, unknown> {
 interface TopologyEdgeData extends Record<string, unknown> {
   routePoints: RoutePoint[];
   labelPoint?: RoutePoint;
+  kind: GraphEdge['kind'];
 }
 
 type TopologyFlowNode = Node<TopologyNodeData>;
 type TopologyFlowEdge = Edge<TopologyEdgeData>;
 
-const STATUS_COLOR: Record<GraphNodeStatus, string> = {
-  success: '#2e7d32',
-  warning: '#ed6c02',
-  error: '#d32f2f',
-  unknown: '#6b7280',
+/** Edge hues per theme mode: label text sits on background.paper chips, so
+ *  light mode needs the darker tones and dark mode the brighter ones. */
+const EDGE_COLOR: Record<'light' | 'dark', Record<GraphEdge['kind'], string>> = {
+  light: {
+    owns: '#64748b',
+    selects: '#2563eb',
+    routes: '#7c3aed',
+    mounts: '#0e7490',
+    binds: '#0f766e',
+    schedules: '#8f6209',
+    manages: '#9333ea',
+  },
+  dark: {
+    owns: '#94a3b8',
+    selects: '#60a5fa',
+    routes: '#a78bfa',
+    mounts: '#22d3ee',
+    binds: '#2dd4bf',
+    schedules: '#e7b341',
+    manages: '#c084fc',
+  },
 };
 
-const EDGE_COLOR: Record<GraphEdge['kind'], string> = {
-  owns: '#64748b',
-  selects: '#2563eb',
-  routes: '#7c3aed',
-  mounts: '#0891b2',
-  binds: '#0f766e',
-  schedules: '#ca8a04',
-  manages: '#9333ea',
-};
+function nodeStatusColor(status: GraphNodeStatus, theme: Theme): string {
+  return status === 'unknown' ? theme.palette.text.secondary : theme.palette[status].main;
+}
 
 function TopologyNode({ data, selected }: NodeProps) {
   const node = (data as TopologyNodeData).graphNode;
-  const color = STATUS_COLOR[node.status];
+  const theme = useTheme();
+  const color = nodeStatusColor(node.status, theme);
+  // Small status text needs the AA-safe tone; the 5px stripe can stay bright.
+  const reasonColor = node.status === 'unknown' ? theme.palette.text.secondary : statusTextColor(node.status)(theme);
   return (
     <Box
       sx={{
@@ -105,7 +120,7 @@ function TopologyNode({ data, selected }: NodeProps) {
         </Typography>
       )}
       {node.reason && (
-        <Typography variant="caption" sx={{ display: 'block', color, mt: 0.25 }} noWrap title={node.reason}>
+        <Typography variant="caption" sx={{ display: 'block', color: reasonColor, mt: 0.25 }} noWrap title={node.reason}>
           {node.reason}
         </Typography>
       )}
@@ -257,7 +272,7 @@ function placeEdgeLabels(edges: TopologyFlowEdge[]): TopologyFlowEdge[] {
     }
     chosen ??= pointAtFraction(points, 0.5);
     occupied.push(chosen);
-    return { ...edge, data: { ...edge.data, routePoints: points, labelPoint: chosen } };
+    return { ...edge, data: { ...edge.data!, routePoints: points, labelPoint: chosen } };
   });
 }
 
@@ -274,6 +289,10 @@ interface FlowState {
 const emptyFlow: FlowState = { nodes: [], edges: [], warnings: [], problemNodes: [] };
 
 function toFlowState(layout: TopologyLayout): FlowState {
+  // Fan-in/fan-out groups (a Service selecting 3 pods, 5 pods scheduled onto
+  // one node) would repeat the same label on every edge — label each identical
+  // text once per shared endpoint and let the rest stay bare lines.
+  const labeled = new Set<string>();
   return {
     nodes: layout.nodes.map(({ node, position }) => ({
       id: node.id,
@@ -282,18 +301,31 @@ function toFlowState(layout: TopologyLayout): FlowState {
       data: { graphNode: node },
       draggable: true,
     })),
-    edges: placeEdgeLabels(layout.edges.map(({ edge, routePoints }) => ({
-      id: edge.id,
-      source: edge.source,
-      target: edge.target,
-      type: 'routed',
-      label: edge.kind === 'owns' ? undefined : (edge.label ?? edge.kind),
-      animated: edge.kind === 'routes' || edge.kind === 'selects',
-      markerEnd: { type: MarkerType.ArrowClosed, color: EDGE_COLOR[edge.kind] },
-      style: { strokeWidth: 1.7, stroke: EDGE_COLOR[edge.kind] },
-      labelStyle: { fill: EDGE_COLOR[edge.kind], fontWeight: 700, fontSize: 11 },
-      data: { routePoints },
-    }))),
+    edges: placeEdgeLabels(layout.edges.map(({ edge, routePoints }) => {
+      const text = edge.kind === 'owns' ? undefined : (edge.label ?? edge.kind);
+      let label: string | undefined;
+      if (text) {
+        const bySource = `${text}|s|${edge.source}`;
+        const byTarget = `${text}|t|${edge.target}`;
+        if (!labeled.has(bySource) && !labeled.has(byTarget)) {
+          labeled.add(bySource);
+          labeled.add(byTarget);
+          label = text;
+        }
+      }
+      return {
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        type: 'routed',
+        label,
+        animated: edge.kind === 'routes' || edge.kind === 'selects',
+        // Colors resolve per theme mode in the render-side edges memo.
+        style: { strokeWidth: 1.7 },
+        labelStyle: { fontWeight: 700, fontSize: 11 },
+        data: { routePoints, kind: edge.kind },
+      };
+    })),
     warnings: layout.warnings,
     problemNodes: layout.problemNodes,
   };
@@ -389,7 +421,7 @@ export default function TopologyGraphImpl({
     setFlow((f) => {
       const boxes = f.nodes.map((node) => topologyNodeBox(node.id, node.position, node.data.graphNode));
       const routes = routeEdges(boxes, f.edges);
-      return { ...f, edges: placeEdgeLabels(f.edges.map((edge) => ({ ...edge, data: { routePoints: routes.get(edge.id) ?? [] } }))) };
+      return { ...f, edges: placeEdgeLabels(f.edges.map((edge) => ({ ...edge, data: { ...edge.data!, routePoints: routes.get(edge.id) ?? [] } }))) };
     });
   }, []);
 
@@ -417,13 +449,16 @@ export default function TopologyGraphImpl({
 
   const edges = useMemo<TopologyFlowEdge[]>(
     () => {
+      const edgeColors = EDGE_COLOR[theme.palette.mode];
       const styled = flow.edges.map((edge) => {
         const connected = !activeSelectedNodeId || edge.source === activeSelectedNodeId || edge.target === activeSelectedNodeId;
+        const color = edgeColors[edge.data!.kind];
         return {
           ...edge,
           selected: !!activeSelectedNodeId && connected,
-          style: { ...edge.style, strokeWidth: activeSelectedNodeId && connected ? 2.8 : edge.style?.strokeWidth, opacity: connected ? 1 : 0.1 },
-          labelStyle: { ...edge.labelStyle, opacity: connected ? 1 : 0.1 },
+          markerEnd: { type: MarkerType.ArrowClosed, color },
+          style: { ...edge.style, stroke: color, strokeWidth: activeSelectedNodeId && connected ? 2.8 : edge.style?.strokeWidth, opacity: connected ? 1 : 0.1 },
+          labelStyle: { ...edge.labelStyle, fill: color, opacity: connected ? 1 : 0.1 },
         };
       });
       // Edges paint in array order within the edge layer, and every edge
@@ -432,7 +467,7 @@ export default function TopologyGraphImpl({
       // sort preserves order within each group).
       return activeSelectedNodeId ? styled.sort((a, b) => Number(a.selected) - Number(b.selected)) : styled;
     },
-    [activeSelectedNodeId, flow.edges],
+    [activeSelectedNodeId, flow.edges, theme.palette.mode],
   );
   const { warnings, problemNodes } = flow;
   // keepPreviousData preserves the prior graph while a new scope is fetched.

--- a/client/src/components/UsageMeter.tsx
+++ b/client/src/components/UsageMeter.tsx
@@ -14,9 +14,8 @@ export function usageColor(pct: number): 'success' | 'warning' | 'error' {
  * container cards.
  *
  * Under budget the track spans the reference total. Over budget it rescales
- * to actual usage: a tick marks where the request/limit sits and the hatched
- * segment beyond it is the overshoot, so 154% and 400% look as different as
- * they are.
+ * to actual usage and a tick marks where the request/limit sits, so 154% and
+ * 400% look as different as they are.
  */
 export function UsageMeter({
   value,
@@ -72,33 +71,19 @@ export function UsageMeter({
               sx={{ height: 5, borderRadius: 999, bgcolor: 'action.hover' }}
             />
             {markerPct !== undefined && (
-              <>
-                <Box
-                  sx={(theme) => ({
-                    position: 'absolute',
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    left: `${markerPct}%`,
-                    right: 0,
-                    height: 5,
-                    borderRadius: '0 999px 999px 0',
-                    backgroundImage: `repeating-linear-gradient(-45deg, ${theme.palette.error.dark} 0 3px, transparent 3px 6px)`,
-                  })}
-                />
-                <Box
-                  sx={(theme) => ({
-                    position: 'absolute',
-                    top: '50%',
-                    left: `${markerPct}%`,
-                    transform: 'translate(-50%, -50%)',
-                    width: 2,
-                    height: 11,
-                    borderRadius: 1,
-                    bgcolor: 'text.primary',
-                    boxShadow: `0 0 0 1px ${theme.palette.background.paper}`,
-                  })}
-                />
-              </>
+              <Box
+                sx={(theme) => ({
+                  position: 'absolute',
+                  top: '50%',
+                  left: `${markerPct}%`,
+                  transform: 'translate(-50%, -50%)',
+                  width: 2,
+                  height: 11,
+                  borderRadius: 1,
+                  bgcolor: 'text.primary',
+                  boxShadow: `0 0 0 1px ${theme.palette.background.paper}`,
+                })}
+              />
             )}
           </Box>
         ) : (

--- a/client/src/components/chart-theme.ts
+++ b/client/src/components/chart-theme.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared chart tokens so every metrics surface draws from the same series
+ * palette and time axis language.
+ *
+ * Categorical palette from the validated dataviz reference set (adjacent-pair
+ * CVD-safe in this order — do not re-order or cycle past 8 series).
+ */
+export const SERIES_LIGHT = ['#2a78d6', '#008300', '#e87ba4', '#eda100', '#1baf7a', '#eb6834', '#4a3aa7', '#e34948'];
+export const SERIES_DARK = ['#3987e5', '#008300', '#d55181', '#c98500', '#199e70', '#d95926', '#9085e9', '#e66767'];
+
+/**
+ * Time-axis tick formatter. Minute precision produces duplicate neighboring
+ * tick labels on ranges shorter than the tick spacing allows, so short spans
+ * include seconds.
+ */
+export function timeTickFormatter(times: Array<Date | number>): (d: Date) => string {
+  const first = times.length ? Number(times[0]) : 0;
+  const last = times.length ? Number(times[times.length - 1]) : 0;
+  const withSeconds = last - first < 15 * 60_000;
+  return (d: Date) =>
+    d.toLocaleTimeString(
+      [],
+      withSeconds ? { hour: '2-digit', minute: '2-digit', second: '2-digit' } : { hour: '2-digit', minute: '2-digit' },
+    );
+}

--- a/client/src/components/columns.tsx
+++ b/client/src/components/columns.tsx
@@ -15,6 +15,7 @@ import { crdStatus, crdVersions, dataKeyCount, eventFields, hasRunningDebugConta
 import { cronHumanText, cronNextRun } from '../cron.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { UsageMeter } from './UsageMeter.js';
+import { statusTextColor } from '../theme.js';
 
 export type MetricsLookup = (ctx: string, namespace: string | undefined, name: string) => { cpuMilli: number; memBytes: number; cpuCapacityMilli?: number; memCapacityBytes?: number } | undefined;
 export type NodeAllocationLookup = (ctx: string, nodeName: string) => NodeAllocationSummary;
@@ -102,7 +103,12 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
     headerName: 'Ready',
     width: 75,
     valueGetter: (_v, row) => podSummary(obj(row)).ready,
-    renderCell: (params) => <ReadyCounter value={String(params.value ?? '')} />,
+    renderCell: (params) => (
+      <ReadyCounter
+        value={String(params.value ?? '')}
+        muted={/^(succeeded|completed)$/i.test(podSummary(obj(params.row)).status)}
+      />
+    ),
   }),
   podStatus: () => ({
     field: 'podStatus',
@@ -575,7 +581,7 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
     headerName: 'Type',
     width: 90,
     valueGetter: (_v, row) => eventFields(obj(row)).type,
-    renderCell: (params) => <StatusChip status={eventFields(obj(params.row)).type === 'Warning' ? 'Error' : 'Ready'} />,
+    renderCell: (params) => <StatusChip status={eventFields(obj(params.row)).type ?? ''} />,
   }),
   eventReason: () => ({
     field: 'eventReason',
@@ -645,7 +651,7 @@ const COLUMN_DEFS: Record<string, (opts: ColumnBuildOptions) => Col> = {
       const text = String(params.value ?? '');
       return text ? (
         <Tooltip title={text}>
-          <Typography variant="body2" color="warning.main" noWrap sx={{ minWidth: 0 }}>
+          <Typography variant="body2" noWrap sx={{ minWidth: 0, color: statusTextColor('warning') }}>
             {text}
           </Typography>
         </Tooltip>

--- a/client/src/components/detail/ContainerCards.tsx
+++ b/client/src/components/detail/ContainerCards.tsx
@@ -10,6 +10,7 @@ import { StatusChip } from '../StatusChip.js';
 import { UsageMeter } from '../UsageMeter.js';
 import { formatBytes, formatCpu } from '../format.js';
 import type { ContainerResources } from '../../kube-display.js';
+import { statusTextColor } from '../../theme.js';
 
 export interface ContainerCardData {
   name: string;
@@ -94,7 +95,7 @@ function ContainerCard({ c, onForwardPort, onEditImage }: { c: ContainerCardData
             WebkitBoxOrient: 'vertical',
             overflow: 'hidden',
             wordBreak: 'break-word',
-            color: 'warning.main',
+            color: statusTextColor('warning'),
             mt: 0.25,
           }}
         >
@@ -102,7 +103,7 @@ function ContainerCard({ c, onForwardPort, onEditImage }: { c: ContainerCardData
         </Typography>
       )}
       {showRestarts && (
-        <Typography variant="caption" sx={{ display: 'block', mt: 0.25, color: 'warning.main' }}>
+        <Typography variant="caption" sx={{ display: 'block', mt: 0.25, color: statusTextColor('warning') }}>
           {`Restarts ${c.restarts ?? 0}`}
           {c.lastRestart && (
             <>

--- a/client/src/components/detail/CrdDetail.tsx
+++ b/client/src/components/detail/CrdDetail.tsx
@@ -13,6 +13,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import type { KubeObject } from '@kubus/shared';
 import { GenericDetail } from './GenericDetail.js';
+import { statusTextColor } from '../../theme.js';
 
 interface JsonSchema {
   $ref?: string;
@@ -168,7 +169,7 @@ export function CrdSchemaDetail({ obj, versionName }: { obj: KubeObject; version
         {version.deprecated && <Chip label="deprecated" color="warning" variant="outlined" />}
       </Stack>
       {version.deprecationWarning && (
-        <Typography variant="body2" color="warning.main">
+        <Typography variant="body2" sx={{ color: statusTextColor('warning') }}>
           {version.deprecationWarning}
         </Typography>
       )}
@@ -194,8 +195,8 @@ export function CrdSchemaDetail({ obj, versionName }: { obj: KubeObject; version
                 {printerColumns.map((column, index) => (
                   <TableRow key={`${column.name ?? index}:${column.jsonPath ?? ''}`}>
                     <TableCell sx={{ width: 180, color: 'text.secondary', border: 0 }}>{column.name ?? ''}</TableCell>
-                    <TableCell sx={{ border: 0, wordBreak: 'break-all' }}>
-                      <Typography component="span" variant="body2" sx={{ fontWeight: 650, mr: 1, color: typeColor(column.type ?? 'string') }}>
+                    <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>
+                      <Typography component="span" variant="body2" sx={{ fontWeight: 600, mr: 1, color: typeColor(column.type ?? 'string') }}>
                         {column.type ?? 'string'}
                       </Typography>
                       <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace', fontSize: 12 }}>
@@ -245,7 +246,7 @@ function InfoRow({ label, value }: { label: string; value: string | undefined })
   return (
     <TableRow>
       <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{label}</TableCell>
-      <TableCell sx={{ border: 0, wordBreak: 'break-all' }}>{value}</TableCell>
+      <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>{value}</TableCell>
     </TableRow>
   );
 }
@@ -322,7 +323,7 @@ function SchemaField({
               <Typography component="span" variant="body2" sx={{ fontWeight: 700, color: 'text.primary', fontFamily: depth ? 'monospace' : undefined }}>
                 {name}
               </Typography>
-              <Typography component="span" variant="body2" sx={{ fontWeight: 650, color: typeColor(typeLabel) }}>
+              <Typography component="span" variant="body2" sx={{ fontWeight: 600, color: typeColor(typeLabel) }}>
                 {typeLabel}
               </Typography>
               {required && <Chip label="required" size="small" variant="outlined" sx={{ height: 18, fontSize: 10 }} />}

--- a/client/src/components/detail/GenericDetail.tsx
+++ b/client/src/components/detail/GenericDetail.tsx
@@ -107,7 +107,9 @@ export function ConditionChips({ obj, goodWhen }: { obj: KubeObject; goodWhen?: 
         return (
           <Tooltip key={c.type} title={tip}>
             <Chip
-              label={c.type}
+              // A red "Available" reads as a contradiction — spell out the
+              // status whenever the condition is off its healthy value.
+              label={healthy ? c.type : `${c.type}: ${c.status}`}
               size="small"
               variant="outlined"
               color={unknown ? 'default' : healthy ? 'success' : 'error'}
@@ -209,7 +211,7 @@ function Row({ label, value }: { label: string; value: string }) {
   return (
     <TableRow>
       <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{label}</TableCell>
-      <TableCell sx={{ border: 0, wordBreak: 'break-all' }}>{value}</TableCell>
+      <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>{value}</TableCell>
     </TableRow>
   );
 }

--- a/client/src/components/detail/NodeDetail.tsx
+++ b/client/src/components/detail/NodeDetail.tsx
@@ -70,7 +70,7 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                 {providerID && (
                   <TableRow>
                     <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>Provider ID</TableCell>
-                    <TableCell sx={{ border: 0, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all' }}>
+                    <TableCell sx={{ border: 0, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-word' }}>
                       {providerID} <CopyValueButton text={providerID} label="Copy provider ID" />
                     </TableCell>
                   </TableRow>

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -30,6 +30,7 @@ import { usePodEnv, useResourceMetrics, useStopDebug } from '../../api/queries.j
 import { useDetailStore } from '../../state/detail.js';
 import { showToast } from '../../state/toast.js';
 import { useDockStore, dockTabId } from '../../state/dock.js';
+import { statusTextColor } from '../../theme.js';
 
 interface Probe {
   httpGet?: { path?: string; port?: number | string; scheme?: string };
@@ -317,10 +318,12 @@ function ProbesSection({ spec, statusByName, terminal }: { spec: PodSpec | undef
         <TableBody>
           {rows.map((r) => (
             <TableRow key={`${r.container}:${r.kind}`}>
-              <TableCell sx={{ wordBreak: 'break-all' }}>{r.container}</TableCell>
+              <TableCell sx={{ wordBreak: 'break-word' }}>{r.container}</TableCell>
               <TableCell>{r.kind}</TableCell>
-              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all' }}>{r.target}</TableCell>
-              <TableCell sx={{ whiteSpace: 'nowrap' }}>
+              {/* Target gets the width priority — nowrap on Timing would starve
+                  it into breaking URLs mid-token. */}
+              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-word', minWidth: 170 }}>{r.target}</TableCell>
+              <TableCell>
                 <Typography variant="caption" color="text.secondary">
                   {r.timing}
                 </Typography>
@@ -378,10 +381,10 @@ function EnvSection({ ctx, namespace, pod, onOpenRef }: { ctx: string; namespace
                 const source = envSourceLabel(env);
                 return (
                   <TableRow key={`${env.name}:${i}`}>
-                    <TableCell sx={{ width: 220, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all' }}>{env.name}</TableCell>
-                    <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, maxWidth: 280, wordBreak: 'break-all' }}>
+                    <TableCell sx={{ width: 220, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-word' }}>{env.name}</TableCell>
+                    <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, maxWidth: 280, wordBreak: 'break-word' }}>
                       {env.error ? (
-                        <Typography component="span" variant="caption" color="warning.main">
+                        <Typography component="span" variant="caption" sx={{ color: statusTextColor('warning') }}>
                           {env.error}
                         </Typography>
                       ) : (
@@ -459,7 +462,7 @@ function VolumesSection({ spec, onOpenRef }: { spec: PodSpec | undefined; onOpen
             const info = volumeInfo(v);
             return (
               <TableRow key={v.name}>
-                <TableCell sx={{ wordBreak: 'break-all' }}>{v.name}</TableCell>
+                <TableCell sx={{ wordBreak: 'break-word' }}>{v.name}</TableCell>
                 <TableCell>
                   {info.refKind && info.refName ? (
                     <Link component="button" variant="body2" sx={{ textAlign: 'left' }} onClick={() => onOpenRef(info.refKind!, info.refName!)}>
@@ -469,7 +472,7 @@ function VolumesSection({ spec, onOpenRef }: { spec: PodSpec | undefined; onOpen
                     `${info.type}${info.detail ? `/${info.detail}` : ''}`
                   )}
                 </TableCell>
-                <TableCell sx={{ whiteSpace: 'pre-line', wordBreak: 'break-all' }}>{(mountsByVolume.get(v.name) ?? []).join('\n')}</TableCell>
+                <TableCell sx={{ whiteSpace: 'pre-line', wordBreak: 'break-word' }}>{(mountsByVolume.get(v.name) ?? []).join('\n')}</TableCell>
               </TableRow>
             );
           })}

--- a/client/src/components/format.ts
+++ b/client/src/components/format.ts
@@ -13,3 +13,8 @@ export function formatBps(bytesPerSec: number): string {
   if (bytesPerSec > 0 && bytesPerSec < 1) return '<1B/s';
   return `${formatBytes(Math.round(bytesPerSec))}/s`;
 }
+
+/** "3 items" / "1 item" — count with a naively pluralized noun. */
+export function countLabel(count: number, noun: string): string {
+  return `${count} ${count === 1 ? noun : `${noun}s`}`;
+}

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -140,7 +140,7 @@ function InventoryTiles({ entries, onOpen }: { entries: NamespaceInventoryEntry[
                   {e.total}
                 </Typography>
                 {warn && (
-                  <Typography variant="body2" sx={{ fontWeight: 700, color: 'warning.main' }}>
+                  <Typography variant="body2" sx={{ fontWeight: 700, color: statusTextColor('warning') }}>
                     {e.unhealthy} unhealthy
                   </Typography>
                 )}

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -15,6 +15,7 @@ import { FailingPodsCard, ProblemCard, WarningEventsCard, kindListPath } from '.
 import { OperatorSection } from './OperatorSection.js';
 import { PodUsagePanels } from './PodUsagePanels.js';
 import { WorkloadHealthSection } from './WorkloadHealthSection.js';
+import { statusTextColor } from '../../theme.js';
 
 /**
  * The overview body while the global namespace filter is active: a

--- a/client/src/components/overview/WorkloadHealthSection.tsx
+++ b/client/src/components/overview/WorkloadHealthSection.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router';
 import { pluralLabel, type OverviewKindHealth, type OverviewWorkloadIssue } from '@kubus/shared';
 import { StatusChip } from '../StatusChip.js';
 import { ProblemCard, kindListPath } from './cards.js';
+import { statusTextColor } from '../../theme.js';
 
 /**
  * Unified workload health: one tile per kind (Deployments … ResourceQuotas)
@@ -56,7 +57,10 @@ export function WorkloadHealthSection({
               display: 'flex',
               alignItems: 'baseline',
               gap: 0.75,
-              '&:hover': { bgcolor: 'action.hover', borderColor: h.unhealthy > 0 ? 'warning.main' : 'primary.main' },
+              // Zero-count kinds are background noise — recede like the
+              // Inventory chips do (hover restores full contrast).
+              opacity: !h.unavailable && h.total === 0 ? 0.55 : 1,
+              '&:hover': { bgcolor: 'action.hover', borderColor: h.unhealthy > 0 ? 'warning.main' : 'primary.main', opacity: 1 },
             }}
           >
             <Typography variant="caption" color="text.secondary">
@@ -72,7 +76,7 @@ export function WorkloadHealthSection({
                   {h.total}
                 </Typography>
                 {h.unhealthy > 0 && (
-                  <Typography variant="body2" sx={{ fontWeight: 700, color: 'warning.main' }}>
+                  <Typography variant="body2" sx={{ fontWeight: 700, color: statusTextColor('warning') }}>
                     {h.unhealthy} unhealthy
                   </Typography>
                 )}

--- a/client/src/components/overview/cards.tsx
+++ b/client/src/components/overview/cards.tsx
@@ -17,6 +17,7 @@ import { AgeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
 import { useApiResources } from '../../api/queries.js';
 import { kindListPath } from '../../resource-links.js';
+import { statusTextColor } from '../../theme.js';
 
 export { kindListPath };
 
@@ -78,7 +79,7 @@ export function WarningEventsCard({ ctx, events }: { ctx: string; events: Overvi
           const label = `${e.involvedKind}/${namespace ? `${namespace}/` : ''}${e.involvedName}`;
           return (
             <Typography key={`${e.namespace}/${e.involvedKind}/${e.involvedName}/${e.reason}/${e.lastTimestamp ?? ''}/${e.message}`} variant="body2">
-              <Typography component="span" variant="body2" sx={{ color: 'warning.main', fontWeight: 600 }}>
+              <Typography component="span" variant="body2" sx={{ color: statusTextColor('warning'), fontWeight: 600 }}>
                 {e.reason}
               </Typography>
               {e.count > 1 && (
@@ -126,8 +127,10 @@ export function StatCard({
   icon?: React.ReactElement;
   onClick?: () => void;
 }) {
+  // Six-up only on wide screens; mid widths get four-up so the values never
+  // ellipsize before the labels do.
   return (
-    <Grid size={{ xs: 6, sm: 4, md: 2 }}>
+    <Grid size={{ xs: 6, sm: 4, md: 3, lg: 2 }}>
       <Card
         variant="outlined"
         onClick={onClick}
@@ -162,7 +165,7 @@ export function StatCard({
                 return {
                   width: 36,
                   height: 36,
-                  borderRadius: 2,
+                  borderRadius: 1.5,
                   flexShrink: 0,
                   display: 'grid',
                   placeItems: 'center',

--- a/client/src/components/truncation.tsx
+++ b/client/src/components/truncation.tsx
@@ -1,0 +1,43 @@
+import { cloneElement, useState, type MouseEvent, type ReactElement } from 'react';
+import Tooltip from '@mui/material/Tooltip';
+
+/**
+ * Themed tooltip that reveals the full text of an ellipsized child — but only
+ * when the child is actually truncated, measured at hover time so it stays
+ * correct across resizes. `disableInteractive` keeps the tooltip purely
+ * visual: it can never sit under the cursor or swallow clicks.
+ */
+export function TruncationTooltip({
+  text,
+  measureSelector,
+  always = false,
+  children,
+}: {
+  text: string;
+  /** Descendant that actually ellipsizes, when the hover target is a wrapper. */
+  measureSelector?: string;
+  /** Show regardless of truncation — for tooltips that carry more than the
+   *  visible label (e.g. a subgroup's full API group). */
+  always?: boolean;
+  children: ReactElement<{ onMouseEnter?: (event: MouseEvent<HTMLElement>) => void }>;
+}) {
+  const [truncated, setTruncated] = useState(false);
+  return (
+    <Tooltip
+      title={always || truncated ? text : ''}
+      placement="bottom-start"
+      enterDelay={300}
+      enterNextDelay={150}
+      disableInteractive
+    >
+      {cloneElement(children, {
+        onMouseEnter: (event: MouseEvent<HTMLElement>) => {
+          const root = event.currentTarget;
+          const el = (measureSelector ? root.querySelector(measureSelector) : root) ?? root;
+          setTruncated(el.scrollWidth > el.clientWidth);
+          children.props.onMouseEnter?.(event);
+        },
+      })}
+    </Tooltip>
+  );
+}

--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -101,6 +101,7 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
                   <IconButton
                     component="span"
                     size="small"
+                    aria-label={`Close ${tab.title}`}
                     sx={{ p: 0.25, ml: 0.5 }}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/client/src/layout/NamespaceFilter.tsx
+++ b/client/src/layout/NamespaceFilter.tsx
@@ -1,6 +1,9 @@
 import Autocomplete from '@mui/material/Autocomplete';
+import Box from '@mui/material/Box';
+import Checkbox from '@mui/material/Checkbox';
 import Chip from '@mui/material/Chip';
 import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
 import { useNamespaces } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 
@@ -21,6 +24,14 @@ export function NamespaceFilter() {
       onChange={(_e, value) => setNamespaces(value)}
       limitTags={2}
       disableCloseOnSelect
+      renderOption={({ key, ...props }, option, { selected: isSelected }) => (
+        <Box component="li" key={key} {...props} sx={{ display: 'flex', gap: 0.75, alignItems: 'center' }}>
+          <Checkbox size="small" checked={isSelected} disableRipple sx={{ p: 0, mr: 0.25 }} />
+          <Typography variant="body2" noWrap sx={{ flex: 1, minWidth: 0 }}>
+            {option}
+          </Typography>
+        </Box>
+      )}
       renderValue={(value, getItemProps) =>
         value.map((option, index) => <Chip {...getItemProps({ index })} key={option} label={option} size="small" />)
       }

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -39,6 +39,7 @@ import { useNavigationStore } from '../state/navigation.js';
 import { useTabsStore } from '../state/tabs.js';
 import { applySavedViewGridState } from '../state/saved-view.js';
 import { GROUP_ICONS } from './tab-meta.js';
+import { TruncationTooltip } from '../components/truncation.js';
 
 const WIDTH = layout.navDrawerWidth;
 // Indent of group items so they line up under the group label (button pl 16px + icon 26px).
@@ -256,15 +257,17 @@ function NavEntry({
       {icon && (
         <ListItemIcon sx={{ minWidth: 26, color: 'text.secondary', '& svg': { fontSize: 17 } }}>{icon}</ListItemIcon>
       )}
-      <ListItemText
-        primary={label}
-        secondary={subtitle}
-        sx={{ my: subtitle ? 0.25 : undefined }}
-        slotProps={{
-          primary: { variant: 'body2', noWrap: true, sx: subtitle ? { lineHeight: 1.25 } : undefined },
-          secondary: { noWrap: true, title: subtitle, sx: { fontSize: 10.5, fontStyle: 'italic', lineHeight: 1.1 } },
-        }}
-      />
+      <TruncationTooltip text={label} measureSelector=".MuiListItemText-primary">
+        <ListItemText
+          primary={label}
+          secondary={subtitle}
+          sx={{ my: subtitle ? 0.25 : undefined }}
+          slotProps={{
+            primary: { variant: 'body2', noWrap: true, sx: subtitle ? { lineHeight: 1.25 } : undefined },
+            secondary: { noWrap: true, title: subtitle, sx: { fontSize: 10.5, fontStyle: 'italic', lineHeight: 1.1 } },
+          }}
+        />
+      </TruncationTooltip>
     </ListItemButton>
   );
   if (!favorite) return button;
@@ -439,12 +442,23 @@ function CustomGroupHeader({
       dense
       aria-expanded={open}
       onClick={onClick}
-      sx={{ pl: indent, pr: 1.5, py: 0.25, mt: 0.5, color: active ? 'primary.main' : open ? 'text.primary' : 'text.secondary' }}
+      sx={{ pl: indent, pr: 1.5, py: 0.375, mt: 0.5, color: active ? 'primary.main' : open ? 'text.primary' : 'text.secondary' }}
     >
-      <ListItemText
-        primary={label}
-        slotProps={{ primary: { variant: 'caption', noWrap: true, title: title ?? label, sx: { fontWeight: subordinate ? 600 : 700, lineHeight: 1.4 } } }}
-      />
+      {/* Same body2 size as the kind rows below — hierarchy comes from the
+          600 weight, indent and rail, not from switching to a smaller bold
+          caption face that reads as foreign next to the rest of the nav.
+          Subgroups tooltip their full API group even untruncated (`always`),
+          since the visible label is only the domain-stripped suffix. */}
+      <TruncationTooltip
+        text={title ?? label}
+        always={!!title && title !== label}
+        measureSelector=".MuiListItemText-primary"
+      >
+        <ListItemText
+          primary={label}
+          slotProps={{ primary: { variant: 'body2', noWrap: true, sx: { fontWeight: 600, lineHeight: 1.4 } } }}
+        />
+      </TruncationTooltip>
       {count !== undefined && (
         <Typography variant="caption" aria-hidden sx={{ ml: 0.5, color: 'text.disabled', fontVariantNumeric: 'tabular-nums' }}>
           {count}
@@ -853,7 +867,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
           borderColor: 'divider',
           overflowY: 'auto',
           overflowX: 'hidden',
-          bgcolor: (theme) => (theme.palette.mode === 'dark' ? '#151518' : '#f4f4f5'),
+          bgcolor: (theme) => theme.palette.sidebar,
           ...(overlay
             ? { top: `${layout.topBarHeight}px`, height: `calc(100% - ${layout.topBarHeight}px)` }
             : { position: 'relative', transition: 'width 150ms ease' }),

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -422,7 +422,6 @@ function CustomGroupHeader({
   indent,
   open,
   active,
-  subordinate,
   onClick,
 }: {
   label: string;
@@ -433,8 +432,6 @@ function CustomGroupHeader({
   open: boolean;
   /** The current page lives inside this branch — color it as the active trail. */
   active?: boolean;
-  /** Nested one level down; rendered lighter than top-level entries. */
-  subordinate?: boolean;
   onClick: () => void;
 }) {
   return (
@@ -1073,7 +1070,6 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                                 indent={SUB_INDENT}
                                 open={isOpen(sgKey)}
                                 active={activeChain.includes(sgKey)}
-                                subordinate
                                 onClick={() => toggleGroup(sgKey)}
                               />
                               <Collapse in={isOpen(sgKey)}>

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -331,7 +331,12 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
                         secondary={row.result.subtitle}
                         slotProps={{ primary: { noWrap: true }, secondary: { noWrap: true } }}
                       />
-                      <Chip size="small" label={row.result.kind} color={RESULT_CHIP_COLOR[row.result.kind]} variant="outlined" sx={{ mr: 0.5 }} />
+                      {/* Resources dominate the results and already name their
+                          kind in the title — a chip on every row is noise, so
+                          only the rarer kind/page results get tagged. */}
+                      {row.result.kind !== 'resource' && (
+                        <Chip size="small" label={row.result.kind} color={RESULT_CHIP_COLOR[row.result.kind]} variant="outlined" sx={{ mr: 0.5 }} />
+                      )}
                       {row.result.ref && (
                         <Tooltip title="Actions (Tab)">
                           <IconButton

--- a/client/src/layout/TabsBar.tsx
+++ b/client/src/layout/TabsBar.tsx
@@ -14,6 +14,7 @@ import { useClustersStore } from '../state/clusters.js';
 import { applySavedViewGridState } from '../state/saved-view.js';
 import { useApiResourcesForContexts } from '../api/queries.js';
 import { tabMeta } from './tab-meta.js';
+import { TruncationTooltip } from '../components/truncation.js';
 
 // Electron always starts at '/'; on the first mount we reopen the tab the user
 // left active. Module-scoped so StrictMode's double effect doesn't re-restore.
@@ -83,7 +84,7 @@ export const TabsBar = memo(function TabsBar() {
         flexShrink: 0,
         borderBottom: 1,
         borderColor: 'divider',
-        bgcolor: (theme) => (theme.palette.mode === 'dark' ? '#151518' : '#f4f4f5'),
+        bgcolor: (theme) => theme.palette.sidebar,
       }}
     >
       <Box
@@ -183,9 +184,11 @@ export const TabsBar = memo(function TabsBar() {
               }}
             >
               <Box sx={{ display: 'flex', color: 'text.secondary', '& svg': { fontSize: 15 } }}>{meta.icon}</Box>
-              <Typography variant="body2" noWrap sx={{ flex: 1, fontSize: 12.5 }}>
-                {meta.title}
-              </Typography>
+              <TruncationTooltip text={meta.title}>
+                <Typography variant="body2" noWrap sx={{ flex: 1, fontSize: 12.5 }}>
+                  {meta.title}
+                </Typography>
+              </TruncationTooltip>
               <IconButton
                 className="tab-close"
                 size="small"

--- a/client/src/layout/TopBar.tsx
+++ b/client/src/layout/TopBar.tsx
@@ -101,13 +101,13 @@ export const TopBar = memo(function TopBar() {
           <NamespaceFilter />
           <Box sx={{ flex: 1 }} />
           <Tooltip title={`Search (${HOTKEY_MOD_LABEL}K)`}>
-            <IconButton size="small" onClick={() => setSearchOpen(true)} onMouseEnter={() => void loadSearchDialog()} onFocus={() => void loadSearchDialog()}>
+            <IconButton size="small" aria-label="Search" onClick={() => setSearchOpen(true)} onMouseEnter={() => void loadSearchDialog()} onFocus={() => void loadSearchDialog()}>
               <SearchIcon fontSize="small" />
             </IconButton>
           </Tooltip>
           {dockTabCount > 0 && (
             <Tooltip title={dockOpen ? `Hide dock (${HOTKEY_MOD_LABEL}J)` : `Show dock — ${dockTabCount} tabs (${HOTKEY_MOD_LABEL}J)`}>
-              <IconButton size="small" onClick={() => setDockOpen(!dockOpen)} color={dockOpen ? 'primary' : 'default'}>
+              <IconButton size="small" aria-label={dockOpen ? 'Hide dock' : 'Show dock'} onClick={() => setDockOpen(!dockOpen)} color={dockOpen ? 'primary' : 'default'}>
                 <TerminalIcon fontSize="small" />
               </IconButton>
             </Tooltip>
@@ -118,12 +118,12 @@ export const TopBar = memo(function TopBar() {
             </IconButton>
           </Tooltip>
           <Tooltip title={mode === 'light' ? 'Switch to dark mode' : mode === 'dark' ? 'Follow system theme' : 'Switch to light mode'}>
-            <IconButton size="small" onClick={toggleTheme}>
+            <IconButton size="small" aria-label="Toggle theme" onClick={toggleTheme}>
               {mode === 'light' ? <DarkModeOutlinedIcon fontSize="small" /> : mode === 'dark' ? <BrightnessAutoOutlinedIcon fontSize="small" /> : <LightModeOutlinedIcon fontSize="small" />}
             </IconButton>
           </Tooltip>
           <Tooltip title={`Settings (${HOTKEY_MOD_LABEL},)`}>
-            <IconButton size="small" onClick={() => setSettingsOpen(true)} onMouseEnter={() => void loadSettingsDialog()} onFocus={() => void loadSettingsDialog()}>
+            <IconButton size="small" aria-label="Settings" onClick={() => setSettingsOpen(true)} onMouseEnter={() => void loadSettingsDialog()} onFocus={() => void loadSettingsDialog()}>
               <SettingsOutlinedIcon fontSize="small" />
             </IconButton>
           </Tooltip>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,6 @@
+import '@fontsource-variable/inter';
+import '@fontsource/jetbrains-mono/400.css';
+import '@fontsource/jetbrains-mono/500.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { MutationCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/client/src/pages/DiffPage.tsx
+++ b/client/src/pages/DiffPage.tsx
@@ -77,7 +77,7 @@ export function DiffPage() {
           <SidePicker label="Right" side={right} onChange={setRight} />
         </Grid>
       </Grid>
-      <Box sx={{ flex: 1, minHeight: 0, border: 1, borderColor: 'divider', borderRadius: 2, overflow: 'hidden' }}>
+      <Box sx={{ flex: 1, minHeight: 0, border: 1, borderColor: 'divider', borderRadius: 1.5, overflow: 'hidden' }}>
         {leftText && rightText ? (
           <DiffViewer left={leftText} right={rightText} />
         ) : (
@@ -100,10 +100,12 @@ function SidePicker({ label, side, onChange }: { label: string; side: Side; onCh
   const listableKinds = useMemo(() => (kinds ?? []).filter((k) => k.verbs.includes('get')).sort((a, b) => a.kind.localeCompare(b.kind) || a.group.localeCompare(b.group)), [kinds]);
 
   return (
-    <Stack direction="row" spacing={1}>
+    // Flexible widths + wrapping: once the namespace picker appears, four
+    // fixed-width controls per side would ellipsize every selected value.
+    <Stack direction="row" spacing={1} useFlexGap sx={{ flexWrap: 'wrap' }}>
       <Autocomplete
         size="small"
-        sx={{ width: 170 }}
+        sx={{ flex: '1 1 150px', minWidth: 150 }}
         options={activeContexts}
         value={side.ctx ?? null}
         onChange={(_e, ctx) => onChange({ ctx: ctx ?? undefined })}
@@ -111,7 +113,7 @@ function SidePicker({ label, side, onChange }: { label: string; side: Side; onCh
       />
       <Autocomplete
         size="small"
-        sx={{ width: 200 }}
+        sx={{ flex: '1 1 170px', minWidth: 170 }}
         options={listableKinds}
         getOptionLabel={(k) => (k.group ? `${k.kind} (${k.group})` : k.kind)}
         value={side.kind ?? null}
@@ -123,7 +125,7 @@ function SidePicker({ label, side, onChange }: { label: string; side: Side; onCh
       {side.kind?.namespaced && (
         <Autocomplete
           size="small"
-          sx={{ width: 160 }}
+          sx={{ flex: '1 1 150px', minWidth: 150 }}
           options={namespaces ?? []}
           value={side.namespace ?? null}
           onChange={(_e, namespace) => onChange({ ...side, namespace: namespace ?? undefined, name: undefined })}
@@ -132,7 +134,7 @@ function SidePicker({ label, side, onChange }: { label: string; side: Side; onCh
       )}
       <Autocomplete
         size="small"
-        sx={{ flex: 1, minWidth: 160 }}
+        sx={{ flex: '2 1 180px', minWidth: 180 }}
         options={names ?? []}
         value={side.name ?? null}
         onChange={(_e, name) => onChange({ ...side, name: name ?? undefined })}

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -25,6 +25,7 @@ import { SmartFilterInput } from '../components/SmartFilterInput.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { NoClustersState } from '../components/NoClustersState.js';
 import { PageHeader } from '../components/PageHeader.js';
+import { countLabel } from '../components/format.js';
 
 interface EventObj extends KubeObject {
   type?: string;
@@ -199,7 +200,7 @@ export function EventsPage() {
         headerName: 'Type',
         width: 90,
         valueGetter: (_v, row) => row.ev.type ?? '',
-        renderCell: (p) => <StatusChip status={p.row.ev.type === 'Warning' ? 'Error' : 'Ready'} />,
+        renderCell: (p) => <StatusChip status={p.row.ev.type ?? ''} />,
       },
       { field: 'reason', headerName: 'Reason', width: 150, valueGetter: (_v, row) => row.ev.reason ?? '' },
       {
@@ -245,7 +246,7 @@ export function EventsPage() {
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Box sx={{ px: 1.5, pt: 1.5 }}>
         <PageHeader title="Events" icon={<NotificationsNoneOutlinedIcon />}>
-          <Chip label={`${rows.length} events`} variant="outlined" />
+          <Chip label={countLabel(rows.length, 'event')} variant="outlined" />
         </PageHeader>
         {errors.map(([ctx, s]) => (
           <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -24,6 +24,7 @@ import { NoClustersState } from '../components/NoClustersState.js';
 import { PageHeader } from '../components/PageHeader.js';
 import { helmOperationPhaseLabel, helmOperationReleaseKey } from '../components/HelmOperationStatus.js';
 import { HelmOperationsOverview } from '../components/HelmOperationsOverview.js';
+import { countLabel } from '../components/format.js';
 
 const HelmInstallDialog = lazy(() => import('../components/HelmInstallDialog.js'));
 
@@ -162,7 +163,7 @@ export function HelmPage() {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5, pt: 1.5 }}>
       <PageHeader title="Helm Releases" icon={<SailingOutlinedIcon />}>
-        <Chip label={`${rows.length} releases`} variant="outlined" />
+        <Chip label={countLabel(rows.length, 'release')} variant="outlined" />
         {availableUpdates > 0 ? <Chip label={`${availableUpdates} update${availableUpdates === 1 ? '' : 's'} available`} color="primary" /> : null}
         <Tooltip title="Check chart repositories for updates">
           <span>

--- a/client/src/pages/MetricsPage.tsx
+++ b/client/src/pages/MetricsPage.tsx
@@ -33,15 +33,10 @@ import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { NoClustersState } from '../components/NoClustersState.js';
 import { InstallMetricsServerButton, UninstallMetricsServerButton } from '../components/MetricsServerControls.js';
 import { formatBytes, formatCpu } from '../components/format.js';
+import { SERIES_DARK, SERIES_LIGHT, timeTickFormatter } from '../components/chart-theme.js';
 
-// Categorical palette from the validated dataviz reference set (adjacent-pair
-// CVD-safe in this order — do not re-order or cycle past 8 series).
-const SERIES_LIGHT = ['#2a78d6', '#008300', '#e87ba4', '#eda100', '#1baf7a', '#eb6834', '#4a3aa7', '#e34948'];
-const SERIES_DARK = ['#3987e5', '#008300', '#d55181', '#c98500', '#199e70', '#d95926', '#9085e9', '#e66767'];
 const MAX_NODE_SERIES = 8;
 const MAX_NAMESPACE_BARS = 10;
-
-const timeFormatter = (d: Date) => d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
 export function MetricsPage() {
   const selected = useClustersStore((s) => s.selected);
@@ -272,7 +267,7 @@ function UsageLineChart({
         area,
         valueFormatter: (v: number | null) => (v === null ? '' : fmt(v)),
       }))}
-      xAxis={[{ data: times, scaleType: 'time', valueFormatter: timeFormatter }]}
+      xAxis={[{ data: times, scaleType: 'time', valueFormatter: timeTickFormatter(times) }]}
       yAxis={[{ min: 0, valueFormatter: (v: number) => fmt(v), width: 56 }]}
       grid={{ horizontal: true }}
       hideLegend={hideLegend ?? entries.length < 2}
@@ -387,7 +382,7 @@ function StatTile({ icon, label, value, sub }: { icon: React.ReactElement; label
             sx={(theme) => ({
               width: 36,
               height: 36,
-              borderRadius: 2,
+              borderRadius: 1.5,
               flexShrink: 0,
               display: 'grid',
               placeItems: 'center',

--- a/client/src/pages/NetworkMetricsPage.tsx
+++ b/client/src/pages/NetworkMetricsPage.tsx
@@ -29,13 +29,12 @@ import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { NoClustersState } from '../components/NoClustersState.js';
 import { InstallNetworkAgentButton, UninstallNetworkAgentButton } from '../components/NetworkAgentControls.js';
 import { formatBps } from '../components/format.js';
+import { SERIES_DARK, SERIES_LIGHT, timeTickFormatter } from '../components/chart-theme.js';
 
-// Sent/received pair from the validated dataviz palette (same set as MetricsPage).
-const SENT_COLOR = { light: '#2a78d6', dark: '#3987e5' };
-const RECV_COLOR = { light: '#008300', dark: '#008300' };
+// Sent/received pair from the shared chart palette (same set as MetricsPage).
+const SENT_COLOR = { light: SERIES_LIGHT[0]!, dark: SERIES_DARK[0]! };
+const RECV_COLOR = { light: SERIES_LIGHT[1]!, dark: SERIES_DARK[1]! };
 const MAX_LINK_ROWS = 50;
-
-const timeFormatter = (d: Date) => d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
 export function NetworkMetricsPage() {
   const selected = useClustersStore((s) => s.selected);
@@ -173,7 +172,7 @@ function ThroughputLineChart({ series, color }: { series: ClusterNetworkSummary[
           valueFormatter: (v: number | null) => (v === null ? '' : formatBps(v)),
         },
       ]}
-      xAxis={[{ data: times, scaleType: 'time', valueFormatter: timeFormatter }]}
+      xAxis={[{ data: times, scaleType: 'time', valueFormatter: timeTickFormatter(times) }]}
       yAxis={[{ min: 0, valueFormatter: (v: number) => formatBps(v), width: 72 }]}
       grid={{ horizontal: true }}
       hideLegend
@@ -305,7 +304,7 @@ function StatTile({ icon, label, value, sub }: { icon: React.ReactElement; label
             sx={(theme) => ({
               width: 36,
               height: 36,
-              borderRadius: 2,
+              borderRadius: 1.5,
               flexShrink: 0,
               display: 'grid',
               placeItems: 'center',

--- a/client/src/pages/PortForwardsPage.tsx
+++ b/client/src/pages/PortForwardsPage.tsx
@@ -49,7 +49,7 @@ export function PortForwardsPage() {
         renderCell: (p) => (
           <Tooltip title={p.row.error ?? ''}>
             <span>
-              <StatusChip status={p.row.state === 'active' ? 'Ready' : 'Error'} />
+              <StatusChip status={p.row.state === 'active' ? 'Active' : 'Error'} />
             </span>
           </Tooltip>
         ),

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -783,6 +783,7 @@ export function ResourceListPage() {
             <YamlEditor
               value={createTemplate(kind, group, version)}
               applyLabel="Create"
+              applyUnchanged
               schema={selected[0] ? { ctx: selected[0], group, version, kind } : undefined}
               onApply={async (text) => {
                 await create.mutateAsync({ ctx: selected[0]!, yamlBody: text });

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -2,6 +2,17 @@ import type { ElementType } from 'react';
 import { alpha, createTheme, type Theme } from '@mui/material/styles';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
+declare module '@mui/material/styles' {
+  /** Chrome surfaces (top bar, nav rail, tab strip) share this background —
+   *  exposed on the palette so no component re-hardcodes the hex. */
+  interface Palette {
+    sidebar: string;
+  }
+  interface PaletteOptions {
+    sidebar?: string;
+  }
+}
+
 /**
  * Shared layout dimensions. Several of these are cross-file contracts:
  * anything that changes one side must keep the other in sync, so both sides
@@ -26,6 +37,16 @@ export const layout = {
 } as const;
 
 const modalBackdropAlpha = 0.5;
+
+/**
+ * Status hue for small colored text (status words, ready counts). The bright
+ * palette mains pass contrast on dark paper but fail WCAG AA as 12-13px text
+ * on the light backgrounds, so light mode drops to the pinned `dark` variant.
+ */
+export const statusTextColor =
+  (color: 'success' | 'error' | 'warning' | 'info') =>
+  (theme: Theme): string =>
+    theme.palette.mode === 'dark' ? theme.palette[color].main : theme.palette[color].dark;
 
 const darkColors = {
         primary: '#6e8bfb',
@@ -98,17 +119,25 @@ export function buildTheme(mode: 'light' | 'dark', options: { modalBackdrop?: El
       mode,
       primary: { main: c.primary },
       secondary: { main: c.secondary },
-      success: { main: c.success },
-      warning: { main: c.warning },
-      error: { main: c.error },
-      info: { main: c.info },
+      // Light mode pins the `dark` variants to hues that pass WCAG AA as
+      // small text on the near-white backgrounds (see statusTextColor).
+      success: { main: c.success, ...(dark ? {} : { dark: '#15803d' }) },
+      warning: { main: c.warning, ...(dark ? {} : { dark: '#8f6209' }) },
+      error: { main: c.error, ...(dark ? {} : { dark: '#b91c1c' }) },
+      info: { main: c.info, ...(dark ? {} : { dark: '#1d4ed8' }) },
       divider: c.divider,
+      sidebar: c.sidebar,
       background: { default: c.bgDefault, paper: c.bgPaper },
-      text: { primary: c.textPrimary, secondary: c.textSecondary },
+      // `disabled` is used as the dimmest text tier; keying it off the
+      // secondary hue keeps the two muted greys in the same family instead
+      // of MUI's unrelated default.
+      text: { primary: c.textPrimary, secondary: c.textSecondary, disabled: alpha(c.textSecondary, dark ? 0.55 : 0.6) },
     },
     shape: { borderRadius: 8 },
     typography: {
-      fontFamily: '"Inter", -apple-system, "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif',
+      // Bundled variable font (see main.tsx) — variable weights make the
+      // 550 emphasis tier real instead of snapping to 600.
+      fontFamily: '"Inter Variable", "Inter", -apple-system, "Segoe UI", "Roboto", "Helvetica", "Arial", sans-serif',
       fontSize: 13,
       h5: { fontWeight: 600, letterSpacing: -0.2 },
       h6: { fontWeight: 600, letterSpacing: -0.2 },
@@ -161,6 +190,9 @@ export function buildTheme(mode: 'light' | 'dark', options: { modalBackdrop?: El
       MuiButton: {
         defaultProps: { size: 'small' },
         styleOverrides: { root: { textTransform: 'none', borderRadius: 7 } },
+      },
+      MuiToggleButton: {
+        styleOverrides: { root: { textTransform: 'none', fontWeight: 550 } },
       },
       MuiTextField: { defaultProps: { size: 'small' } },
       MuiOutlinedInput: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@fontsource-variable/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@kubus/shared':
         specifier: workspace:*
         version: link:../shared
@@ -563,6 +569,12 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource-variable/inter@5.3.0':
+    resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
+
+  '@fontsource/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -4136,6 +4148,10 @@ snapshots:
       - utf-8-validate
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@fontsource-variable/inter@5.3.0': {}
+
+  '@fontsource/jetbrains-mono@5.3.0': {}
 
   '@img/colour@1.1.0': {}
 


### PR DESCRIPTION
A broad polish pass over the client, driven by a screenshot review of every major surface in both themes.

## Color semantics
- Status text (`StatusChip`, ready counts, warning captions) now passes WCAG AA in light mode via a `statusTextColor` helper backed by pinned palette `dark` variants; dark mode keeps the bright hues
- Events show their real `Normal`/`Warning` type instead of an invented Ready/Error, matching the "Warnings only" toggle
- Unhealthy condition chips spell out the status (`Available: False`) so color and wording agree; port forwards read "Active"
- Succeeded pods no longer flag their `0/1` ready count as a warning

## Charts & topology
- New shared chart palette (`chart-theme.ts`) with per-mode series colors — the detail-drawer Metrics tab no longer hardcodes dark-theme hues that washed out on white
- Time axes include seconds on short ranges (no more duplicate `06:07 PM` ticks); drawer chart areas use the same soft fill as the metrics page
- Topology node/edge colors come from the theme with dark-mode variants; repeated edge labels (`schedules` ×5) dedupe per fan-in/out group
- Log level-filter chips get light-mode legible colors

## Typography & layout
- Inter (variable) and JetBrains Mono are now self-hosted via fontsource: the 550 emphasis tier renders for real instead of snapping to 600, and the desktop app looks identical offline
- Detail tables wrap at word boundaries instead of `break-all`; probe targets get width priority
- Overview stat cards drop to four columns at mid widths so values never ellipsize; diff pickers wrap into readable rows; toasts sit above the terminal/logs dock instead of covering it
- CRD nav tree headers use the same type as the rest of the nav

## Details
- Truncated names (list cells, nav entries, page tabs, drawer header, CRD tree) reveal the full name in a themed, non-interactive tooltip on hover — only when actually cut off
- "1 item" instead of "1 items"; sentence-case toggle buttons; friendly empty-list state that distinguishes an empty scope from filters hiding everything; namespace filter shows option checkboxes; command palette drops the redundant per-row "resource" chip; the create dialog enables its button on the unedited template
- aria-labels for the per-row actions menu, dock tab close, drawer back button and top-bar icons
- Consistency sweep: `fontWeight: 650` → 600, `text.disabled` derived from the secondary hue, off-scale radii normalized, unified overlay shadow, sidebar color exposed as `palette.sidebar`

Verified with light+dark screenshot sweeps against the kind dev clusters; client build (`tsc` + vite) is clean.