### PR TITLE
Add debug image presets and login-shell terminals

### DIFF
--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
+import Chip from '@mui/material/Chip';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -19,6 +20,7 @@ import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
+import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
@@ -926,6 +928,20 @@ export function SetImageDialog({
   );
 }
 
+/**
+ * Version-pinned so a preset never silently changes underneath a user; the
+ * field stays free-text for anything else. `profile` marks presets whose
+ * tooling is useless without extra capabilities — selecting one adjusts the
+ * profile dropdown.
+ */
+const DEBUG_IMAGE_PRESETS: Array<{ label: string; image: string; hint: string; profile?: DebugProfile }> = [
+  { label: 'busybox', image: 'busybox:1.36', hint: 'Minimal shell and coreutils (~2 MB).' },
+  { label: 'DebugBox lite', image: 'ghcr.io/ibtisam-iq/debugbox:lite-1.2.0', hint: 'curl, dig, jq, yq (~15 MB) — DNS and HTTP checks.' },
+  { label: 'DebugBox balanced', image: 'ghcr.io/ibtisam-iq/debugbox:1.2.0', hint: 'Adds bash, vim, tcpdump, strace, openssl (~47 MB).' },
+  { label: 'DebugBox power', image: 'ghcr.io/ibtisam-iq/debugbox:power-1.2.0', hint: 'tshark, nmap, iptables, nftables (~91 MB) — needs the network admin profile.', profile: 'netadmin' },
+  { label: 'netshoot', image: 'nicolaka/netshoot:v0.16', hint: 'The kitchen-sink network toolbox (~200 MB).' },
+];
+
 const DEBUG_PROFILES: Array<{ value: DebugProfile; label: string; hint: string }> = [
   { value: 'general', label: 'General', hint: 'No extra privileges — inherits the namespace defaults.' },
   { value: 'restricted', label: 'Restricted', hint: 'Non-root, all capabilities dropped — for PodSecurity-restricted namespaces (needs a non-root image).' },
@@ -941,6 +957,7 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
   const [targetContainer, setTargetContainer] = useState(containers[0] ?? '');
   const [profile, setProfile] = useState<DebugProfile>('general');
   const name = target.obj.metadata.name;
+  const imagePreset = DEBUG_IMAGE_PRESETS.find((p) => p.image === image);
   return (
     <Dialog open onClose={debug.isPending ? undefined : onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Debug container — {name}</DialogTitle>
@@ -950,6 +967,25 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
           container stays in the pod spec until the pod is recreated.
         </Typography>
         <TextField autoFocus fullWidth label="Image" value={image} onChange={(e) => setImage(e.target.value)} />
+        <Stack direction="row" spacing={1} sx={{ mt: -1, flexWrap: 'wrap' }}>
+          {DEBUG_IMAGE_PRESETS.map((p) => (
+            <Chip
+              key={p.image}
+              label={p.label}
+              size="small"
+              variant={image === p.image ? 'filled' : 'outlined'}
+              onClick={() => {
+                setImage(p.image);
+                if (p.profile) setProfile(p.profile);
+              }}
+            />
+          ))}
+        </Stack>
+        {imagePreset && (
+          <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
+            {imagePreset.hint}
+          </Typography>
+        )}
         <FormControl size="small" fullWidth>
           <InputLabel id="debug-target">Target container (shared process namespace)</InputLabel>
           <Select labelId="debug-target" label="Target container (shared process namespace)" value={targetContainer} onChange={(e) => setTargetContainer(e.target.value)}>

--- a/docs/guide/shell.md
+++ b/docs/guide/shell.md
@@ -35,7 +35,14 @@ attach an **ephemeral debug container**:
 
 - **Pod** ⋮ menu → **Debug container…**
 
-1. Choose a debug **image** (default `busybox:1.36`).
+1. Choose a debug **image** (default `busybox:1.36`). Preset chips offer curated
+   images without having to remember registry paths: busybox, the three
+   [DebugBox](https://github.com/ibtisam-iq/debugbox) tiers (lite ~15 MB for
+   DNS/HTTP checks, balanced ~47 MB with tcpdump and strace, power ~91 MB with
+   tshark and nmap) and [netshoot](https://github.com/nicolaka/netshoot)
+   (~200 MB, everything). Picking **DebugBox power** switches the profile to
+   **Network admin** for you, since its tools need `NET_ADMIN`. The field stays
+   editable — any image reference works.
 2. Optionally pick a **target container** to share a process namespace with, so you can
    see and poke at its processes.
 3. Kubus attaches the ephemeral container and drops you into a shell inside it — the same

--- a/server/src/ws/exec-socket.ts
+++ b/server/src/ws/exec-socket.ts
@@ -10,7 +10,9 @@ export function registerExecSocket(app: FastifyInstance, ctx: AppContext): void 
     try {
       const handle = ctx.clusters.get(q.ctx ?? '');
       const shell = q.shell;
-      const command = shell ? [shell] : ['/bin/sh', '-c', 'command -v bash >/dev/null 2>&1 && exec bash || exec sh'];
+      // Login shells (-l) so /etc/profile.d is sourced — debug images
+      // (debugbox, netshoot) define their helper functions there.
+      const command = shell ? [shell] : ['/bin/sh', '-c', 'command -v bash >/dev/null 2>&1 && exec bash -l || exec sh -l'];
       void runExecBridge(socket, handle, {
         namespace: q.namespace ?? '',
         pod: q.pod ?? '',

--- a/server/src/ws/exec-socket.ts
+++ b/server/src/ws/exec-socket.ts
@@ -3,16 +3,25 @@ import type { WebSocket } from 'ws';
 import type { AppContext } from '../app.js';
 import { runExecBridge } from './exec-bridge.js';
 
+const LOGIN_SHELLS = new Set(['sh', 'bash', 'ash', 'dash', 'ksh', 'zsh']);
+
+function shellCommand(shell?: string): string[] {
+  if (!shell) return ['/bin/sh', '-c', 'command -v bash >/dev/null 2>&1 && exec bash -l || exec sh -l'];
+
+  const name = shell.split('/').at(-1);
+  return name && LOGIN_SHELLS.has(name) ? [shell, '-l'] : [shell];
+}
+
 /** Interactive shell into a container. One browser socket per terminal. */
 export function registerExecSocket(app: FastifyInstance, ctx: AppContext): void {
   app.get('/ws/exec', { websocket: true }, (socket: WebSocket, req: FastifyRequest) => {
     const q = req.query as Record<string, string | undefined>;
     try {
       const handle = ctx.clusters.get(q.ctx ?? '');
-      const shell = q.shell;
       // Login shells (-l) so /etc/profile.d is sourced — debug images
-      // (debugbox, netshoot) define their helper functions there.
-      const command = shell ? [shell] : ['/bin/sh', '-c', 'command -v bash >/dev/null 2>&1 && exec bash -l || exec sh -l'];
+      // (debugbox, netshoot) define their helper functions there. Unknown
+      // custom executables stay untouched because they may not accept -l.
+      const command = shellCommand(q.shell);
       void runExecBridge(socket, handle, {
         namespace: q.namespace ?? '',
         pod: q.pod ?? '',

--- a/tests/unit/client/row-actions.test.tsx
+++ b/tests/unit/client/row-actions.test.tsx
@@ -246,6 +246,18 @@ describe('pod actions', () => {
     view.unmount();
   });
 
+  it('debug image presets fill the field and pair the power tier with netadmin', () => {
+    const view = clickMenuAction(pod, 'Debug container…');
+    fireEvent.click(screen.getByText('DebugBox power'));
+    expect(screen.getByLabelText('Image')).toHaveValue('ghcr.io/ibtisam-iq/debugbox:power-1.2.0');
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    expect(queryMocks.debug.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ image: 'ghcr.io/ibtisam-iq/debugbox:power-1.2.0', profile: 'netadmin' }) }),
+      expect.anything(),
+    );
+    view.unmount();
+  });
+
   it('favorites, copies, and confirms deletion of protected resources', async () => {
     let view = clickMenuAction(pod, 'Add to favorites');
     expect(useNavigationStore.getState().favorites).toHaveLength(1);

--- a/tests/unit/server/exec-socket.test.ts
+++ b/tests/unit/server/exec-socket.test.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from 'node:events';
+import { expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import type { AppContext } from '../../../server/src/app.js';
+import { registerExecSocket } from '../../../server/src/ws/exec-socket.js';
+
+type Handler = (socket: unknown, request: unknown) => unknown;
+
+function routeCollector() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, optionsOrHandler: unknown, handler?: unknown) {
+      routes.set(path, (handler ?? optionsOrHandler) as Handler);
+    },
+  } as unknown as FastifyInstance;
+  return { routes, app };
+}
+
+class FakeSocket extends EventEmitter {
+  OPEN = 1;
+  readyState = this.OPEN;
+
+  send() {}
+
+  ping() {}
+
+  close() {
+    if (this.readyState !== this.OPEN) return;
+    this.readyState = 3;
+    this.emit('close');
+  }
+}
+
+async function waitFor(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('timed out waiting for exec setup');
+}
+
+it.each([
+  [undefined, ['/bin/sh', '-c', 'command -v bash >/dev/null 2>&1 && exec bash -l || exec sh -l']],
+  ['bash', ['bash', '-l']],
+  ['sh', ['sh', '-l']],
+  ['/bin/zsh', ['/bin/zsh', '-l']],
+  ['/opt/tools/custom-shell', ['/opt/tools/custom-shell']],
+])('starts configured shell %s with appropriate login semantics', async (shell, expected) => {
+  const { app, routes } = routeCollector();
+  const commands: string[][] = [];
+  const upstream = new FakeSocket();
+  const handle = {
+    makeExec() {
+      return {
+        async exec(
+          _namespace: string,
+          _pod: string,
+          _container: string,
+          command: string[],
+        ) {
+          commands.push(command);
+          return upstream;
+        },
+      };
+    },
+  };
+  const ctx = { clusters: { get: () => handle } } as unknown as AppContext;
+  registerExecSocket(app, ctx);
+
+  const socket = new FakeSocket();
+  routes.get('/ws/exec')?.(socket, {
+    query: {
+      ctx: 'dev',
+      namespace: 'ops',
+      pod: 'api-0',
+      container: 'app',
+      shell,
+    },
+  });
+  await waitFor(() => upstream.listenerCount('close') > 0);
+
+  expect(commands).toEqual([expected]);
+  upstream.emit('close');
+});


### PR DESCRIPTION
## What

- **Debug dialog image presets** — the free-text image field keeps working, but five preset chips now sit below it: `busybox:1.36` (default), the three [DebugBox](https://github.com/ibtisam-iq/debugbox) tiers, and [netshoot](https://github.com/nicolaka/netshoot). All presets are version-pinned so an image never changes underneath a user; a caption shows the matched preset's tooling and size.
- **Profile pairing** — selecting *DebugBox power* switches the profile select to *Network admin*, since tshark/nmap/iptables need `NET_ADMIN`/`NET_RAW`.
- **Login-shell terminals** — the exec socket now starts `bash -l` / `sh -l` instead of non-login shells, so `/etc/profile.d` is sourced. Debug images define their shell helpers there (DebugBox's `json()`, `ports()`, `sniff-dns()`, …), which were previously silently unavailable in Kubus terminals. Also covers the ash-only lite tier.
- Docs: the *Debug containers* section in `docs/guide/shell.md` covers the presets and the profile pairing.

## Testing

- New unit test: clicking the power chip fills the pinned image reference and sends `profile: 'netadmin'` in the mutation payload.
- Full unit suite (860 tests), typecheck, and lint pass.
- Verified end-to-end against a kind cluster with the built client: chips render, power chip fills the image field and flips the profile, and the filled/outlined selection marker follows the active chip.