### PR TITLE
Make details drawer handle draggable

### DIFF
--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -128,6 +128,7 @@ function EmbeddedResourceDetail() {
   const focusSeq = useDetailStore((s) => s.focusSeq);
   const [searchParams, setSearchParams] = useSearchParams();
   const asideRef = useRef<HTMLElement>(null);
+  const collapseHandleDraggedRef = useRef(false);
 
   // Keyboard row activation asks for focus here; Escape hands it back.
   useEffect(() => {
@@ -154,18 +155,25 @@ function EmbeddedResourceDetail() {
 
   // Same drag pattern as BottomDock: width goes straight to the DOM (one
   // write per frame) and the store is committed once on mouseup.
-  const startResize = (e: React.MouseEvent) => {
+  const startResize = (e: React.MouseEvent, fromCollapseHandle = false) => {
+    if (e.button !== 0) return;
     e.preventDefault();
     const el = asideRef.current;
     if (!el) return;
     const startX = e.clientX;
     const startWidth = useDetailStore.getState().width;
+    if (fromCollapseHandle) collapseHandleDraggedRef.current = false;
     let pending = startWidth;
     let frame = 0;
     el.style.transition = 'none';
     document.body.style.cursor = 'col-resize';
     const onMove = (ev: MouseEvent) => {
-      pending = clampDetailWidth(startWidth + (startX - ev.clientX));
+      const delta = startX - ev.clientX;
+      // Preserve the handle's click-to-collapse behavior when the pointer only
+      // jitters by a couple of pixels.
+      if (fromCollapseHandle && Math.abs(delta) < 4) return;
+      if (fromCollapseHandle) collapseHandleDraggedRef.current = true;
+      pending = clampDetailWidth(startWidth + delta);
       if (!frame) {
         frame = requestAnimationFrame(() => {
           frame = 0;
@@ -258,7 +266,18 @@ function EmbeddedResourceDetail() {
         )}
         <Tooltip title={collapsed ? 'Expand details' : 'Collapse details'} placement="left">
           <ButtonBase
-            onClick={() => setCollapsed(!collapsed)}
+            disableRipple
+            onMouseDown={collapsed ? undefined : (e) => startResize(e, true)}
+            onClick={(e) => {
+              // A mouse drag ends in a click when it is released over the
+              // handle. Consume that click, while keeping keyboard activation.
+              if (e.detail > 0 && collapseHandleDraggedRef.current) {
+                collapseHandleDraggedRef.current = false;
+                return;
+              }
+              collapseHandleDraggedRef.current = false;
+              setCollapsed(!collapsed);
+            }}
             aria-label={collapsed ? 'Expand resource details' : 'Collapse resource details'}
             aria-expanded={!collapsed}
             sx={{
@@ -276,7 +295,12 @@ function EmbeddedResourceDetail() {
               bgcolor: 'background.paper',
               boxShadow: 2,
               color: 'text.secondary',
-              '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
+              cursor: collapsed ? 'pointer' : 'col-resize',
+              '&:hover': {
+                bgcolor: 'background.paper',
+                borderColor: 'text.secondary',
+                color: 'text.primary',
+              },
             }}
           >
             {collapsed ? <ChevronLeftIcon sx={{ fontSize: 16 }} /> : <ChevronRightIcon sx={{ fontSize: 16 }} />}

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -170,9 +170,12 @@ function EmbeddedResourceDetail() {
     const onMove = (ev: MouseEvent) => {
       const delta = startX - ev.clientX;
       // Preserve the handle's click-to-collapse behavior when the pointer only
-      // jitters by a couple of pixels.
-      if (fromCollapseHandle && Math.abs(delta) < 4) return;
-      if (fromCollapseHandle) collapseHandleDraggedRef.current = true;
+      // jitters by a couple of pixels. Once it is a drag, keep tracking every
+      // move so reversing toward the starting point cannot commit stale width.
+      if (fromCollapseHandle && !collapseHandleDraggedRef.current) {
+        if (Math.abs(delta) < 4) return;
+        collapseHandleDraggedRef.current = true;
+      }
       pending = clampDetailWidth(startWidth + delta);
       if (!frame) {
         frame = requestAnimationFrame(() => {

--- a/tests/unit/client/resource-list-page.test.tsx
+++ b/tests/unit/client/resource-list-page.test.tsx
@@ -320,6 +320,22 @@ describe('ResourceListPage', () => {
     fireEvent.click(screen.getByLabelText('Expand resource details'));
   });
 
+  it('resizes from the visible detail handle without collapsing it', () => {
+    renderPage('/r/core/v1/pods?sel=dev%7Cteam-a%7Cpod-a');
+
+    const handle = screen.getByLabelText('Collapse resource details');
+    fireEvent.mouseDown(handle, { button: 0, clientX: 700 });
+    fireEvent.mouseMove(window, { clientX: 650 });
+    fireEvent.mouseUp(window, { clientX: 650 });
+    // Browsers dispatch click after mouseup when the pointer is released over
+    // the button; the drag must consume it instead of collapsing the panel.
+    fireEvent.click(handle, { detail: 1 });
+
+    expect(useDetailStore.getState().width).toBe(690);
+    expect(useDetailStore.getState().collapsed).toBe(false);
+    expect(document.body.style.cursor).toBe('');
+  });
+
   it('uses the guided create flow for Jobs and CronJobs', () => {
     for (const [plural, kind] of [['jobs', 'Job'], ['cronjobs', 'CronJob']] as const) {
       const info = resource('batch', 'v1', plural, kind);

--- a/tests/unit/client/resource-list-page.test.tsx
+++ b/tests/unit/client/resource-list-page.test.tsx
@@ -326,12 +326,15 @@ describe('ResourceListPage', () => {
     const handle = screen.getByLabelText('Collapse resource details');
     fireEvent.mouseDown(handle, { button: 0, clientX: 700 });
     fireEvent.mouseMove(window, { clientX: 650 });
-    fireEvent.mouseUp(window, { clientX: 650 });
+    // Once classified as a drag, returning inside the original dead zone must
+    // track the final pointer position instead of committing the 690px peak.
+    fireEvent.mouseMove(window, { clientX: 698 });
+    fireEvent.mouseUp(window, { clientX: 698 });
     // Browsers dispatch click after mouseup when the pointer is released over
     // the button; the drag must consume it instead of collapsing the panel.
     fireEvent.click(handle, { detail: 1 });
 
-    expect(useDetailStore.getState().width).toBe(690);
+    expect(useDetailStore.getState().width).toBe(642);
     expect(useDetailStore.getState().collapsed).toBe(false);
     expect(document.body.style.cursor).toBe('');
   });


### PR DESCRIPTION
## Summary

- keep the details drawer chevron handle opaque on hover
- allow the expanded drawer to be resized by dragging the visible chevron handle
- preserve click and keyboard collapse behavior with a small drag threshold and click suppression after a resize
- add regression coverage for resizing through the handle

## Why

The handle replaced its solid paper background with MUI's translucent hover color, which made it appear transparent. It also sat above the narrow resize strip, so the drawer's most visible affordance intercepted drag starts instead of resizing the panel.

This makes resizing easier to discover while retaining the existing collapse interaction.

## Validation

- `pnpm --filter @kubus/tests exec vitest run unit/client/resource-list-page.test.tsx`
- `pnpm exec oxlint client/src/pages/ResourceListPage.tsx tests/unit/client/resource-list-page.test.tsx --deny-warnings`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- isolated Playwright browser verification of hover styling, drag resizing, drag/click suppression, and normal collapse behavior