### PR TITLE
Polish detail drawers and survive unreachable clusters

### DIFF
--- a/client/src/components/detail/ConfigMapDetail.tsx
+++ b/client/src/components/detail/ConfigMapDetail.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import type { KubeObject } from '@kubus/shared';
 import { formatBytes } from '../format.js';
 import { GenericDetail } from './GenericDetail.js';
+import { Section } from './Section.js';
 import { b64ByteLength } from './data-editor.js';
 
 function stringEntries(obj: KubeObject, field: 'data' | 'binaryData'): Array<[string, string]> {
@@ -25,20 +26,19 @@ export function ConfigMapDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) 
       </Stack>
       {total > 0 && (
         <Box sx={{ px: 2, pt: 2 }}>
-          <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-            Data keys
-          </Typography>
-          <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
-            {textKeys.map(([k, v]) => (
-              <Chip key={k} label={`${k} · ${formatBytes(new TextEncoder().encode(v).length)}`} variant="outlined" title={k} />
-            ))}
-            {binaryKeys.map(([k, v]) => (
-              <Chip key={k} label={`${k} · binary ${formatBytes(b64ByteLength(v))}`} variant="outlined" title={k} />
-            ))}
-          </Stack>
-          <Typography variant="caption" color="text.secondary">
-            View and edit values per key in the Data tab.
-          </Typography>
+          <Section title="Data keys" count={total}>
+            <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+              {textKeys.map(([k, v]) => (
+                <Chip key={k} label={`${k} · ${formatBytes(new TextEncoder().encode(v).length)}`} variant="outlined" title={k} />
+              ))}
+              {binaryKeys.map(([k, v]) => (
+                <Chip key={k} label={`${k} · binary ${formatBytes(b64ByteLength(v))}`} variant="outlined" title={k} />
+              ))}
+            </Stack>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+              View and edit values per key in the Data tab.
+            </Typography>
+          </Section>
         </Box>
       )}
       <GenericDetail obj={obj} ctx={ctx} />

--- a/client/src/components/detail/CrdDetail.tsx
+++ b/client/src/components/detail/CrdDetail.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
@@ -13,6 +12,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import type { KubeObject } from '@kubus/shared';
 import { GenericDetail } from './GenericDetail.js';
+import { Section } from './Section.js';
 import { statusTextColor } from '../../theme.js';
 
 interface JsonSchema {
@@ -121,11 +121,7 @@ export function CrdDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
 
   return (
     <GenericDetail obj={obj} ctx={ctx} hideConditions>
-      <Divider />
-      <Box>
-        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-          Definition
-        </Typography>
+      <Section title="Definition">
         <Table size="small">
           <TableBody>
             <InfoRow label="Group" value={spec.group} />
@@ -139,7 +135,7 @@ export function CrdDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
             <InfoRow label="Categories" value={(names.categories ?? []).join(', ')} />
           </TableBody>
         </Table>
-      </Box>
+      </Section>
     </GenericDetail>
   );
 }
@@ -184,36 +180,30 @@ export function CrdSchemaDetail({ obj, versionName }: { obj: KubeObject; version
         ))}
       </Box>
       {printerColumns.length > 0 && (
-        <>
-          <Divider />
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Printer columns
-            </Typography>
-            <Table size="small">
-              <TableBody>
-                {printerColumns.map((column, index) => (
-                  <TableRow key={`${column.name ?? index}:${column.jsonPath ?? ''}`}>
-                    <TableCell sx={{ width: 180, color: 'text.secondary', border: 0 }}>{column.name ?? ''}</TableCell>
-                    <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>
-                      <Typography component="span" variant="body2" sx={{ fontWeight: 600, mr: 1, color: typeColor(column.type ?? 'string') }}>
-                        {column.type ?? 'string'}
+        <Section title="Printer columns" count={printerColumns.length}>
+          <Table size="small">
+            <TableBody>
+              {printerColumns.map((column, index) => (
+                <TableRow key={`${column.name ?? index}:${column.jsonPath ?? ''}`}>
+                  <TableCell sx={{ width: 180, color: 'text.secondary', border: 0 }}>{column.name ?? ''}</TableCell>
+                  <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>
+                    <Typography component="span" variant="body2" sx={{ fontWeight: 600, mr: 1, color: typeColor(column.type ?? 'string') }}>
+                      {column.type ?? 'string'}
+                    </Typography>
+                    <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                      {column.jsonPath ?? ''}
+                    </Typography>
+                    {column.description && (
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        {column.description}
                       </Typography>
-                      <Typography component="span" variant="body2" sx={{ fontFamily: 'monospace', fontSize: 12 }}>
-                        {column.jsonPath ?? ''}
-                      </Typography>
-                      {column.description && (
-                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-                          {column.description}
-                        </Typography>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </Box>
-        </>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Section>
       )}
     </Stack>
   );

--- a/client/src/components/detail/GenericDetail.tsx
+++ b/client/src/components/detail/GenericDetail.tsx
@@ -122,16 +122,13 @@ export function ConditionChips({ obj, goodWhen }: { obj: KubeObject; goodWhen?: 
   );
 }
 
-export function ConditionsTable({ obj, goodWhen }: { obj: KubeObject; goodWhen?: (type: string) => 'True' | 'False' }) {
+export function ConditionsTable({ obj, goodWhen, defaultOpen = true }: { obj: KubeObject; goodWhen?: (type: string) => 'True' | 'False'; defaultOpen?: boolean }) {
   const conditions = objConditions(obj);
   if (!conditions.length) return null;
   return (
-    <Box>
-      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-        Conditions
-      </Typography>
+    <Section title="Conditions" count={conditions.length} defaultOpen={defaultOpen}>
       <ConditionRows conditions={conditions} goodWhen={goodWhen} />
-    </Box>
+    </Section>
   );
 }
 
@@ -159,8 +156,8 @@ export function ConditionRows({ conditions, goodWhen }: { conditions: Condition[
                 <StatusChip status={display} label={c.status} />
               </TableCell>
               <TableCell>{c.reason ?? ''}</TableCell>
-              <TableCell sx={{ maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis' }} title={c.message}>
-                {c.message ?? ''}
+              <TableCell title={c.message}>
+                <Box sx={{ maxWidth: 320, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.message ?? ''}</Box>
               </TableCell>
               <TableCell>
                 <AgeCell timestamp={c.lastTransitionTime} />

--- a/client/src/components/detail/NodeDetail.tsx
+++ b/client/src/components/detail/NodeDetail.tsx
@@ -1,16 +1,15 @@
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Typography from '@mui/material/Typography';
 import type { KubeObject } from '@kubus/shared';
-import { GenericDetail, ConditionsTable } from './GenericDetail.js';
+import { GenericDetail, ConditionsTable, hasUnhealthyCondition } from './GenericDetail.js';
 import { PodMiniList } from './PodMiniList.js';
+import { Section } from './Section.js';
 import { CopyValueButton } from '../CellCopy.js';
 import { StatusChip } from '../StatusChip.js';
 import { formatBytes } from '../format.js';
@@ -55,10 +54,7 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
       </Stack>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
         {(!!status.addresses?.length || providerID) && (
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Addresses
-            </Typography>
+          <Section title="Addresses">
             <Table size="small">
               <TableBody>
                 {(status.addresses ?? []).map((a) => (
@@ -77,13 +73,10 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                 )}
               </TableBody>
             </Table>
-          </Box>
+          </Section>
         )}
         {resourceKeys.length > 0 && (
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Capacity
-            </Typography>
+          <Section title="Capacity">
             <Table size="small">
               <TableHead>
                 <TableRow>
@@ -102,11 +95,12 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                 ))}
               </TableBody>
             </Table>
-          </Box>
+          </Section>
         )}
-        <ConditionsTable obj={obj} goodWhen={nodeGoodWhen} />
-        <Divider />
-        <PodMiniList ctx={ctx} pods={podsQuery.data?.items ?? []} title="Pods on this node" loading={podsQuery.isLoading} />
+        <ConditionsTable obj={obj} goodWhen={nodeGoodWhen} defaultOpen={hasUnhealthyCondition(obj, nodeGoodWhen)} />
+        <Section title="Pods on this node" count={podsQuery.isLoading ? undefined : (podsQuery.data?.items ?? []).length}>
+          <PodMiniList ctx={ctx} pods={podsQuery.data?.items ?? []} loading={podsQuery.isLoading} />
+        </Section>
       </Stack>
       <GenericDetail obj={obj} ctx={ctx} hideConditions />
     </Box>

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -12,12 +12,14 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import type { ContainerUsage, KubeObject, PodEnvVar } from '@kubus/shared';
 import { gvkForKind } from '@kubus/shared';
 import { ConditionChips, KeyValueChips, KeyValueSection, MetadataSection } from './GenericDetail.js';
+import { CopyValueButton } from '../CellCopy.js';
 import { PortForwardDialog } from '../PortForwardDialog.js';
 import { PodProblems } from './PodProblems.js';
 import { Section } from './Section.js';
@@ -210,8 +212,8 @@ function DebugContainersSection({ obj, ctx }: { obj: KubeObject; ctx: string }) 
           {debugContainers.map((c) => (
             <TableRow key={c.name}>
               <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>{c.name}</TableCell>
-              <TableCell sx={{ maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis' }} title={c.image}>
-                {c.image}
+              <TableCell title={c.image}>
+                <Box sx={{ maxWidth: 200, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{c.image}</Box>
               </TableCell>
               <TableCell>{c.target ?? ''}</TableCell>
               <TableCell>
@@ -344,7 +346,9 @@ function envSourceLabel(env: PodEnvVar): { text: string; refKind?: 'ConfigMap' |
   if (s.type === 'resourceFieldRef') return { text: `resource ${s.key ?? ''}` };
   const isSecret = s.type === 'secretKeyRef' || s.type === 'secretRef';
   const base = `${isSecret ? 'secret' : 'configmap'}/${s.ref ?? ''}`;
-  return { text: s.key && s.type !== 'configMapRef' && s.type !== 'secretRef' ? `${base} → ${s.key}` : base, refKind: isSecret ? 'Secret' : 'ConfigMap', refName: s.ref };
+  // The key only earns space when it differs from the variable name.
+  const showKey = s.key && s.key !== env.name && s.type !== 'configMapRef' && s.type !== 'secretRef';
+  return { text: showKey ? `${base} → ${s.key}` : base, refKind: isSecret ? 'Secret' : 'ConfigMap', refName: s.ref };
 }
 
 function EnvSection({ ctx, namespace, pod, onOpenRef }: { ctx: string; namespace: string; pod: string; onOpenRef: RefOpener }) {
@@ -367,48 +371,106 @@ function EnvSection({ ctx, namespace, pod, onOpenRef }: { ctx: string; namespace
       }
     >
       {isLoading && <CircularProgress size={18} />}
-      {containers.map((c) => (
-        <Box key={`${c.init ? 'i' : 'c'}:${c.name}`} sx={{ mb: 1.5 }}>
-          {containers.length > 1 && (
-            <Typography variant="caption" color="text.secondary">
-              {c.name}
-              {c.init ? ' (init)' : ''}
-            </Typography>
-          )}
-          <Table size="small">
-            <TableBody>
-              {c.env.map((env, i) => {
-                const source = envSourceLabel(env);
-                return (
-                  <TableRow key={`${env.name}:${i}`}>
-                    <TableCell sx={{ width: 220, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-word' }}>{env.name}</TableCell>
-                    <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, maxWidth: 280, wordBreak: 'break-word' }}>
-                      {env.error ? (
-                        <Typography component="span" variant="caption" sx={{ color: statusTextColor('warning') }}>
-                          {env.error}
-                        </Typography>
-                      ) : (
-                        (env.value ?? '')
-                      )}
-                    </TableCell>
-                    <TableCell sx={{ width: 200 }}>
-                      {source.refKind && source.refName ? (
-                        <Link component="button" variant="caption" color="text.secondary" sx={{ textAlign: 'left' }} onClick={() => onOpenRef(source.refKind!, source.refName!)}>
-                          {source.text}
-                        </Link>
-                      ) : (
-                        <Typography variant="caption" color="text.secondary">
-                          {source.text}
-                        </Typography>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </Box>
-      ))}
+      {containers.map((c) => {
+        // Kubernetes resolves duplicates last-wins (env overrides envFrom,
+        // later envFrom sources override earlier ones) — mark shadowed rows.
+        const lastIndexByName = new Map<string, number>();
+        c.env.forEach((env, i) => lastIndexByName.set(env.name, i));
+        return (
+          <Box key={`${c.init ? 'i' : 'c'}:${c.name}`} sx={{ mb: 1.5 }}>
+            {containers.length > 1 && (
+              <Stack direction="row" sx={{ alignItems: 'center', gap: 0.75, mb: 0.25 }}>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  {c.name}
+                </Typography>
+                {c.init && <Chip label="init" sx={{ height: 16, fontSize: 10 }} />}
+                <Typography variant="caption" color="text.secondary">
+                  {c.env.length}
+                </Typography>
+              </Stack>
+            )}
+            <Table size="small">
+              <TableBody>
+                {c.env.map((env, i) => {
+                  const source = envSourceLabel(env);
+                  const overridden = lastIndexByName.get(env.name) !== i;
+                  const hidden = !!env.redacted && !reveal;
+                  const copyable = !env.error && !hidden && !!env.value;
+                  return (
+                    <TableRow
+                      key={`${env.name}:${i}`}
+                      sx={{ '& .kubus-env-copy': { opacity: 0, transition: 'opacity 120ms' }, '&:hover .kubus-env-copy': { opacity: 1 } }}
+                    >
+                      <TableCell
+                        sx={{
+                          width: '1%',
+                          pr: 1,
+                          verticalAlign: 'top',
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                          ...(overridden && { color: 'text.disabled', textDecoration: 'line-through' }),
+                        }}
+                        title={env.name}
+                      >
+                        <Box sx={{ maxWidth: 240, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                          {overridden ? (
+                            <Tooltip title="Shadowed — a later entry with the same name wins.">
+                              <span>{env.name}</span>
+                            </Tooltip>
+                          ) : (
+                            env.name
+                          )}
+                        </Box>
+                      </TableCell>
+                      <TableCell
+                        sx={{
+                          px: 1,
+                          verticalAlign: 'top',
+                          fontFamily: 'monospace',
+                          fontSize: 12,
+                          wordBreak: 'break-word',
+                          position: 'relative',
+                          ...(overridden && { color: 'text.disabled' }),
+                          ...(hidden && { color: 'text.secondary', letterSpacing: 1 }),
+                        }}
+                      >
+                        {env.error ? (
+                          <Typography component="span" variant="caption" sx={{ color: statusTextColor('warning') }}>
+                            {env.error}
+                          </Typography>
+                        ) : (
+                          (env.value ?? '')
+                        )}
+                        {copyable && (
+                          <Box
+                            className="kubus-env-copy"
+                            sx={{ position: 'absolute', top: 2, right: 0, bgcolor: 'background.paper', borderRadius: 1, boxShadow: 1 }}
+                          >
+                            <CopyValueButton text={env.value!} label={`Copy value of ${env.name}`} />
+                          </Box>
+                        )}
+                      </TableCell>
+                      <TableCell align="right" sx={{ pl: 1, verticalAlign: 'top' }} title={source.text || undefined}>
+                        <Box sx={{ maxWidth: 260, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', ml: 'auto' }}>
+                          {source.refKind && source.refName ? (
+                            <Link component="button" variant="caption" color="text.secondary" onClick={() => onOpenRef(source.refKind!, source.refName!)}>
+                              {source.text}
+                            </Link>
+                          ) : (
+                            <Typography variant="caption" color="text.secondary">
+                              {source.text}
+                            </Typography>
+                          )}
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Box>
+        );
+      })}
     </Section>
   );
 }
@@ -440,10 +502,13 @@ function VolumesSection({ spec, onOpenRef }: { spec: PodSpec | undefined; onOpen
   const volumes = spec?.volumes ?? [];
   if (!volumes.length) return null;
   const allContainers = [...(spec?.initContainers ?? []), ...(spec?.containers ?? [])];
-  const mountsByVolume = new Map<string, string[]>();
+  // The container prefix is only informative when there is more than one.
+  const showContainer = allContainers.length > 1;
+  const mountsByVolume = new Map<string, Array<{ container: string; path: string; note?: string }>>();
   for (const c of allContainers) {
     for (const m of c.volumeMounts ?? []) {
-      const entry = `${c.name}: ${m.mountPath}${m.subPath ? ` (subPath ${m.subPath})` : ''}${m.readOnly ? ' (ro)' : ''}`;
+      const note = [m.subPath ? `subPath ${m.subPath}` : undefined, m.readOnly ? 'ro' : undefined].filter(Boolean).join(', ');
+      const entry = { container: c.name, path: m.mountPath, note: note || undefined };
       mountsByVolume.set(m.name, [...(mountsByVolume.get(m.name) ?? []), entry]);
     }
   }
@@ -462,8 +527,8 @@ function VolumesSection({ spec, onOpenRef }: { spec: PodSpec | undefined; onOpen
             const info = volumeInfo(v);
             return (
               <TableRow key={v.name}>
-                <TableCell sx={{ wordBreak: 'break-word' }}>{v.name}</TableCell>
-                <TableCell>
+                <TableCell sx={{ verticalAlign: 'top', wordBreak: 'break-word' }}>{v.name}</TableCell>
+                <TableCell sx={{ verticalAlign: 'top' }}>
                   {info.refKind && info.refName ? (
                     <Link component="button" variant="body2" sx={{ textAlign: 'left' }} onClick={() => onOpenRef(info.refKind!, info.refName!)}>
                       {info.type}/{info.detail}
@@ -472,7 +537,23 @@ function VolumesSection({ spec, onOpenRef }: { spec: PodSpec | undefined; onOpen
                     `${info.type}${info.detail ? `/${info.detail}` : ''}`
                   )}
                 </TableCell>
-                <TableCell sx={{ whiteSpace: 'pre-line', wordBreak: 'break-word' }}>{(mountsByVolume.get(v.name) ?? []).join('\n')}</TableCell>
+                <TableCell sx={{ verticalAlign: 'top', wordBreak: 'break-word' }}>
+                  {(mountsByVolume.get(v.name) ?? []).map((m, i) => (
+                    <Typography key={i} variant="body2" sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                      {showContainer && (
+                        <Box component="span" sx={{ color: 'text.secondary' }}>
+                          {m.container}:{' '}
+                        </Box>
+                      )}
+                      {m.path}
+                      {m.note && (
+                        <Box component="span" sx={{ color: 'text.secondary' }}>
+                          {` (${m.note})`}
+                        </Box>
+                      )}
+                    </Typography>
+                  ))}
+                </TableCell>
               </TableRow>
             );
           })}

--- a/client/src/components/detail/PodMiniList.tsx
+++ b/client/src/components/detail/PodMiniList.tsx
@@ -31,6 +31,7 @@ export function PodMiniList({
   title?: string;
   loading?: boolean;
   emptyText?: string;
+  /** Hide the namespace caption under pod names (single-namespace callers). */
   hideNamespace?: boolean;
 }) {
   const push = useDetailStore((s) => s.push);
@@ -56,15 +57,14 @@ export function PodMiniList({
           {emptyText ?? 'No pods.'}
         </Typography>
       ) : (
-        <Table size="small">
+        <Table size="small" sx={{ '& th, & td': { px: 1 }, '& th:first-of-type, & td:first-of-type': { pl: 2 } }}>
           <TableHead>
             <TableRow>
-              {!hideNamespace && <TableCell>Namespace</TableCell>}
               <TableCell>Name</TableCell>
               <TableCell>Ready</TableCell>
               <TableCell>Status</TableCell>
-              {usageByPod && <TableCell sx={{ minWidth: 110 }}>CPU</TableCell>}
-              {usageByPod && <TableCell sx={{ minWidth: 110 }}>Memory</TableCell>}
+              {usageByPod && <TableCell sx={{ minWidth: 96 }}>CPU</TableCell>}
+              {usageByPod && <TableCell sx={{ minWidth: 96 }}>Memory</TableCell>}
               <TableCell>Restarts</TableCell>
             </TableRow>
           </TableHead>
@@ -80,9 +80,13 @@ export function PodMiniList({
                   sx={{ cursor: 'pointer' }}
                   onClick={() => push({ ctx, group: '', version: 'v1', plural: 'pods', kind: 'Pod', name: pod.metadata.name, namespace: pod.metadata.namespace })}
                 >
-                  {!hideNamespace && <TableCell>{pod.metadata.namespace}</TableCell>}
-                  <TableCell sx={{ maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis' }} title={pod.metadata.name}>
+                  <TableCell sx={{ minWidth: 140, wordBreak: 'break-word' }} title={pod.metadata.name}>
                     {pod.metadata.name}
+                    {!hideNamespace && pod.metadata.namespace && (
+                      <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                        {pod.metadata.namespace}
+                      </Typography>
+                    )}
                   </TableCell>
                   <TableCell>
                     <ReadyCounter value={summary.ready} />

--- a/client/src/components/detail/RolloutHistory.tsx
+++ b/client/src/components/detail/RolloutHistory.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Table from '@mui/material/Table';
@@ -59,11 +60,13 @@ export function RolloutHistory({ ctx, kind, obj }: { ctx: string; kind: 'Deploym
                 {rev.revision}
                 {rev.current && <Chip label="current" size="small" color="primary" variant="outlined" sx={{ ml: 1, height: 18 }} />}
               </TableCell>
-              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12, maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                {rev.images.join(', ') || '—'}
+              <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }} title={rev.images.join(', ')}>
+                <Box sx={{ maxWidth: 280, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{rev.images.join(', ') || '—'}</Box>
               </TableCell>
               <TableCell>{rev.createdAt ? <AgeCell timestamp={rev.createdAt} /> : '—'}</TableCell>
-              <TableCell sx={{ maxWidth: 220, overflow: 'hidden', textOverflow: 'ellipsis' }}>{rev.changeCause ?? ''}</TableCell>
+              <TableCell title={rev.changeCause}>
+                <Box sx={{ maxWidth: 220, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{rev.changeCause ?? ''}</Box>
+              </TableCell>
               <TableCell align="right">
                 {!rev.current && (
                   <Button size="small" startIcon={<UndoIcon />} onClick={() => setConfirmRevision(rev.revision)}>

--- a/client/src/components/detail/SecretDetail.tsx
+++ b/client/src/components/detail/SecretDetail.tsx
@@ -6,6 +6,7 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { KubeObject, TlsCertInfo } from '@kubus/shared';
 import { GenericDetail } from './GenericDetail.js';
+import { Section } from './Section.js';
 import { useSecretTls } from '../../api/queries.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -40,19 +41,16 @@ export function SecretDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
       </Stack>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
         {keys.length > 0 && (
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Data keys
-            </Typography>
+          <Section title="Data keys" count={keys.length}>
             <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
               {keys.map((k) => (
                 <Chip key={k} label={k} variant="outlined" />
               ))}
             </Stack>
-            <Typography variant="caption" color="text.secondary">
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
               Values are redacted — reveal, copy or edit them per key in the Data tab.
             </Typography>
-          </Box>
+          </Section>
         )}
         {isTls &&
           (tls.data?.certificates ?? []).map((cert, i) => (

--- a/client/src/components/detail/Section.tsx
+++ b/client/src/components/detail/Section.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import ButtonBase from '@mui/material/ButtonBase';
 import Collapse from '@mui/material/Collapse';
@@ -23,6 +23,14 @@ export function Section({
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  // Callers pass live values (e.g. conditions collapse while healthy). When
+  // the value flips on a later render — a node turning unhealthy in an open
+  // drawer — follow it; between flips, manual toggles win.
+  const prevDefault = useRef(defaultOpen);
+  if (prevDefault.current !== defaultOpen) {
+    prevDefault.current = defaultOpen;
+    if (open !== defaultOpen) setOpen(defaultOpen);
+  }
   return (
     <Box>
       <Stack direction="row" sx={{ alignItems: 'center', minHeight: 28 }}>

--- a/client/src/components/detail/ServiceDetail.tsx
+++ b/client/src/components/detail/ServiceDetail.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
-import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
@@ -13,9 +12,10 @@ import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CableIcon from '@mui/icons-material/Cable';
 import type { KubeObject } from '@kubus/shared';
-import { GenericDetail, KeyValueChips } from './GenericDetail.js';
+import { GenericDetail, KeyValueSection } from './GenericDetail.js';
 import { PodMiniList } from './PodMiniList.js';
 import { PortForwardDialog } from '../PortForwardDialog.js';
+import { Section } from './Section.js';
 import { useResourceList } from '../../api/queries.js';
 
 interface ServiceSpec {
@@ -60,17 +60,14 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
       </Stack>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
         {!!spec.ports?.length && (
-          <Box>
-            <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-              Ports
-            </Typography>
+          <Section title="Ports" count={spec.ports.length}>
             <Table size="small">
               <TableHead>
                 <TableRow>
-                  <TableCell>Name</TableCell>
+                  {spec.ports.some((p) => p.name) && <TableCell>Name</TableCell>}
                   <TableCell>Port</TableCell>
                   <TableCell>Target</TableCell>
-                  <TableCell>NodePort</TableCell>
+                  {spec.ports.some((p) => p.nodePort !== undefined) && <TableCell>NodePort</TableCell>}
                   <TableCell>Protocol</TableCell>
                   <TableCell padding="none" />
                 </TableRow>
@@ -78,10 +75,10 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
               <TableBody>
                 {spec.ports.map((p, i) => (
                   <TableRow key={p.name ?? i}>
-                    <TableCell>{p.name ?? ''}</TableCell>
+                    {spec.ports!.some((q) => q.name) && <TableCell>{p.name ?? ''}</TableCell>}
                     <TableCell>{p.port}</TableCell>
                     <TableCell>{p.targetPort ?? p.port}</TableCell>
-                    <TableCell>{p.nodePort ?? ''}</TableCell>
+                    {spec.ports!.some((q) => q.nodePort !== undefined) && <TableCell>{p.nodePort ?? ''}</TableCell>}
                     <TableCell>{p.protocol ?? 'TCP'}</TableCell>
                     <TableCell padding="none" align="right">
                       {(p.protocol ?? 'TCP') === 'TCP' && (
@@ -96,13 +93,14 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
                 ))}
               </TableBody>
             </Table>
-          </Box>
+          </Section>
         )}
         {labelSelector ? (
           <>
-            <KeyValueChips title="Selector" entries={selector} />
-            <Divider />
-            <PodMiniList ctx={ctx} pods={podsQuery.data?.items ?? []} title="Matching pods" loading={podsQuery.isLoading} emptyText="No pods match the selector." />
+            <KeyValueSection title="Selector" entries={selector} />
+            <Section title="Matching pods" count={podsQuery.isLoading ? undefined : (podsQuery.data?.items ?? []).length}>
+              <PodMiniList ctx={ctx} pods={podsQuery.data?.items ?? []} loading={podsQuery.isLoading} emptyText="No pods match the selector." hideNamespace />
+            </Section>
           </>
         ) : (
           <Typography variant="body2" color="text.secondary">

--- a/client/src/components/overview/cards.tsx
+++ b/client/src/components/overview/cards.tsx
@@ -50,8 +50,8 @@ export function FailingPodsCard({ ctx, pods, hideNamespace }: { ctx: string; pod
                 <StatusChip status={p.reason} />
               </TableCell>
               <TableCell>{p.restarts}</TableCell>
-              <TableCell sx={{ maxWidth: 400, overflow: 'hidden', textOverflow: 'ellipsis' }} title={p.message}>
-                {p.message ?? ''}
+              <TableCell title={p.message}>
+                <Box sx={{ maxWidth: 400, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.message ?? ''}</Box>
               </TableCell>
             </TableRow>
           ))}

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -43,6 +43,10 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
       nodesWatcher.watcher.ready(),
       namespacesWatcher.watcher.ready(),
     ]);
+    // The rejection is re-observed at the `await coreReady` below; without this
+    // parked handler a core LIST failure while the optional await is still
+    // pending is an unhandled rejection and takes down the whole process.
+    void coreReady.catch(() => {});
     const [persistentVolumesResult, crdsResult, ...healthResults] = await Promise.all([
       optionalItems(pvsWatcher.watcher),
       optionalItems(crdsWatcher.watcher),


### PR DESCRIPTION
## Server

- **Fix a whole-process crash when a connected cluster is unreachable.** `computeOverview` started the five core watcher warmups as a detached `Promise.all` and only awaited it after the optional-watcher await. A core LIST failure in that gap (connection refused, e.g. a SOCKS proxy that is not running) was an unhandled rejection and Node killed the server about a second after the page connected — `pnpm start` appeared broken. The combined promise now gets a parked catch at creation; the failure still surfaces at the real await and the overview request answers with an error while the server keeps serving. Reproduced with a kubeconfig pointing at a closed port: before the fix the process died on the first overview request, after it all startup endpoints answer and the process stays up.

## Detail drawers

- **Environment**: name column shrinks to fit and the value column takes the remaining width (long values no longer wrap in a narrow band next to empty space); source refs are single-line and right-aligned, showing `→ key` only when the key differs from the variable name; duplicate names shadowed by a later entry (env overrides envFrom, last one wins) are struck through and dimmed with a tooltip; values get a hover copy button (hidden while a secret is redacted); container group headers are legible with a count and an init chip.
- **Pod mini-lists** (Service/Deployment/Node): namespace moves from its own column to a caption under the pod name, tighter padding and meter widths — names fit in 1–2 lines instead of 3; Services hide the namespace entirely since a selector only matches its own namespace.
- **Consistent sections**: Ports/Selector/Matching pods, Addresses/Capacity/Pods on this node, Conditions, Data keys and CRD Definition/Printer columns all use the same collapsible section header with a separate count. Node conditions collapse by default while healthy and open automatically when not. Empty NodePort/Name port columns are hidden.
- **Real truncation**: several tables set `text-overflow: ellipsis` without `white-space: nowrap`, which never truncates — it wraps (node condition messages rendered one word per line). Fixed via an inner block element in condition messages, rollout history, debug-container images and overview failing-pod messages, with full-text tooltips.
- **Volumes**: mounts render as structured lines — muted container prefix (dropped for single-container pods), monospace path, muted `ro`/subPath notes.

## Testing

- `pnpm build` and `pnpm lint` clean.
- Crash repro before/after against an unreachable API server; `pnpm start` verified to stay up with the proxy down.
- Screenshot sweep of pod (env/probes/volumes/crashloop), deployment, service, configmap, secret, node and CRD drawers plus overview and rollout history in light and dark themes, using a fixture pod exercising every env source type (envFrom duplicates, fieldRef, resourceFieldRef, secret refs, long literals).