### PR TITLE
Fix false metrics-server prompt on startup and stream overview sections

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -18,6 +18,8 @@ import type {
   MetricsServerUninstallResult,
   MetricsSnapshot,
   NamespaceOverview,
+  OperatorRollup,
+  OverviewCertificates,
   PodResourcesResponse,
   ClusterNetworkSummary,
   NetworkAgentInstallResult,
@@ -777,7 +779,7 @@ export function useResourceMetrics(contexts: string[], kind: 'pods' | 'nodes') {
         queryKey: ['metrics-snapshot', kind, ctx] as const,
         queryFn: () =>
           apiFetch<MetricsSnapshot>(`/api/contexts/${encodeURIComponent(ctx)}/metrics/${kind}`).catch(
-            () => ({ available: false, items: [] }) as MetricsSnapshot,
+            () => ({ available: false, probed: true, items: [] }) as MetricsSnapshot,
           ),
         refetchInterval: interval,
       })),
@@ -940,6 +942,37 @@ export function useOverview(ctx: string) {
     queryKey: ['overview', ctx],
     queryFn: () => apiFetch<ClusterOverview>(`/api/contexts/${encodeURIComponent(ctx)}/overview`),
     refetchInterval: useRefetchInterval(10_000),
+  });
+}
+
+/** Overview sections that warm up slowly stream in behind the core payload. */
+function overviewSectionQuery(ctx: string, section: 'operators' | 'certificates', namespaces?: string[]) {
+  const key = namespaces && namespaces.length > 0 ? [...namespaces].sort().join(',') : '';
+  return {
+    queryKey: [`overview-${section}`, ctx, key],
+    path: `/api/contexts/${encodeURIComponent(ctx)}/overview/${section}${key ? `?namespaces=${encodeURIComponent(key)}` : ''}`,
+  };
+}
+
+/** Operator rollups (cert-manager, Argo, Flux…), optionally namespace-scoped. */
+export function useOverviewOperators(ctx: string, namespaces?: string[]) {
+  const { queryKey, path } = overviewSectionQuery(ctx, 'operators', namespaces);
+  return useQuery({
+    queryKey,
+    queryFn: () => apiFetch<OperatorRollup[]>(path),
+    refetchInterval: useRefetchInterval(15_000),
+    placeholderData: keepPreviousData,
+  });
+}
+
+/** TLS certificate expiry rollup, optionally namespace-scoped. */
+export function useOverviewCertificates(ctx: string, namespaces?: string[]) {
+  const { queryKey, path } = overviewSectionQuery(ctx, 'certificates', namespaces);
+  return useQuery({
+    queryKey,
+    queryFn: () => apiFetch<OverviewCertificates>(path),
+    refetchInterval: useRefetchInterval(30_000),
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -954,25 +954,27 @@ function overviewSectionQuery(ctx: string, section: 'operators' | 'certificates'
   };
 }
 
-/** Operator rollups (cert-manager, Argo, Flux…), optionally namespace-scoped. */
+/**
+ * Operator rollups (cert-manager, Argo, Flux…), optionally namespace-scoped.
+ * No placeholder across key changes: a namespace switch must not show the
+ * previous scope's rollups while the new scope loads.
+ */
 export function useOverviewOperators(ctx: string, namespaces?: string[]) {
   const { queryKey, path } = overviewSectionQuery(ctx, 'operators', namespaces);
   return useQuery({
     queryKey,
     queryFn: () => apiFetch<OperatorRollup[]>(path),
     refetchInterval: useRefetchInterval(15_000),
-    placeholderData: keepPreviousData,
   });
 }
 
-/** TLS certificate expiry rollup, optionally namespace-scoped. */
+/** TLS certificate expiry rollup, optionally namespace-scoped. Same no-placeholder rule as operators. */
 export function useOverviewCertificates(ctx: string, namespaces?: string[]) {
   const { queryKey, path } = overviewSectionQuery(ctx, 'certificates', namespaces);
   return useQuery({
     queryKey,
     queryFn: () => apiFetch<OverviewCertificates>(path),
     refetchInterval: useRefetchInterval(30_000),
-    placeholderData: keepPreviousData,
   });
 }
 

--- a/client/src/components/MetricsChartImpl.tsx
+++ b/client/src/components/MetricsChartImpl.tsx
@@ -13,7 +13,16 @@ export default function MetricsChartImpl({ ctx, kind, name, namespace }: Metrics
   const { data } = useMetricsHistory({ ctx, kind, name, namespace });
   const series = useTheme().palette.mode === 'dark' ? SERIES_DARK : SERIES_LIGHT;
 
-  if (!data?.available) {
+  // Query in flight, or the server's poller hasn't finished its first probe —
+  // availability is unknown, so don't claim metrics-server is missing yet.
+  if (!data || !data.probed) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+        Loading metrics…
+      </Typography>
+    );
+  }
+  if (!data.available) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
         Metrics unavailable — is metrics-server installed in this cluster?

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -25,15 +25,17 @@ import { statusTextColor } from '../../theme.js';
  * List links inherit the same global filter.
  */
 export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; namespaces: string[] }) {
-  const { data, isLoading, error } = useNamespaceOverview(ctx, namespaces);
+  const { data, isLoading, error, isPlaceholderData } = useNamespaceOverview(ctx, namespaces);
   // Operator rollups and certificates warm up slowly (operator CR lists, the
   // all-secrets watcher) — they stream in behind the inventory and health.
   const { data: operators } = useOverviewOperators(ctx, namespaces);
   const { data: certificates } = useOverviewCertificates(ctx, namespaces);
   const single = namespaces.length === 1;
-  // The success alert must agree with every problem card above it.
+  // The success alert must agree with every problem card above it — and never
+  // judge a stale previous-scope placeholder against fresh operators/certs.
   const healthy =
     !!data &&
+    !isPlaceholderData &&
     data.issues.length === 0 &&
     data.failingPods.length === 0 &&
     data.warningEvents.length === 0 &&

--- a/client/src/components/overview/NamespaceOverviewSection.tsx
+++ b/client/src/components/overview/NamespaceOverviewSection.tsx
@@ -7,7 +7,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useNavigate } from 'react-router';
 import { pluralLabel, type NamespaceInventoryEntry, type NamespaceQuotaStatus } from '@kubus/shared';
-import { useNamespaceOverview } from '../../api/queries.js';
+import { useNamespaceOverview, useOverviewCertificates, useOverviewOperators } from '../../api/queries.js';
 import { StatusChip } from '../StatusChip.js';
 import { usageColor } from '../UsageMeter.js';
 import { CertExpiryCard } from './CertExpiryCard.js';
@@ -26,6 +26,10 @@ import { statusTextColor } from '../../theme.js';
  */
 export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; namespaces: string[] }) {
   const { data, isLoading, error } = useNamespaceOverview(ctx, namespaces);
+  // Operator rollups and certificates warm up slowly (operator CR lists, the
+  // all-secrets watcher) — they stream in behind the inventory and health.
+  const { data: operators } = useOverviewOperators(ctx, namespaces);
+  const { data: certificates } = useOverviewCertificates(ctx, namespaces);
   const single = namespaces.length === 1;
   // The success alert must agree with every problem card above it.
   const healthy =
@@ -33,8 +37,10 @@ export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; nam
     data.issues.length === 0 &&
     data.failingPods.length === 0 &&
     data.warningEvents.length === 0 &&
-    data.certificates.expiring.length === 0 &&
-    data.operators.every((op) => op.resources.every((r) => r.issues.length === 0 && r.ready >= r.total));
+    !!certificates &&
+    certificates.expiring.length === 0 &&
+    !!operators &&
+    operators.every((op) => op.resources.every((r) => r.issues.length === 0 && r.ready >= r.total));
 
   return (
     <>
@@ -62,9 +68,9 @@ export function NamespaceOverviewSection({ ctx, namespaces }: { ctx: string; nam
 
           <WorkloadHealthSection ctx={ctx} health={data.workloadHealth} issues={data.issues} scoped hideNamespace={single} />
 
-          <OperatorSection ctx={ctx} operators={data.operators} scoped />
+          {operators && <OperatorSection ctx={ctx} operators={operators} scoped />}
 
-          <CertExpiryCard ctx={ctx} certificates={data.certificates} hideNamespace={single} />
+          {certificates && <CertExpiryCard ctx={ctx} certificates={certificates} hideNamespace={single} />}
 
           {data.quotas.length > 0 && <QuotasCard quotas={data.quotas} />}
 

--- a/client/src/components/overview/cards.tsx
+++ b/client/src/components/overview/cards.tsx
@@ -121,7 +121,7 @@ export function StatCard({
   onClick,
 }: {
   label: string;
-  value: number | string;
+  value: React.ReactNode;
   sub?: string;
   warn?: boolean;
   icon?: React.ReactElement;

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -24,7 +24,7 @@ import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 import VerifiedUserOutlinedIcon from '@mui/icons-material/VerifiedUserOutlined';
 import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router';
-import { useContexts, useKubeconfigSettings, useNodeMetrics, useOverview } from '../api/queries.js';
+import { useContexts, useKubeconfigSettings, useNodeMetrics, useOverview, useOverviewCertificates, useOverviewOperators } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 import { ClusterSectionHeader } from '../components/ClusterSectionHeader.js';
 import { InstallMetricsServerButton } from '../components/MetricsServerControls.js';
@@ -157,6 +157,10 @@ function ClusterOverviewSection({ ctx }: { ctx: string }) {
 function WholeClusterSection({ ctx }: { ctx: string }) {
   const { data, isLoading, error } = useOverview(ctx);
   const { data: nodeMetrics } = useNodeMetrics(ctx);
+  // Slow-warmup sections (all-secrets watcher, operator CR lists, API-server
+  // TLS probe) arrive on their own; the core stats never wait for them.
+  const { data: operators } = useOverviewOperators(ctx);
+  const { data: certificates } = useOverviewCertificates(ctx);
   const navigate = useNavigate();
 
   return (
@@ -207,12 +211,12 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
             />
             <StatCard
               label="TLS certificates"
-              value={data.certificates.expiring.length > 0 ? data.certificates.expiring.length : data.certificates.total}
-              sub={data.certificates.expiring.length > 0 ? 'expiring <30d' : 'tracked'}
-              warn={data.certificates.expiring.length > 0}
+              value={certificates ? (certificates.expiring.length > 0 ? certificates.expiring.length : certificates.total) : <Skeleton width={32} />}
+              sub={certificates ? (certificates.expiring.length > 0 ? 'expiring <30d' : 'tracked') : undefined}
+              warn={(certificates?.expiring.length ?? 0) > 0}
               icon={<VerifiedUserOutlinedIcon />}
               onClick={() => {
-                const certs = data.operators.find((o) => o.id === 'cert-manager')?.resources.find((r) => r.plural === 'certificates');
+                const certs = operators?.find((o) => o.id === 'cert-manager')?.resources.find((r) => r.plural === 'certificates');
                 void navigate(certs ? `/r/${certs.group}/${certs.version}/${certs.plural}` : '/r/core/v1/secrets');
               }}
             />
@@ -236,9 +240,9 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
 
           <WorkloadHealthSection ctx={ctx} health={data.workloadHealth} issues={data.unavailableWorkloads} />
 
-          <OperatorSection ctx={ctx} operators={data.operators} />
+          {operators && <OperatorSection ctx={ctx} operators={operators} />}
 
-          <CertExpiryCard ctx={ctx} certificates={data.certificates} />
+          {certificates && <CertExpiryCard ctx={ctx} certificates={certificates} />}
 
           <PodUsagePanels ctx={ctx} />
 
@@ -259,8 +263,10 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
           {data.failingPods.length === 0 &&
             data.unavailableWorkloads.length === 0 &&
             data.warningEvents.length === 0 &&
-            data.certificates.expiring.length === 0 &&
-            data.operators.every((op) => op.resources.every((r) => r.issues.length === 0 && r.ready >= r.total)) && (
+            certificates &&
+            certificates.expiring.length === 0 &&
+            operators &&
+            operators.every((op) => op.resources.every((r) => r.issues.length === 0 && r.ready >= r.total)) && (
               <Alert severity="success" variant="outlined">
                 No problems detected — all workloads healthy.
               </Alert>
@@ -276,8 +282,8 @@ function OverviewSkeleton() {
   return (
     <>
       <Grid container spacing={1.5} sx={{ mb: 2 }}>
-        {Array.from({ length: 8 }, (_, i) => (
-          <Grid key={i} size={{ xs: 6, sm: 4, md: 2 }}>
+        {Array.from({ length: 10 }, (_, i) => (
+          <Grid key={i} size={{ xs: 6, sm: 4, md: 3, lg: 2 }}>
             <Skeleton variant="rounded" height={62} />
           </Grid>
         ))}
@@ -307,8 +313,10 @@ function NodeUsageCard({ ctx, nodeMetrics }: { ctx: string; nodeMetrics: ReturnT
         <Typography variant="subtitle2" sx={{ mb: 1 }}>
           Node usage
         </Typography>
-        {!nodeMetrics && <LinearProgress />}
-        {nodeMetrics && !nodeMetrics.available && (
+        {/* Before the first poller probe completes, "unavailable" is provisional —
+            keep the progress bar instead of a false install prompt. */}
+        {(!nodeMetrics || !nodeMetrics.probed) && <LinearProgress />}
+        {nodeMetrics?.probed && !nodeMetrics.available && (
           <Alert severity="info" variant="outlined" sx={{ alignItems: 'center' }} action={<InstallMetricsServerButton ctx={ctx} />}>
             CPU and memory usage are unavailable — metrics-server is not serving data in this cluster.
           </Alert>

--- a/server/src/kube/metrics-poller.ts
+++ b/server/src/kube/metrics-poller.ts
@@ -14,6 +14,8 @@ const RING_CAPACITY = 90; // ~30 min at 20s
  */
 export class MetricsPoller {
   available = false;
+  /** At least one probe has completed — before that `available` is provisional, not a verdict. */
+  probed = false;
   private nodes = new Map<string, MetricsSample[]>();
   private pods = new Map<string, MetricsSample[]>(); // key: ns/name
   private latestNodes: MetricsSnapshotEntry[] = [];
@@ -81,6 +83,7 @@ export class MetricsPoller {
   markUnavailable(): void {
     this.epoch++;
     this.available = false;
+    this.probed = true;
     this.latestNodes = [];
     this.latestPods = [];
     if (this.timer) clearTimeout(this.timer);
@@ -139,6 +142,7 @@ export class MetricsPoller {
       this.latestNodes = [];
       this.latestPods = [];
     } finally {
+      this.probed = true;
       this.polling = false;
     }
     if (this.stopped) return;

--- a/server/src/kube/namespace-overview.ts
+++ b/server/src/kube/namespace-overview.ts
@@ -5,9 +5,8 @@ import {
   type NamespaceOverview,
   type NamespaceQuotaStatus,
 } from '@kubus/shared';
-import { collectCertificates } from './cert-expiry.js';
 import type { ClusterHandle } from './cluster-manager.js';
-import { computeOperatorRollups, resolveCrd } from './operator-rollups.js';
+import { resolveCrd } from './operator-rollups.js';
 import { collectWarningEvents, optionalItems, podFailure } from './overview.js';
 import { parseQuantity } from './quantity.js';
 import { HEALTH_KINDS, computeWorkloadHealth, type HealthKindItems } from './workload-health.js';
@@ -155,8 +154,6 @@ export async function computeNamespaceOverview(handle: ClusterHandle, namespaces
       failingPods,
       quotas,
       warningEvents: collectWarningEvents(events, now, await handle.discovery.getResources().catch(() => [])),
-      operators: await computeOperatorRollups(handle, crdsResult.items, scope),
-      certificates: await collectCertificates(handle, crdsResult.items, scope),
     };
   } finally {
     namespacesWatcher.release();

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -1,7 +1,5 @@
 import type { ClusterOverview, KubeObject, OverviewWarningEvent, ResourceKindInfo } from '@kubus/shared';
-import { apiServerCertNotAfter, collectCertificates } from './cert-expiry.js';
 import type { ClusterHandle } from './cluster-manager.js';
-import { computeOperatorRollups } from './operator-rollups.js';
 import { HEALTH_KINDS, computeWorkloadHealth, type HealthKindItems } from './workload-health.js';
 
 const RECENT_MS = 60 * 60 * 1000; // 1h window for restarts/events
@@ -15,7 +13,12 @@ interface ContainerStatus {
 
 const FAILING_WAIT_REASONS = new Set(['CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull', 'CreateContainerConfigError', 'CreateContainerError', 'InvalidImageName', 'RunContainerError']);
 
-/** Compute the health dashboard from already-cached watcher state — no API calls. */
+/**
+ * Compute the health dashboard from already-cached watcher state — no API
+ * calls. Operator rollups and certificate expiry live on their own endpoints
+ * so their (slower) warmups — the all-secrets watcher, operator CR lists, the
+ * API-server TLS probe — never delay the first paint of counts and health.
+ */
 export async function computeOverview(handle: ClusterHandle): Promise<ClusterOverview> {
   const podsWatcher = handle.watchers.acquire('', 'v1', 'pods');
   const deploysWatcher = handle.watchers.acquire('apps', 'v1', 'deployments');
@@ -31,7 +34,9 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
     handle: handle.watchers.acquire(spec.group, spec.version, spec.plural),
   }));
   try {
-    await Promise.all([
+    // Warm every watcher concurrently — the optional ones must not wait for
+    // the core set to finish listing first.
+    const coreReady = Promise.all([
       podsWatcher.watcher.ready(),
       deploysWatcher.watcher.ready(),
       eventsWatcher.watcher.ready(),
@@ -43,6 +48,7 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       optionalItems(crdsWatcher.watcher),
       ...healthWatchers.map((w) => optionalItems(w.handle.watcher)),
     ]);
+    await coreReady;
     const pods = podsWatcher.watcher.items();
     const deployments = deploysWatcher.watcher.items();
     const events = eventsWatcher.watcher.items();
@@ -72,8 +78,6 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       recentRestarts: [],
       warningEvents: [],
       workloadHealth: [],
-      operators: [],
-      certificates: { total: 0, expiring: [] },
     };
 
     const healthBySpec = new Map(healthWatchers.map((w, i) => [w.spec, healthResults[i] ?? { items: [], unavailable: true }]));
@@ -85,13 +89,6 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
     const health = computeWorkloadHealth(healthKinds);
     overview.workloadHealth = health.kinds;
     overview.unavailableWorkloads = health.issues;
-    const [operators, certificates, apiServerNotAfter] = await Promise.all([
-      computeOperatorRollups(handle, crds),
-      collectCertificates(handle, crds),
-      apiServerCertNotAfter(handle),
-    ]);
-    overview.operators = operators;
-    overview.certificates = { ...certificates, apiServerNotAfter };
 
     const now = Date.now();
     for (const pod of pods) {
@@ -229,6 +226,16 @@ function eventTime(e: KubeObject): string {
 function isEstablishedCrd(crd: KubeObject): boolean {
   const conditions = (crd.status as { conditions?: Array<{ type?: string; status?: string }> } | undefined)?.conditions ?? [];
   return conditions.some((c) => c.type === 'Established' && c.status === 'True');
+}
+
+/** Installed CRDs for the operator/certificate endpoints (empty when RBAC-denied). */
+export async function installedCrds(handle: ClusterHandle): Promise<KubeObject[]> {
+  const acquired = handle.watchers.acquire('apiextensions.k8s.io', 'v1', 'customresourcedefinitions');
+  try {
+    return (await optionalItems(acquired.watcher)).items;
+  } finally {
+    acquired.release();
+  }
 }
 
 export async function optionalItems(watcher: {

--- a/server/src/routes/metrics.ts
+++ b/server/src/routes/metrics.ts
@@ -1,13 +1,24 @@
 import type { FastifyInstance } from 'fastify';
-import type { MetricsHistoryResponse, MetricsServerInstallRequest, MetricsSnapshot } from '@kubus/shared';
+import type { MetricsHistoryResponse, MetricsServerInstallRequest, MetricsSnapshot, OverviewCertificates } from '@kubus/shared';
 import type { AppContext } from '../app.js';
+import { apiServerCertNotAfter, collectCertificates } from '../kube/cert-expiry.js';
 import { computeNamespaceOverview } from '../kube/namespace-overview.js';
-import { computeOverview } from '../kube/overview.js';
+import { computeOperatorRollups } from '../kube/operator-rollups.js';
+import { computeOverview, installedCrds } from '../kube/overview.js';
 import { computePodResources } from '../kube/pod-resources.js';
 import { installMetricsServer, metricsServerStatus, uninstallMetricsServer } from '../kube/metrics-server.js';
 import { computeMetricsSummary } from '../kube/metrics-summary.js';
 import { cpuToMilli, memToBytes } from '../kube/quantity.js';
 import { sendError } from '../util/errors.js';
+
+/** Optional `?namespaces=a,b` scope shared by the operator/certificate endpoints. */
+function parseNamespaceScope(raw: string | undefined): ReadonlySet<string> | undefined {
+  const namespaces = (raw ?? '')
+    .split(',')
+    .map((ns) => ns.trim())
+    .filter(Boolean);
+  return namespaces.length > 0 ? new Set(namespaces) : undefined;
+}
 
 export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): void {
   app.get<{ Params: { ctx: string } }>('/api/contexts/:ctx/metrics/nodes', async (req, reply) => {
@@ -24,6 +35,7 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
       }
       const snapshot: MetricsSnapshot = {
         available: poller.available,
+        probed: poller.probed,
         items: items.map((n) => {
           const alloc = capacity.get(n.name);
           return {
@@ -45,6 +57,7 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
       const handle = ctx.clusters.get(req.params.ctx);
       const snapshot: MetricsSnapshot = {
         available: handle.metricsPoller.available,
+        probed: handle.metricsPoller.probed,
         items: handle.metricsPoller.podSnapshot(req.query.namespace || undefined),
       };
       return snapshot;
@@ -60,6 +73,7 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
       const { kind, name, namespace } = req.query;
       const response: MetricsHistoryResponse = {
         available: handle.metricsPoller.available,
+        probed: handle.metricsPoller.probed,
         series: handle.metricsPoller.history(kind, name, namespace || undefined),
       };
       return response;
@@ -113,6 +127,35 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
     try {
       const handle = ctx.clusters.get(req.params.ctx);
       return await computeOverview(handle);
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  // Operator rollups and certificate expiry are split off the main overview
+  // payload: both can involve slow warmups (operator CR lists; the all-secrets
+  // watcher and an API-server TLS probe) and stream in behind the core stats.
+  app.get<{ Params: { ctx: string }; Querystring: { namespaces?: string } }>('/api/contexts/:ctx/overview/operators', async (req, reply) => {
+    try {
+      const handle = ctx.clusters.get(req.params.ctx);
+      return await computeOperatorRollups(handle, await installedCrds(handle), parseNamespaceScope(req.query.namespaces));
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  app.get<{ Params: { ctx: string }; Querystring: { namespaces?: string } }>('/api/contexts/:ctx/overview/certificates', async (req, reply) => {
+    try {
+      const handle = ctx.clusters.get(req.params.ctx);
+      const scope = parseNamespaceScope(req.query.namespaces);
+      const [certificates, apiServerNotAfter] = await Promise.all([
+        installedCrds(handle).then((crds) => collectCertificates(handle, crds, scope)),
+        scope ? undefined : apiServerCertNotAfter(handle),
+      ]);
+      const response: OverviewCertificates = { ...certificates, apiServerNotAfter };
+      return response;
     } catch (err) {
       sendError(reply, err);
       return reply;

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -521,11 +521,15 @@ export interface MetricsSnapshotEntry {
 
 export interface MetricsSnapshot {
   available: boolean;
+  /** At least one metrics probe has completed — until then `available` is provisional. */
+  probed: boolean;
   items: MetricsSnapshotEntry[];
 }
 
 export interface MetricsHistoryResponse {
   available: boolean;
+  /** At least one metrics probe has completed — until then `available` is provisional. */
+  probed: boolean;
   series: MetricsSample[];
 }
 
@@ -772,7 +776,7 @@ export interface OverviewCertificates {
   total: number;
   /** Expired or expiring within 30 days, soonest first. */
   expiring: CertExpiryEntry[];
-  /** API server serving certificate expiry (cluster overview only), from the TLS handshake. */
+  /** API server serving certificate expiry (cluster-wide scope only), from the TLS handshake. */
   apiServerNotAfter?: string;
   /** Secrets are RBAC-denied — TLS secret expiry unknown. */
   secretsUnavailable?: boolean;
@@ -800,10 +804,6 @@ export interface ClusterOverview {
   warningEvents: OverviewWarningEvent[];
   /** Unified per-kind health across workloads, autoscaling, storage, and policy. */
   workloadHealth: OverviewKindHealth[];
-  /** Rollups for operators whose CRDs are installed (cert-manager, Argo, Flux, KEDA, Karpenter). */
-  operators: OperatorRollup[];
-  /** TLS certificate expiry rollup. */
-  certificates: OverviewCertificates;
 }
 
 // ---- Pod resource usage vs requests/limits (overview panels) ----
@@ -865,10 +865,6 @@ export interface NamespaceOverview {
   failingPods: OverviewProblemPod[];
   quotas: NamespaceQuotaStatus[];
   warningEvents: OverviewWarningEvent[];
-  /** Operator rollups scoped to this namespace (namespaced resources only). */
-  operators: OperatorRollup[];
-  /** TLS certificate expiry rollup scoped to this namespace. */
-  certificates: OverviewCertificates;
 }
 
 // ---- Security audit ----


### PR DESCRIPTION
## Problem

- On startup the overview showed "metrics-server is not serving data" with an install button even when metrics-server was installed: the server's metrics poller starts `available = false`, and any request landing before its first poll completed was indistinguishable from a cluster genuinely missing metrics-server. The detail-drawer metrics chart had the same flaw and even claimed metrics were unavailable while its own fetch was still in flight.
- The overview first paint waited on the slowest part of one monolithic `/overview` computation — including the all-secrets watcher warmup for certificate expiry, operator CR lists, and an API-server TLS probe with a 3s timeout (painful on tunneled clusters).

## Changes

**Metrics tri-state**
- `MetricsPoller` exposes a `probed` flag that flips true once the first probe completes (or after uninstall's `markUnavailable`).
- `/metrics/nodes`, `/metrics/pods`, and `/metrics/history` include it; the node-usage card and metrics chart keep a loading state until the first probe settles and only then judge availability.

**Progressive overview**
- `/overview` now returns only the fast core (counts, workload health, failing pods, restarts, warnings), and its watcher warmups run concurrently instead of in two sequential barriers.
- New `/overview/operators` and `/overview/certificates` endpoints (optional `?namespaces=` scope) carry the slow sections; the client fetches them as separate queries so core stats render immediately and operators/certificates stream in when ready.
- The TLS stat card shows a skeleton until its data arrives; the "No problems detected" alert waits for all three queries; the namespace-scoped overview gets the same treatment.

## Verification

- Typecheck, lint, and server tests pass.
- Drove the built client against a fresh isolated server on a kind cluster with metrics-server installed: stat cards painted ~340ms after page load, node usage bars ~940ms, and polling the DOM through the whole warmup window never caught the false install prompt.
- Namespace-scoped view verified end-to-end; scoped certificates omit the API-server cert, matching prior behavior.