### PR TITLE
Improve topology relationship inference

### DIFF
--- a/server/src/routes/graph.ts
+++ b/server/src/routes/graph.ts
@@ -40,6 +40,8 @@ interface RelationHint {
   path: string;
   value: string;
   selector?: Record<string, string>;
+  referenceKind?: string;
+  referenceNamespace?: string;
 }
 
 interface FocusQuery {
@@ -201,17 +203,33 @@ function parseEqualitySelector(value: string): Record<string, string> | undefine
 
 const URL_VALUE_RE = /^https?:\/\//i;
 
-function collectRelationHints(value: unknown, prefix = ''): RelationHint[] {
+interface RelationContext {
+  referenceKind?: string;
+  referenceNamespace?: string;
+}
+
+function trimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function collectRelationHints(value: unknown, prefix = '', context: RelationContext = {}): RelationHint[] {
   if (typeof value === 'string') {
     const trimmed = value.trim();
     if (!trimmed || trimmed.length > 120 || URL_VALUE_RE.test(trimmed)) return [];
-    return [{ path: prefix, value: trimmed, selector: parseEqualitySelector(trimmed) }];
+    return [{ path: prefix, value: trimmed, selector: parseEqualitySelector(trimmed), ...context }];
   }
   if (Array.isArray(value)) {
-    return value.flatMap((item, i) => collectRelationHints(item, `${prefix}[${i}]`));
+    return value.flatMap((item, i) => collectRelationHints(item, `${prefix}[${i}]`, context));
   }
   if (value && typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>).flatMap(([key, item]) => collectRelationHints(item, prefix ? `${prefix}.${key}` : key));
+    const record = value as Record<string, unknown>;
+    const siblingContext = {
+      referenceKind: trimmedString(record.kind),
+      referenceNamespace: trimmedString(record.namespace),
+    };
+    return Object.entries(record).flatMap(([key, item]) => collectRelationHints(item, prefix ? `${prefix}.${key}` : key, siblingContext));
   }
   return [];
 }
@@ -338,7 +356,7 @@ function scoreCandidateKind(kind: ResourceKindInfo, focusSpec: KindSpec, hintTer
 
 function pickDynamicCandidateSpecs(kinds: ResourceKindInfo[], focusSpec: KindSpec, focusObj: KubeObject): KindSpec[] {
   const hints = collectRelationHints({ spec: focusObj.spec, status: focusObj.status });
-  const hintTerms = new Set(hints.flatMap((hint) => tokens(hint.path)));
+  const hintTerms = new Set(hints.flatMap((hint) => [...tokens(hint.path), ...tokens(hint.referenceKind ?? '')]));
   return dedupeResourceKinds(kinds)
     .flatMap((kind) => {
       const score = scoreCandidateKind(kind, focusSpec, hintTerms);
@@ -362,60 +380,81 @@ function collectMetadataRelationHints(obj: KubeObject): RelationHint[] {
   ];
 }
 
-function relationPathScore(path: string, target: KindSpec): number {
+const REFERENCE_CONTEXT_FIELDS = new Set(['apiversion', 'group', 'kind', 'namespace', 'version']);
+
+function canonicalKind(kind: string): string {
+  return kind.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function relationPathScore(hint: RelationHint, target: KindSpec): number {
+  const leaf = hint.path.replace(ARRAY_INDEX_RE, '').split('.').at(-1)?.toLowerCase();
+  if (leaf && REFERENCE_CONTEXT_FIELDS.has(leaf)) return 0;
   const targetTerms = new Set(tokens(`${target.kind} ${target.plural}`));
-  return new Set(tokens(path).filter((term) => targetTerms.has(term))).size;
+  const pathScore = new Set(tokens(hint.path).filter((term) => targetTerms.has(term))).size;
+  if (!hint.referenceKind) return pathScore;
+  return canonicalKind(hint.referenceKind) === canonicalKind(target.kind) ? 100 + pathScore : 0;
 }
 
 function bestTypedHint(hints: RelationHint[], target: KindSpec): RelationHint | undefined {
   return hints
     .flatMap((hint) => {
-      const score = relationPathScore(hint.path, target);
+      const score = relationPathScore(hint, target);
       return score > 0 ? [{ hint, score }] : [];
     })
     .sort((a, b) => b.score - a.score || a.hint.path.length - b.hint.path.length || a.hint.path.localeCompare(b.hint.path))[0]?.hint;
 }
 
-function sameReferenceScope(a: Item, b: Item): boolean {
-  return !a.spec.namespaced || !b.spec.namespaced || (a.obj.metadata.namespace ?? '') === (b.obj.metadata.namespace ?? '');
+function referenceScopeMatches(source: Item, target: Item, hint?: RelationHint): boolean {
+  if (!target.spec.namespaced) return true;
+  const explicitNamespace = hint?.referenceNamespace;
+  if (explicitNamespace) return target.obj.metadata.namespace === explicitNamespace;
+  return !source.spec.namespaced || (source.obj.metadata.namespace ?? '') === (target.obj.metadata.namespace ?? '');
 }
 
 // A matching value is not enough: commonName/displayName-style fields often
 // happen to equal an object name. Require the field (or metadata key) to name
 // the target kind, and keep only the strongest evidence for each object pair.
 function inferredRelation(focus: Item, item: Item, focusHints: RelationHint[]): { kind: 'manages' | 'selects'; label: string } | undefined {
-  if (!sameReferenceScope(focus, item)) return undefined;
-
-  const directName = bestTypedHint(focusHints.filter((hint) => hint.value === item.obj.metadata.name), item.spec);
+  const directName = bestTypedHint(
+    focusHints.filter((hint) => hint.value === item.obj.metadata.name && referenceScopeMatches(focus, item, hint)),
+    item.spec,
+  );
   if (directName) return { kind: 'manages', label: hintLabel(directName.path) };
 
   const directSelector = bestTypedHint(
-    focusHints.filter((hint) => hint.selector && selectorMatches(hint.selector, item.obj.metadata.labels)),
+    focusHints.filter((hint) => hint.selector && selectorMatches(hint.selector, item.obj.metadata.labels) && referenceScopeMatches(focus, item, hint)),
     item.spec,
   );
   if (directSelector) return { kind: 'selects', label: hintLabel(directSelector.path) };
 
   const reverseHints = collectRelationHints({ spec: item.obj.spec, status: item.obj.status });
-  const reverseName = bestTypedHint(reverseHints.filter((hint) => hint.value === focus.obj.metadata.name), focus.spec);
+  const reverseName = bestTypedHint(
+    reverseHints.filter((hint) => hint.value === focus.obj.metadata.name && referenceScopeMatches(item, focus, hint)),
+    focus.spec,
+  );
   if (reverseName) return { kind: 'manages', label: hintLabel(reverseName.path) };
 
   const reverseSelector = bestTypedHint(
-    reverseHints.filter((hint) => hint.selector && selectorMatches(hint.selector, focus.obj.metadata.labels)),
+    reverseHints.filter((hint) => hint.selector && selectorMatches(hint.selector, focus.obj.metadata.labels) && referenceScopeMatches(item, focus, hint)),
     focus.spec,
   );
   if (reverseSelector) return { kind: 'selects', label: hintLabel(reverseSelector.path) };
 
-  const directMetadata = bestTypedHint(
-    collectMetadataRelationHints(focus.obj).filter((hint) => hint.value === item.obj.metadata.name),
-    item.spec,
-  );
-  if (directMetadata) return { kind: 'manages', label: 'metadata' };
+  if (referenceScopeMatches(focus, item)) {
+    const directMetadata = bestTypedHint(
+      collectMetadataRelationHints(focus.obj).filter((hint) => hint.value === item.obj.metadata.name),
+      item.spec,
+    );
+    if (directMetadata) return { kind: 'manages', label: 'metadata' };
+  }
 
-  const reverseMetadata = bestTypedHint(
-    collectMetadataRelationHints(item.obj).filter((hint) => hint.value === focus.obj.metadata.name),
-    focus.spec,
-  );
-  if (reverseMetadata) return { kind: 'manages', label: 'metadata' };
+  if (referenceScopeMatches(item, focus)) {
+    const reverseMetadata = bestTypedHint(
+      collectMetadataRelationHints(item.obj).filter((hint) => hint.value === focus.obj.metadata.name),
+      focus.spec,
+    );
+    if (reverseMetadata) return { kind: 'manages', label: 'metadata' };
+  }
 
   return undefined;
 }

--- a/server/src/routes/graph.ts
+++ b/server/src/routes/graph.ts
@@ -355,54 +355,87 @@ async function listFocusedRelatedItems(handle: ClusterHandle, focus: Item, names
   return (await Promise.all(candidates.map((spec) => listKind(handle, spec, namespaces, warnings)))).flat();
 }
 
-function metadataMentions(obj: KubeObject, name: string): boolean {
-  const values = [
-    ...Object.values(obj.metadata.labels ?? {}),
-    ...Object.values(obj.metadata.annotations ?? {}),
+function collectMetadataRelationHints(obj: KubeObject): RelationHint[] {
+  return [
+    ...Object.entries(obj.metadata.labels ?? {}).map(([key, value]) => ({ path: `metadata.labels.${key}`, value })),
+    ...Object.entries(obj.metadata.annotations ?? {}).map(([key, value]) => ({ path: `metadata.annotations.${key}`, value })),
   ];
-  return values.some((value) => value === name);
 }
 
-function addFocusedResourceEdges(edges: GraphEdge[], focus: Item | undefined, nodeItems: Map<string, Item>, nodes: Map<string, GraphNode>, byUid: Map<string, string>): void {
+function relationPathScore(path: string, target: KindSpec): number {
+  const targetTerms = new Set(tokens(`${target.kind} ${target.plural}`));
+  return new Set(tokens(path).filter((term) => targetTerms.has(term))).size;
+}
+
+function bestTypedHint(hints: RelationHint[], target: KindSpec): RelationHint | undefined {
+  return hints
+    .flatMap((hint) => {
+      const score = relationPathScore(hint.path, target);
+      return score > 0 ? [{ hint, score }] : [];
+    })
+    .sort((a, b) => b.score - a.score || a.hint.path.length - b.hint.path.length || a.hint.path.localeCompare(b.hint.path))[0]?.hint;
+}
+
+function sameReferenceScope(a: Item, b: Item): boolean {
+  return !a.spec.namespaced || !b.spec.namespaced || (a.obj.metadata.namespace ?? '') === (b.obj.metadata.namespace ?? '');
+}
+
+// A matching value is not enough: commonName/displayName-style fields often
+// happen to equal an object name. Require the field (or metadata key) to name
+// the target kind, and keep only the strongest evidence for each object pair.
+function inferredRelation(focus: Item, item: Item, focusHints: RelationHint[]): { kind: 'manages' | 'selects'; label: string } | undefined {
+  if (!sameReferenceScope(focus, item)) return undefined;
+
+  const directName = bestTypedHint(focusHints.filter((hint) => hint.value === item.obj.metadata.name), item.spec);
+  if (directName) return { kind: 'manages', label: hintLabel(directName.path) };
+
+  const directSelector = bestTypedHint(
+    focusHints.filter((hint) => hint.selector && selectorMatches(hint.selector, item.obj.metadata.labels)),
+    item.spec,
+  );
+  if (directSelector) return { kind: 'selects', label: hintLabel(directSelector.path) };
+
+  const reverseHints = collectRelationHints({ spec: item.obj.spec, status: item.obj.status });
+  const reverseName = bestTypedHint(reverseHints.filter((hint) => hint.value === focus.obj.metadata.name), focus.spec);
+  if (reverseName) return { kind: 'manages', label: hintLabel(reverseName.path) };
+
+  const reverseSelector = bestTypedHint(
+    reverseHints.filter((hint) => hint.selector && selectorMatches(hint.selector, focus.obj.metadata.labels)),
+    focus.spec,
+  );
+  if (reverseSelector) return { kind: 'selects', label: hintLabel(reverseSelector.path) };
+
+  const directMetadata = bestTypedHint(
+    collectMetadataRelationHints(focus.obj).filter((hint) => hint.value === item.obj.metadata.name),
+    item.spec,
+  );
+  if (directMetadata) return { kind: 'manages', label: 'metadata' };
+
+  const reverseMetadata = bestTypedHint(
+    collectMetadataRelationHints(item.obj).filter((hint) => hint.value === focus.obj.metadata.name),
+    focus.spec,
+  );
+  if (reverseMetadata) return { kind: 'manages', label: 'metadata' };
+
+  return undefined;
+}
+
+function addFocusedResourceEdges(edges: GraphEdge[], focus: Item | undefined, nodeItems: Map<string, Item>, nodes: Map<string, GraphNode>): void {
   if (!focus) return;
   const actualFocusId = [...nodeItems.entries()].find(([, item]) => sameGvr(item.spec, focus.spec) && item.obj.metadata.name === focus.obj.metadata.name && (item.obj.metadata.namespace ?? '') === (focus.obj.metadata.namespace ?? ''))?.[0];
   if (!actualFocusId) return;
   const focusHints = collectRelationHints({ spec: focus.obj.spec, status: focus.obj.status });
-  const focusLabelValues = Object.values(focus.obj.metadata.labels ?? {});
-  const focusAnnotationValues = Object.values(focus.obj.metadata.annotations ?? {});
+  const focusOwnerUids = new Set((focus.obj.metadata.ownerReferences ?? []).map((owner) => owner.uid));
 
   for (const [id, item] of nodeItems) {
     if (id === actualFocusId) continue;
-    const labels = item.obj.metadata.labels ?? {};
-    for (const hint of focusHints) {
-      if (hint.value === item.obj.metadata.name) {
-        addEdge(edges, actualFocusId, id, 'manages', hintLabel(hint.path));
-      }
-      if (hint.selector && selectorMatches(hint.selector, labels)) {
-        addEdge(edges, actualFocusId, id, 'selects', hintLabel(hint.path));
-      }
-    }
+    const ownershipPair =
+      (item.obj.metadata.ownerReferences ?? []).some((owner) => owner.uid === focus.obj.metadata.uid) ||
+      (!!item.obj.metadata.uid && focusOwnerUids.has(item.obj.metadata.uid));
+    if (ownershipPair) continue;
 
-    if (metadataMentions(item.obj, focus.obj.metadata.name)) {
-      addEdge(edges, actualFocusId, id, 'manages', 'metadata');
-    }
-
-    if (focusLabelValues.includes(item.obj.metadata.name) || focusAnnotationValues.includes(item.obj.metadata.name)) {
-      addEdge(edges, actualFocusId, id, 'manages', 'metadata');
-    }
-
-    const reverseHints = collectRelationHints({ spec: item.obj.spec, status: item.obj.status });
-    if (reverseHints.some((hint) => hint.value === focus.obj.metadata.name || (hint.selector && selectorMatches(hint.selector, focus.obj.metadata.labels)))) {
-      addEdge(edges, actualFocusId, id, 'manages', item.spec.kind);
-    }
-
-    for (const owner of item.obj.metadata.ownerReferences ?? []) {
-      if (owner.uid === focus.obj.metadata.uid) addEdge(edges, actualFocusId, id, 'owns', owner.kind);
-    }
-    for (const owner of focus.obj.metadata.ownerReferences ?? []) {
-      const ownerId = byUid.get(owner.uid);
-      if (ownerId) addEdge(edges, ownerId, actualFocusId, 'owns', owner.kind);
-    }
+    const relation = inferredRelation(focus, item, focusHints);
+    if (relation) addEdge(edges, actualFocusId, id, relation.kind, relation.label);
   }
 
   if (nodes.has(actualFocusId)) {
@@ -556,7 +589,7 @@ async function buildGraph(handle: ClusterHandle, query: FocusQuery): Promise<Rel
       addEdge(edges, byUid.get(owner.uid), id, 'owns', owner.kind);
     }
   }
-  addFocusedResourceEdges(edges, focusItems[0], nodeItems, nodes, byUid);
+  addFocusedResourceEdges(edges, focusItems[0], nodeItems, nodes);
 
   for (const svc of services) {
     const svcId = nodeId(handle.contextName, svc.spec, svc.obj);

--- a/tests/electron/specs/desktop.spec.ts
+++ b/tests/electron/specs/desktop.spec.ts
@@ -27,6 +27,7 @@ test('boots the real desktop shell behind the restricted preload bridge', async 
 
   try {
     await expect(launched.page).toHaveTitle('Kubus');
+    // The title is static HTML; token removal proves the renderer bootstrap completed.
     await expect(launched.page).toHaveURL((url) => !url.searchParams.has('token'));
     const surface = await launched.page.evaluate(async () => {
       const desktop = window.kubusDesktop;

--- a/tests/electron/specs/desktop.spec.ts
+++ b/tests/electron/specs/desktop.spec.ts
@@ -27,6 +27,7 @@ test('boots the real desktop shell behind the restricted preload bridge', async 
 
   try {
     await expect(launched.page).toHaveTitle('Kubus');
+    await expect(launched.page).toHaveURL((url) => !url.searchParams.has('token'));
     const surface = await launched.page.evaluate(async () => {
       const desktop = window.kubusDesktop;
       if (!desktop) throw new Error('desktop bridge was not installed');

--- a/tests/unit/server/graph-routes.test.ts
+++ b/tests/unit/server/graph-routes.test.ts
@@ -247,6 +247,9 @@ describe('topology graph routes', () => {
           {
             displayName: 'router-a',
             routerRef: 'router-a',
+            targetRef: { apiVersion: 'example.io/v1', kind: 'Router', name: 'router-generic' },
+            remoteRouterRef: { name: 'router-remote', namespace: 'team-b' },
+            misleadingRouterRef: { kind: 'Service', name: 'router-decoy' },
             peerSelector: 'role=peer',
             targetPools: ['pool-a'],
             endpoint: 'https://ignored.example.test',
@@ -261,6 +264,10 @@ describe('topology graph routes', () => {
           items: [
             object('Router', 'router-a', 'team-a', { widgetName: 'widget-a' }, { state: 'down' }),
             object('Router', 'router-a', 'team-b', { widgetName: 'widget-a' }, { state: 'down' }),
+            object('Router', 'router-generic', 'team-a'),
+            object('Router', 'router-remote', 'team-a'),
+            object('Router', 'router-remote', 'team-b'),
+            object('Router', 'router-decoy', 'team-a'),
           ],
         };
       }
@@ -293,14 +300,20 @@ describe('topology graph routes', () => {
     });
     const graph = response.json();
     expect(response.statusCode).toBe(200);
-    const node = (kind: string) => graph.nodes.find((candidate: { ref: { kind: string } }) => candidate.ref.kind === kind);
-    const relations = (targetKind: string) =>
-      graph.edges.filter((edge: { source: string; target: string }) => edge.source === node('Widget').id && edge.target === node(targetKind).id);
-    expect(node('Widget')).toMatchObject({ status: 'success', layer: 'other' });
-    expect(relations('Router')).toEqual([expect.objectContaining({ kind: 'manages', label: 'spec.routerRef' })]);
-    expect(relations('Peer')).toEqual([expect.objectContaining({ kind: 'selects', label: 'spec.peerSelector' })]);
-    expect(relations('ResourcePool')).toEqual([expect.objectContaining({ kind: 'manages', label: 'spec.targetPools' })]);
-    expect(relations('HealthMonitor')).toEqual([expect.objectContaining({ kind: 'manages', label: 'metadata' })]);
+    const node = (kind: string, name?: string, namespace?: string) =>
+      graph.nodes.find((candidate: { ref: { kind: string; name: string; namespace?: string } }) =>
+        candidate.ref.kind === kind && (!name || candidate.ref.name === name) && (!namespace || candidate.ref.namespace === namespace));
+    const widget = node('Widget', 'widget-a', 'team-a');
+    const relations = (target: { id: string }) =>
+      graph.edges.filter((edge: { source: string; target: string }) => edge.source === widget.id && edge.target === target.id);
+    expect(widget).toMatchObject({ status: 'success', layer: 'other' });
+    expect(relations(node('Router', 'router-a', 'team-a'))).toEqual([expect.objectContaining({ kind: 'manages', label: 'spec.routerRef' })]);
+    expect(relations(node('Router', 'router-generic', 'team-a'))).toEqual([expect.objectContaining({ kind: 'manages', label: 'targetRef.name' })]);
+    expect(relations(node('Router', 'router-remote', 'team-b'))).toEqual([expect.objectContaining({ kind: 'manages', label: 'remoteRouterRef.name' })]);
+    expect(graph.nodes.filter((candidate: { ref: { kind: string } }) => candidate.ref.kind === 'Router')).toHaveLength(3);
+    expect(relations(node('Peer'))).toEqual([expect.objectContaining({ kind: 'selects', label: 'spec.peerSelector' })]);
+    expect(relations(node('ResourcePool'))).toEqual([expect.objectContaining({ kind: 'manages', label: 'spec.targetPools' })]);
+    expect(relations(node('HealthMonitor'))).toEqual([expect.objectContaining({ kind: 'manages', label: 'metadata' })]);
     expect(graph.edges.map((edge: { kind: string }) => edge.kind)).toEqual(expect.arrayContaining(['manages', 'selects']));
   });
 

--- a/tests/unit/server/graph-routes.test.ts
+++ b/tests/unit/server/graph-routes.test.ts
@@ -245,6 +245,7 @@ describe('topology graph routes', () => {
           'widget-a',
           'team-a',
           {
+            displayName: 'router-a',
             routerRef: 'router-a',
             peerSelector: 'role=peer',
             targetPools: ['pool-a'],
@@ -256,7 +257,12 @@ describe('topology graph routes', () => {
         );
       }
       if (path.includes('/routers')) {
-        return { items: [object('Router', 'router-a', 'team-a', { widgetName: 'widget-a' }, { state: 'down' })] };
+        return {
+          items: [
+            object('Router', 'router-a', 'team-a', { widgetName: 'widget-a' }, { state: 'down' }),
+            object('Router', 'router-a', 'team-b', { widgetName: 'widget-a' }, { state: 'down' }),
+          ],
+        };
       }
       if (path.includes('/peers')) {
         return {
@@ -268,19 +274,33 @@ describe('topology graph routes', () => {
         };
       }
       if (path.includes('/pools')) return { items: [object('ResourcePool', 'pool-a', 'team-a', {}, { conditions: [{ type: 'Ready', status: 'False', message: 'warming' }] })] };
-      if (path.includes('/monitors')) return { items: [object('HealthMonitor', 'monitor-a', 'team-a', {}, { conditions: [{ type: 'Ready', status: 'True' }] })] };
+      if (path.includes('/monitors')) {
+        return {
+          items: [
+            object('HealthMonitor', 'monitor-a', 'team-a', {}, { conditions: [{ type: 'Ready', status: 'True' }] }, {
+              metadata: { name: 'monitor-a', namespace: 'team-a', uid: 'uid-monitor', labels: { 'example.io/widget': 'widget-a' } },
+            }),
+          ],
+        };
+      }
       const plural = pluralFromPath(path);
       return { items: plural ? fixtures[plural] : [] };
     });
 
     const response = await app.inject({
       method: 'GET',
-      url: '/api/contexts/dev/graph?namespace=team-a&focusGroup=example.io&focusVersion=v1&focusPlural=widgets&focusKind=Widget&focusNamespace=team-a&focusName=widget-a&depth=2',
+      url: '/api/contexts/dev/graph?focusGroup=example.io&focusVersion=v1&focusPlural=widgets&focusKind=Widget&focusNamespace=team-a&focusName=widget-a&depth=2',
     });
     const graph = response.json();
     expect(response.statusCode).toBe(200);
-    expect(graph.nodes.find((node: { ref: { kind: string } }) => node.ref.kind === 'Widget')).toMatchObject({ status: 'success', layer: 'other' });
-    expect(graph.nodes.some((node: { ref: { kind: string } }) => node.ref.kind === 'Router')).toBe(true);
+    const node = (kind: string) => graph.nodes.find((candidate: { ref: { kind: string } }) => candidate.ref.kind === kind);
+    const relations = (targetKind: string) =>
+      graph.edges.filter((edge: { source: string; target: string }) => edge.source === node('Widget').id && edge.target === node(targetKind).id);
+    expect(node('Widget')).toMatchObject({ status: 'success', layer: 'other' });
+    expect(relations('Router')).toEqual([expect.objectContaining({ kind: 'manages', label: 'spec.routerRef' })]);
+    expect(relations('Peer')).toEqual([expect.objectContaining({ kind: 'selects', label: 'spec.peerSelector' })]);
+    expect(relations('ResourcePool')).toEqual([expect.objectContaining({ kind: 'manages', label: 'spec.targetPools' })]);
+    expect(relations('HealthMonitor')).toEqual([expect.objectContaining({ kind: 'manages', label: 'metadata' })]);
     expect(graph.edges.map((edge: { kind: string }) => edge.kind)).toEqual(expect.arrayContaining(['manages', 'selects']));
   });
 


### PR DESCRIPTION
## Summary

- require inferred topology references to use field paths or metadata keys that identify the target resource kind
- keep the strongest relationship evidence per resource pair
- exclude same-name matches across namespaces
- preserve ownership, selectors, nested custom-resource references, and typed metadata fallbacks

## Why

Focused custom-resource maps previously treated every matching string value as a relationship. Coincidental fields such as `commonName` and repeated metadata values could therefore create duplicate, misleading lines between the same resources.

## Impact

Certificate-to-Secret maps now show the meaningful `spec.secretName` relationship without duplicate `spec.commonName` or metadata edges. EDA relationships such as `bridgeDomains.name`, allocation-pool fields, selectors, and typed metadata associations remain visible.

## Validation

- `pnpm test` — 865 tests passed
- shared, client, and server builds passed
- `pnpm lint` passed
- verified the Certificate and VirtualNetwork maps against `myairframe3-k8s-vms`
