### PR TITLE
Preserve SSH jump settings across kubeconfig imports

### DIFF
--- a/client/src/components/settings/AddClusterDialog.tsx
+++ b/client/src/components/settings/AddClusterDialog.tsx
@@ -19,7 +19,7 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { dump as dumpYaml } from 'js-yaml';
 import type { KubeconfigImportResponse } from '@kubus/shared';
-import { useImportKubeconfig, useSetSshHost } from '../../api/queries.js';
+import { useImportKubeconfig } from '../../api/queries.js';
 import { ApiError } from '../../api/http.js';
 import { SshJumpHostField, SSH_DESTINATION_RE } from './SshJumpHostField.js';
 import { normalizePemInput } from './pem.js';
@@ -58,7 +58,6 @@ function buildKubeconfigYaml(form: { name: string; server: string; ca: string; s
 /** Merge a new cluster into the kubeconfig file: paste a config or fill in the form. */
 export function AddClusterDialog({ primaryPath, onClose }: Props) {
   const importKubeconfig = useImportKubeconfig();
-  const setSshHost = useSetSshHost();
   const [mode, setMode] = useState(0);
   const [pasted, setPasted] = useState('');
   const [form, setForm] = useState({ name: '', server: '', ca: '', skipTls: false, auth: 'token' as AuthMethod, token: '', cert: '', key: '' });
@@ -67,28 +66,19 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
   const [proxyUrl, setProxyUrl] = useState('');
   const [conflicts, setConflicts] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [sshWarning, setSshWarning] = useState<string | null>(null);
   const [result, setResult] = useState<KubeconfigImportResponse | null>(null);
 
   const sshSelected = connMode === 'ssh';
-  // The proxy URL lands in the generated kubeconfig, so it's manual-form-only;
-  // for pasted configs put `proxy-url` in the YAML itself.
-  const proxySelected = connMode === 'proxy' && mode === 1;
+  const proxySelected = connMode === 'proxy';
   const connValid = (!sshSelected || SSH_DESTINATION_RE.test(sshHost.trim())) && (!proxySelected || PROXY_URL_RE.test(proxyUrl.trim()));
   const formValid =
     !!form.name.trim() &&
     !!form.server.trim() &&
     (form.auth === 'token' ? !!form.token.trim() : !!form.cert.trim() && !!form.key.trim());
 
-  const switchTab = (v: number) => {
-    setMode(v);
-    if (v === 0 && connMode === 'proxy') setConnMode('direct');
-  };
-
   const submit = (overwrite: boolean) => {
     setError(null);
     setConflicts(null);
-    setSshWarning(null);
     setResult(null);
     let yamlBody: string;
     try {
@@ -98,21 +88,14 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
       return;
     }
     importKubeconfig.mutate(
-      { yaml: yamlBody, overwrite },
       {
-        onSuccess: async (resp) => {
-          // Attach the managed tunnel to every context the import created.
-          if (sshSelected && sshHost.trim()) {
-            for (const ctxName of resp.added.contexts) {
-              try {
-                await setSshHost.mutateAsync({ ctx: ctxName, body: { sshHost: sshHost.trim() } });
-              } catch (err) {
-                setSshWarning(`Imported, but setting the SSH jump host on "${ctxName}" failed: ${err instanceof Error ? err.message : String(err)}`);
-              }
-            }
-          }
-          setResult(resp);
-        },
+        yaml: yamlBody,
+        overwrite,
+        sshHost: sshSelected ? sshHost.trim() : undefined,
+        proxyUrl: mode === 0 && proxySelected ? proxyUrl.trim() : undefined,
+      },
+      {
+        onSuccess: setResult,
         onError: (err) => {
           if (err instanceof ApiError && err.status === 409) setConflicts(err.message);
           else setError(err instanceof Error ? err.message : String(err));
@@ -122,14 +105,14 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
   };
 
   const set = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) => setForm((f) => ({ ...f, [key]: value }));
-  const busy = importKubeconfig.isPending || setSshHost.isPending;
+  const busy = importKubeconfig.isPending;
   const addedContexts = result?.added.contexts ?? [];
 
   return (
     <Dialog open onClose={busy ? undefined : onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Add cluster</DialogTitle>
       <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: '8px !important' }}>
-        <Tabs value={mode} onChange={(_, v: number) => switchTab(v)} sx={{ minHeight: 36, '& .MuiTab-root': { minHeight: 36 } }}>
+        <Tabs value={mode} onChange={(_, v: number) => setMode(v)} sx={{ minHeight: 36, '& .MuiTab-root': { minHeight: 36 } }}>
           <Tab label="Paste kubeconfig" />
           <Tab label="Manual" />
         </Tabs>
@@ -209,7 +192,7 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
           <Select labelId="add-conn" label="Connection" value={connMode} onChange={(e) => setConnMode(e.target.value as ConnMode)}>
             <MenuItem value="direct">Direct — the API server is reachable from this machine</MenuItem>
             <MenuItem value="ssh">SSH jump host — Kubus opens the tunnel for you</MenuItem>
-            {mode === 1 && <MenuItem value="proxy">Proxy URL — an existing SOCKS or HTTP proxy</MenuItem>}
+            <MenuItem value="proxy">Proxy URL — an existing SOCKS or HTTP proxy</MenuItem>
           </Select>
         </FormControl>
         {sshSelected && <SshJumpHostField value={sshHost} onChange={setSshHostValue} />}
@@ -226,7 +209,7 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
             onChange={(e) => setProxyUrl(e.target.value)}
             placeholder="socks5://host:port"
             error={!!proxyUrl.trim() && !PROXY_URL_RE.test(proxyUrl.trim())}
-            helperText="Written into the kubeconfig as proxy-url"
+            helperText={mode === 0 ? 'Written into every imported cluster as proxy-url' : 'Written into the kubeconfig as proxy-url'}
           />
         )}
         <Typography variant="caption" color="text.secondary">
@@ -245,11 +228,11 @@ export function AddClusterDialog({ primaryPath, onClose }: Props) {
           </Alert>
         )}
         {error && <Alert severity="error">{error}</Alert>}
-        {sshWarning && <Alert severity="warning">{sshWarning}</Alert>}
         {result && (
           <Alert severity="success">
             {addedContexts.length > 0 ? `Added context${addedContexts.length > 1 ? 's' : ''}: ${addedContexts.join(', ')}.` : 'Nothing new to add.'}
-            {sshSelected && !sshWarning && addedContexts.length > 0 && ` SSH tunnel via ${sshHost.trim()} configured.`}
+            {sshSelected && addedContexts.length > 0 && ` SSH tunnel via ${sshHost.trim()} configured.`}
+            {proxySelected && addedContexts.length > 0 && ` Proxy ${proxyUrl.trim()} configured.`}
             {result.skipped.length > 0 && ` Skipped ${result.skipped.length} identical entr${result.skipped.length > 1 ? 'ies' : 'y'}.`}
             {result.backupPath && ` Backup: ${result.backupPath}`}
           </Alert>

--- a/docs/guide/clusters.md
+++ b/docs/guide/clusters.md
@@ -59,8 +59,9 @@ namespace simply contribute nothing to the list.
 Open **Settings → Clusters** to manage the entries in your kubeconfig:
 
 - **Add cluster** — paste a kubeconfig snippet, or fill in a short form (name, API server,
-  CA, and either a bearer token or a client certificate). It's merged into your kubeconfig,
-  and a backup is written first.
+  CA, and either a bearer token or a client certificate). For either path you can choose
+  direct access, a Kubus-managed SSH jump host, or an existing SOCKS/HTTP proxy. It's
+  merged into your kubeconfig, and a backup is written first.
 - **Edit** (:material-pencil: on any row) — change a cluster's **API server**,
   **credentials**, TLS settings, and the connection options below (SSH jump host /
   proxy). Cloud-provider clusters that

--- a/server/src/kube/cluster-manager.ts
+++ b/server/src/kube/cluster-manager.ts
@@ -162,6 +162,8 @@ export class ClusterHandle {
 
 export class ClusterManager extends EventEmitter {
   private kc = new KubeConfig();
+  /** File that supplied each context at the last load; retained until the next load completes. */
+  private contextFiles = new Map<string, string>();
   private handles = new Map<string, ClusterHandle>();
   private connecting = new Map<string, Promise<ClusterHandle>>();
   private fsWatchers: fs.FSWatcher[] = [];
@@ -204,6 +206,7 @@ export class ClusterManager extends EventEmitter {
     }
     // Bridge standard proxy env vars (client-node only reads kubeconfig proxy-url).
     this.envProxyClusters = applyEnvProxy(this.kc);
+    this.contextFiles = this.scanContextFiles();
   }
 
   private kubeconfigPaths(): string[] {
@@ -301,8 +304,10 @@ export class ClusterManager extends EventEmitter {
   reload(): void {
     this.log.info('kubeconfig changed, reloading');
     const before = this.contextFingerprints();
+    const sshAssociations = this.sshAssociations();
     this.kc = new KubeConfig();
     this.loadKubeconfig();
+    this.restoreMovedSshAssociations(sshAssociations);
     this.probeClients.clear();
     const after = this.contextFingerprints();
     for (const [name, handle] of this.handles) {
@@ -592,13 +597,43 @@ export class ClusterManager extends EventEmitter {
   }
 
   private sshTunnelKeyForContext(contextName: string): string | null {
-    const contextFile = this.findEntryFile('context', contextName);
+    const contextFile = this.contextFiles.get(contextName);
     if (!contextFile) return null;
     return sshTunnelKeyFor(contextFile, contextName);
   }
 
-  /** The kubeconfig file defining each context, loading every watched path once. */
-  private contextFilesByName(): Map<string, string> {
+  /** Capture enough identity to carry a jump host across a context's file move. */
+  private sshAssociations(): Map<string, { key: string; server?: string }> {
+    const associations = new Map<string, { key: string; server?: string }>();
+    if (!this.sshTunnels) return associations;
+    for (const context of this.kc.getContexts()) {
+      const contextFile = this.contextFiles.get(context.name);
+      if (!contextFile) continue;
+      const key = sshTunnelKeyFor(contextFile, context.name);
+      const host = this.sshTunnels.hostForContextKey(key);
+      if (host) associations.set(context.name, { key, server: this.kc.getCluster(context.cluster)?.server });
+    }
+    return associations;
+  }
+
+  /**
+   * An import into the first file of a multi-file KUBECONFIG can move which
+   * file supplies an existing context. Keep its external SSH metadata attached
+   * when the context still names the same API server.
+   */
+  private restoreMovedSshAssociations(before: Map<string, { key: string; server?: string }>): void {
+    if (!this.sshTunnels || before.size === 0) return;
+    for (const context of this.kc.getContexts()) {
+      const previous = before.get(context.name);
+      const contextFile = this.contextFiles.get(context.name);
+      if (!previous || !contextFile || previous.server !== this.kc.getCluster(context.cluster)?.server) continue;
+      const nextKey = sshTunnelKeyFor(contextFile, context.name);
+      this.sshTunnels.rekeyContext(previous.key, nextKey);
+    }
+  }
+
+  /** Scan the kubeconfig file defining each context, loading every watched path once. */
+  private scanContextFiles(): Map<string, string> {
     const files = new Map<string, string>();
     for (const p of this.kubeconfigPaths()) {
       try {
@@ -614,14 +649,19 @@ export class ClusterManager extends EventEmitter {
     return files;
   }
 
+  /** Snapshot of the context origins established by the last completed load. */
+  private contextFilesByName(): Map<string, string> {
+    return new Map(this.contextFiles);
+  }
+
   /** Locate the kubeconfig file (among the watched paths) that defines an entry. */
   private findEntryFile(kind: 'context' | 'cluster' | 'user', name: string | undefined): string | null {
     if (!name) return null;
+    if (kind === 'context') return this.contextFiles.get(name) ?? null;
     for (const p of this.kubeconfigPaths()) {
       try {
         const kc = new KubeConfig();
         kc.loadFromFile(p);
-        if (kind === 'context' && kc.getContexts().some((c) => c.name === name)) return p;
         if (kind === 'cluster' && kc.getClusters().some((c) => c.name === name)) return p;
         if (kind === 'user' && kc.getUsers().some((u) => u.name === name)) return p;
       } catch {

--- a/server/src/kube/kubeconfig-file.ts
+++ b/server/src/kube/kubeconfig-file.ts
@@ -40,7 +40,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
  * objects are merged (not KubeConfig.exportConfig output) so unknown fields
  * and the existing file's structure are preserved faithfully.
  */
-export function mergeKubeconfig(existingYaml: string | null, incomingYaml: string, overwrite: boolean): MergeResult {
+export function mergeKubeconfig(existingYaml: string | null, incomingYaml: string, overwrite: boolean, proxyUrl?: string | null): MergeResult {
   // Validate with the real parser first: garbage in → 400 out.
   const probe = new KubeConfig();
   try {
@@ -54,6 +54,12 @@ export function mergeKubeconfig(existingYaml: string | null, incomingYaml: strin
 
   const incoming = (loadYaml(incomingYaml) ?? {}) as KubeconfigDoc;
   const existing: KubeconfigDoc | null = existingYaml?.trim() ? ((loadYaml(existingYaml) ?? {}) as KubeconfigDoc) : null;
+  if (proxyUrl !== undefined) {
+    for (const entry of asEntries(incoming.clusters)) {
+      const cluster = (entry.cluster && typeof entry.cluster === 'object' ? entry.cluster : (entry.cluster = {})) as Record<string, unknown>;
+      setString(cluster, 'proxy-url', proxyUrl);
+    }
+  }
 
   const added = { contexts: [] as string[], clusters: [] as string[], users: [] as string[] };
   const skipped: string[] = [];

--- a/server/src/kube/kubeconfig-file.ts
+++ b/server/src/kube/kubeconfig-file.ts
@@ -22,6 +22,8 @@ interface KubeconfigDoc {
 export interface MergeResult {
   merged: string;
   added: { contexts: string[]; clusters: string[]; users: string[] };
+  /** Incoming contexts whose cluster entries receive the selected connection mode. */
+  connectionContexts: string[];
   skipped: string[];
   conflicts: string[];
 }
@@ -51,6 +53,11 @@ export function mergeKubeconfig(existingYaml: string | null, incomingYaml: strin
   if (probe.getContexts().length === 0) {
     throw new HttpProblem(400, 'kubeconfig contains no contexts', 'BadRequest');
   }
+  const incomingClusterNames = new Set(probe.getClusters().map((cluster) => cluster.name));
+  const connectionContexts = probe
+    .getContexts()
+    .filter((context) => incomingClusterNames.has(context.cluster))
+    .map((context) => context.name);
 
   const incoming = (loadYaml(incomingYaml) ?? {}) as KubeconfigDoc;
   const existing: KubeconfigDoc | null = existingYaml?.trim() ? ((loadYaml(existingYaml) ?? {}) as KubeconfigDoc) : null;
@@ -75,7 +82,7 @@ export function mergeKubeconfig(existingYaml: string | null, incomingYaml: strin
     added.contexts = asEntries(incoming.contexts).map((e) => e.name);
     added.clusters = asEntries(incoming.clusters).map((e) => e.name);
     added.users = asEntries(incoming.users).map((e) => e.name);
-    return { merged: dumpYaml(doc, { lineWidth: -1 }), added, skipped, conflicts };
+    return { merged: dumpYaml(doc, { lineWidth: -1 }), added, connectionContexts, skipped, conflicts };
   }
 
   for (const section of ['clusters', 'users', 'contexts'] as const) {
@@ -99,7 +106,7 @@ export function mergeKubeconfig(existingYaml: string | null, incomingYaml: strin
   }
 
   // Never touch current-context of an existing file.
-  return { merged: dumpYaml(existing, { lineWidth: -1 }), added, skipped, conflicts };
+  return { merged: dumpYaml(existing, { lineWidth: -1 }), added, connectionContexts, skipped, conflicts };
 }
 
 export interface ClusterEditPatch {

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -110,9 +110,11 @@ export function registerSettingsRoutes(app: FastifyInstance, ctx: AppContext): v
       }
       const backupPath = writeKubeconfig(target, result.merged);
       ctx.clusters.reload();
-      if (parsed.data.sshHost) {
-        for (const contextName of result.added.contexts) {
-          ctx.clusters.setSshHost(contextName, parsed.data.sshHost);
+      if (parsed.data.sshHost || parsed.data.proxyUrl) {
+        for (const contextName of result.connectionContexts) {
+          // A managed SSH tunnel overrides proxy-url at runtime, so selecting a
+          // proxy must clear any external jump mapping left from an earlier import.
+          ctx.clusters.setSshHost(contextName, parsed.data.sshHost ?? null);
         }
       }
       const response: KubeconfigImportResponse = {

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -29,7 +29,25 @@ function importAuthWarnings(incomingYaml: string, addedUsers: string[]): string[
 }
 
 const setKubeconfigSchema = z.object({ path: z.string().min(1).nullable() });
-const importSchema = z.object({ yaml: z.string().min(1), overwrite: z.boolean().optional() });
+const sshHostSchema = z
+  .string()
+  .trim()
+  .max(256)
+  .regex(/^(ssh:\/\/)?[A-Za-z0-9][A-Za-z0-9._~%@:[\]-]*$/, 'SSH jump host must be an ssh config alias, user@host or ssh://user@host:port');
+const proxyUrlSchema = z
+  .string()
+  .trim()
+  .regex(/^(socks5?|socks5h|https?):\/\//i, 'proxy URL must start with socks5://, socks5h://, http:// or https://');
+const importSchema = z
+  .object({
+    yaml: z.string().min(1),
+    overwrite: z.boolean().optional(),
+    sshHost: sshHostSchema.optional(),
+    proxyUrl: proxyUrlSchema.optional(),
+  })
+  .refine((value) => !(value.sshHost && value.proxyUrl), {
+    message: 'choose either an SSH jump host or a proxy URL, not both',
+  });
 
 export function registerSettingsRoutes(app: FastifyInstance, ctx: AppContext): void {
   const kubeconfigSettings = (): KubeconfigSettings => {
@@ -81,12 +99,22 @@ export function registerSettingsRoutes(app: FastifyInstance, ctx: AppContext): v
       const target = ctx.clusters.primaryKubeconfigPath();
       if (!target) throw new HttpProblem(400, 'no kubeconfig path could be resolved', 'BadRequest');
       const existing = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : null;
-      const result = mergeKubeconfig(existing, parsed.data.yaml, parsed.data.overwrite ?? false);
+      const result = mergeKubeconfig(
+        existing,
+        parsed.data.yaml,
+        parsed.data.overwrite ?? false,
+        parsed.data.sshHost ? null : parsed.data.proxyUrl,
+      );
       if (result.conflicts.length) {
         throw new HttpProblem(409, `entries already exist with different content: ${result.conflicts.join(', ')}`, 'Conflict');
       }
       const backupPath = writeKubeconfig(target, result.merged);
       ctx.clusters.reload();
+      if (parsed.data.sshHost) {
+        for (const contextName of result.added.contexts) {
+          ctx.clusters.setSshHost(contextName, parsed.data.sshHost);
+        }
+      }
       const response: KubeconfigImportResponse = {
         added: result.added,
         skipped: result.skipped,

--- a/server/src/ssh/tunnel-manager.ts
+++ b/server/src/ssh/tunnel-manager.ts
@@ -71,11 +71,29 @@ export class SshTunnelManager {
     return this.mapping[contextKey];
   }
 
+  /**
+   * Move a persisted mapping when the same context starts resolving from a
+   * different kubeconfig file. This can happen after a multi-file import; the
+   * tunnel belongs to the context, not to the old file location.
+   */
+  rekeyContext(oldKey: string, newKey: string): void {
+    const oldHost = this.mapping[oldKey];
+    if (oldKey === newKey || !oldHost) return;
+    if (!this.mapping[newKey]) this.mapping[newKey] = oldHost;
+    delete this.mapping[oldKey];
+    this.settings.save({ sshTunnels: { ...this.mapping } });
+    this.stopUnreferencedTunnels();
+  }
+
   /** Update the context→host mapping, persist it, and stop tunnels nothing references anymore. */
   setHostForContextKey(contextKey: string, host: string | null): void {
     if (host) this.mapping[contextKey] = host;
     else delete this.mapping[contextKey];
     this.settings.save({ sshTunnels: { ...this.mapping } });
+    this.stopUnreferencedTunnels();
+  }
+
+  private stopUnreferencedTunnels(): void {
     const referenced = new Set(Object.values(this.mapping));
     for (const [tunnelHost, tunnel] of this.tunnels) {
       if (!referenced.has(tunnelHost)) {

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -146,6 +146,10 @@ export interface KubeconfigImportRequest {
   yaml: string;
   /** Replace existing entries with the same name instead of failing with 409. */
   overwrite?: boolean;
+  /** Apply a Kubus-managed SSH jump host to every context added/replaced by the import. */
+  sshHost?: string;
+  /** Write this proxy URL into every cluster added/replaced by the import. */
+  proxyUrl?: string;
 }
 
 export interface KubeconfigImportResponse {

--- a/tests/unit/server/cluster-manager.test.ts
+++ b/tests/unit/server/cluster-manager.test.ts
@@ -22,6 +22,7 @@ import { WatcherRegistry } from '../../../server/src/kube/watcher';
 
 interface ManagerInternals {
   kc: KubeConfig;
+  contextFiles: Map<string, string>;
   handles: Map<string, ClusterHandle>;
   connecting: Map<string, Promise<ClusterHandle>>;
   fsWatchers: Array<{ close(): void }>;
@@ -48,6 +49,7 @@ interface ManagerInternals {
   refreshCachedHealthNow(): Promise<void>;
   sshTunnelKeyForContext(contextName: string): string | null;
   contextFilesByName(): Map<string, string>;
+  scanContextFiles(): Map<string, string>;
   findEntryFile(kind: 'context' | 'cluster' | 'user', name: string | undefined): string | null;
   disconnectHandlesForEntries(clusterName: string, userName: string | undefined): void;
   connectFresh(contextName: string): Promise<ClusterHandle>;
@@ -143,6 +145,12 @@ function sshHarness() {
   const hosts = new Map<string, string>();
   const tunnel = {
     hostForContextKey: vi.fn((key: string) => hosts.get(key)),
+    rekeyContext: vi.fn((oldKey: string, newKey: string) => {
+      const host = hosts.get(oldKey);
+      if (!host) return;
+      if (!hosts.has(newKey)) hosts.set(newKey, host);
+      hosts.delete(oldKey);
+    }),
     setHostForContextKey: vi.fn((key: string, value: string | null) => {
       if (value === null) hosts.delete(key);
       else hosts.set(key, value);
@@ -427,6 +435,41 @@ describe('ClusterManager file watching and reloads', () => {
     expect(internals.kubeconfigPaths()).toEqual([first.file, second.file]);
     vi.stubEnv('KUBECONFIG', '');
     expect(internals.kubeconfigPaths()[0]).toContain(path.join('.kube', 'config'));
+  });
+
+  it('keeps an SSH jump host when a multi-file reload moves a context to another file', () => {
+    const first = writeFixture(kubeconfigYaml({ contexts: [{ name: 'other', cluster: 'cluster-a', user: 'user-a' }], current: 'other' }));
+    const second = writeFixture(
+      kubeconfigYaml({ contexts: [{ name: 'kind-a', cluster: 'cluster-a', user: 'user-a' }], current: 'kind-a' })
+        .replaceAll('cluster-a', 'cluster-kind-a')
+        .replaceAll('user-a', 'user-kind-a'),
+    );
+    vi.stubEnv('KUBECONFIG', `${first.file}${path.delimiter}${second.file}`);
+    const { tunnel, hosts } = sshHarness();
+    const manager = new ClusterManager(logger(), undefined, tunnel);
+    managers.push(manager);
+    const internals = manager as unknown as ManagerInternals;
+    const oldKey = internals.sshTunnelKeyForContext('kind-a')!;
+    manager.setSshHost('kind-a', 'jump');
+
+    fs.writeFileSync(
+      first.file,
+      kubeconfigYaml({
+        contexts: [
+          { name: 'other', cluster: 'cluster-a', user: 'user-a' },
+          { name: 'kind-a', cluster: 'cluster-a', user: 'user-a' },
+        ],
+        current: 'other',
+      }),
+    );
+    manager.reload();
+
+    const newKey = internals.sshTunnelKeyForContext('kind-a')!;
+    expect(newKey).not.toBe(oldKey);
+    expect(hosts.has(oldKey)).toBe(false);
+    expect(hosts.get(newKey)).toBe('jump');
+    expect(manager.listContexts().find((context) => context.name === 'kind-a')?.sshHost).toBe('jump');
+    expect(tunnel.rekeyContext).toHaveBeenCalledWith(oldKey, newKey);
   });
 });
 

--- a/tests/unit/server/cluster-manager.test.ts
+++ b/tests/unit/server/cluster-manager.test.ts
@@ -437,10 +437,16 @@ describe('ClusterManager file watching and reloads', () => {
     expect(internals.kubeconfigPaths()[0]).toContain(path.join('.kube', 'config'));
   });
 
-  it('keeps an SSH jump host when a multi-file reload moves a context to another file', () => {
+  it('keeps distinct SSH jump hosts when a multi-file reload moves contexts to another file', () => {
     const first = writeFixture(kubeconfigYaml({ contexts: [{ name: 'other', cluster: 'cluster-a', user: 'user-a' }], current: 'other' }));
     const second = writeFixture(
-      kubeconfigYaml({ contexts: [{ name: 'kind-a', cluster: 'cluster-a', user: 'user-a' }], current: 'kind-a' })
+      kubeconfigYaml({
+        contexts: [
+          { name: 'kind-a', cluster: 'cluster-a', user: 'user-a' },
+          { name: 'kind-b', cluster: 'cluster-a', user: 'user-a' },
+        ],
+        current: 'kind-a',
+      })
         .replaceAll('cluster-a', 'cluster-kind-a')
         .replaceAll('user-a', 'user-kind-a'),
     );
@@ -449,8 +455,10 @@ describe('ClusterManager file watching and reloads', () => {
     const manager = new ClusterManager(logger(), undefined, tunnel);
     managers.push(manager);
     const internals = manager as unknown as ManagerInternals;
-    const oldKey = internals.sshTunnelKeyForContext('kind-a')!;
+    const oldKeyA = internals.sshTunnelKeyForContext('kind-a')!;
+    const oldKeyB = internals.sshTunnelKeyForContext('kind-b')!;
     manager.setSshHost('kind-a', 'jump');
+    manager.setSshHost('kind-b', 'other-jump');
 
     fs.writeFileSync(
       first.file,
@@ -458,22 +466,52 @@ describe('ClusterManager file watching and reloads', () => {
         contexts: [
           { name: 'other', cluster: 'cluster-a', user: 'user-a' },
           { name: 'kind-a', cluster: 'cluster-a', user: 'user-a' },
+          { name: 'kind-b', cluster: 'cluster-a', user: 'user-a' },
         ],
         current: 'other',
       }),
     );
     manager.reload();
 
-    const newKey = internals.sshTunnelKeyForContext('kind-a')!;
-    expect(newKey).not.toBe(oldKey);
-    expect(hosts.has(oldKey)).toBe(false);
-    expect(hosts.get(newKey)).toBe('jump');
+    const newKeyA = internals.sshTunnelKeyForContext('kind-a')!;
+    const newKeyB = internals.sshTunnelKeyForContext('kind-b')!;
+    expect(newKeyA).not.toBe(oldKeyA);
+    expect(newKeyB).not.toBe(oldKeyB);
+    expect(hosts.has(oldKeyA)).toBe(false);
+    expect(hosts.has(oldKeyB)).toBe(false);
+    expect(hosts.get(newKeyA)).toBe('jump');
+    expect(hosts.get(newKeyB)).toBe('other-jump');
     expect(manager.listContexts().find((context) => context.name === 'kind-a')?.sshHost).toBe('jump');
-    expect(tunnel.rekeyContext).toHaveBeenCalledWith(oldKey, newKey);
+    expect(manager.listContexts().find((context) => context.name === 'kind-b')?.sshHost).toBe('other-jump');
+    expect(tunnel.rekeyContext).toHaveBeenCalledWith(oldKeyA, newKeyA);
+    expect(tunnel.rekeyContext).toHaveBeenCalledWith(oldKeyB, newKeyB);
   });
 });
 
 describe('ClusterManager connections and SSH', () => {
+  it('keeps different SSH jumps isolated for contexts that share one cluster entry', async () => {
+    const { file } = writeFixture();
+    const { tunnel } = sshHarness();
+    const manager = createManager(file, tunnel);
+    await vi.waitFor(() => expect(manager.listContexts().every((context) => context.health === 'connected')).toBe(true));
+
+    manager.setSshHost('kind-a', 'jump');
+    manager.setSshHost('kind-b', 'other-jump');
+    (tunnel.ensure as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    const [handleA, handleB] = await Promise.all([manager.connect('kind-a'), manager.connect('kind-b')]);
+
+    expect(handleA.kc).not.toBe(handleB.kc);
+    expect(handleA.kc.getCurrentContext()).toBe('kind-a');
+    expect(handleB.kc.getCurrentContext()).toBe('kind-b');
+    expect(handleA.kc.getCurrentCluster()?.name).toBe('cluster-a');
+    expect(handleB.kc.getCurrentCluster()?.name).toBe('cluster-a');
+    expect(handleA.kc.getCurrentCluster()?.proxyUrl).toBe('socks5h://127.0.0.1:4100');
+    expect(handleB.kc.getCurrentCluster()?.proxyUrl).toBe('socks5h://127.0.0.1:4200');
+    expect(tunnel.ensure).toHaveBeenCalledWith('jump');
+    expect(tunnel.ensure).toHaveBeenCalledWith('other-jump');
+  });
+
   it('reuses active/in-flight connects, activates healthy handles, relays discovery, disconnects, and reconnects', async () => {
     const { file } = writeFixture();
     const manager = createManager(file);

--- a/tests/unit/server/kubeconfig-file.test.ts
+++ b/tests/unit/server/kubeconfig-file.test.ts
@@ -93,6 +93,7 @@ describe('mergeKubeconfig', () => {
       clusters: ['first-cluster'],
       users: ['first-user'],
     });
+    expect(result.connectionContexts).toEqual(['first']);
     expect(result.skipped).toEqual([]);
     expect(result.conflicts).toEqual([]);
   });
@@ -108,6 +109,7 @@ describe('mergeKubeconfig', () => {
       clusters: ['beta-cluster'],
       users: ['beta-user'],
     });
+    expect(result.connectionContexts).toEqual(['beta']);
   });
 
   it('applies an imported proxy URL to every incoming cluster', () => {

--- a/tests/unit/server/kubeconfig-file.test.ts
+++ b/tests/unit/server/kubeconfig-file.test.ts
@@ -110,6 +110,30 @@ describe('mergeKubeconfig', () => {
     });
   });
 
+  it('applies an imported proxy URL to every incoming cluster', () => {
+    const incoming = configDoc('proxied');
+    incoming.clusters!.push({
+      name: 'second-cluster',
+      cluster: { server: 'https://second.example.test', 'proxy-url': 'http://old-proxy' },
+    });
+
+    const result = mergeKubeconfig(null, yaml(incoming), false, 'socks5h://jump.example.test:1080');
+
+    expect(parse(result.merged).clusters?.map((entry) => entry.cluster['proxy-url'])).toEqual([
+      'socks5h://jump.example.test:1080',
+      'socks5h://jump.example.test:1080',
+    ]);
+  });
+
+  it('removes imported proxy URLs when an SSH jump host will own the connection', () => {
+    const incoming = configDoc('jumped');
+    incoming.clusters![0]!.cluster['proxy-url'] = 'socks5://old-proxy:1080';
+
+    const result = mergeKubeconfig(null, yaml(incoming), false, null);
+
+    expect(parse(result.merged).clusters?.[0]?.cluster['proxy-url']).toBeUndefined();
+  });
+
   it('separates identical entries from conflicting entries', () => {
     const existing = configDoc('same');
     const incoming = structuredClone(existing);

--- a/tests/unit/server/misc-routes.test.ts
+++ b/tests/unit/server/misc-routes.test.ts
@@ -510,7 +510,25 @@ describe('settings routes', () => {
 
     expect(response.statusCode).toBe(200);
     expect(fs.readFileSync(target, 'utf8')).toContain('proxy-url: socks5h://proxy.example.test:1080');
-    expect(harness.clusters.setSshHost).not.toHaveBeenCalled();
+    expect(harness.clusters.setSshHost).toHaveBeenCalledWith('proxied', null);
+  });
+
+  it('clears an existing SSH mapping when a proxy import overwrites an unchanged context', async () => {
+    const target = tempKubeconfig(kubeconfig('same'));
+    const harness = createHarness();
+    harness.clusters.primaryKubeconfigPath.mockReturnValue(target);
+    const app = await buildApp(harness);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/settings/kubeconfig/import',
+      payload: { yaml: kubeconfig('same'), proxyUrl: 'socks5://proxy.example.test:1080', overwrite: true },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json().added.contexts).toEqual([]);
+    expect(harness.clusters.setSshHost).toHaveBeenCalledWith('same', null);
+    expect(fs.readFileSync(target, 'utf8')).toContain('proxy-url: socks5://proxy.example.test:1080');
   });
 
   it('rejects imports with invalid bodies, unresolved targets, and conflicts', async () => {

--- a/tests/unit/server/misc-routes.test.ts
+++ b/tests/unit/server/misc-routes.test.ts
@@ -484,14 +484,33 @@ describe('settings routes', () => {
     const response = await app.inject({
       method: 'POST',
       url: '/api/settings/kubeconfig/import',
-      payload: { yaml: incoming },
+      payload: { yaml: incoming, sshHost: 'jump-host' },
     });
     expect(response.statusCode).toBe(200);
     expect(response.json().added.contexts).toEqual(['imported']);
     expect(response.json().warnings[0]).toContain('was not found on PATH');
     expect(response.json().backupPath).toContain('.kubus.bak');
     expect(harness.clusters.reload).toHaveBeenCalled();
+    expect(harness.clusters.setSshHost).toHaveBeenCalledWith('imported', 'jump-host');
     expect(fs.readFileSync(target, 'utf8')).toContain('name: imported');
+  });
+
+  it('writes a proxy URL into clusters imported from pasted kubeconfig YAML', async () => {
+    const target = tempKubeconfig(kubeconfig('base'));
+    const incoming = kubeconfig('proxied').replaceAll('cluster-a', 'cluster-proxied').replaceAll('user-a', 'user-proxied');
+    const harness = createHarness();
+    harness.clusters.primaryKubeconfigPath.mockReturnValue(target);
+    const app = await buildApp(harness);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/settings/kubeconfig/import',
+      payload: { yaml: incoming, proxyUrl: 'socks5h://proxy.example.test:1080' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(fs.readFileSync(target, 'utf8')).toContain('proxy-url: socks5h://proxy.example.test:1080');
+    expect(harness.clusters.setSshHost).not.toHaveBeenCalled();
   });
 
   it('rejects imports with invalid bodies, unresolved targets, and conflicts', async () => {
@@ -513,6 +532,15 @@ describe('settings routes', () => {
       payload: { yaml: kubeconfig('same').replace('token: token', 'token: different') },
     });
     expect(conflict.statusCode).toBe(409);
+    expect(
+      (
+        await app.inject({
+          method: 'POST',
+          url: '/api/settings/kubeconfig/import',
+          payload: { yaml: kubeconfig('new'), sshHost: 'jump', proxyUrl: 'socks5://proxy:1080' },
+        })
+      ).statusCode,
+    ).toBe(400);
   });
 });
 

--- a/tests/unit/server/tunnel-manager.test.ts
+++ b/tests/unit/server/tunnel-manager.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SshTunnelManager } from '../../../server/src/ssh/tunnel-manager';
+
+interface TunnelManagerInternals {
+  mapping: Record<string, string>;
+  tunnels: Map<string, unknown>;
+  settings: { save: ReturnType<typeof vi.fn> };
+}
+
+function managerWith(mapping: Record<string, string>) {
+  const save = vi.fn();
+  const manager = Object.create(SshTunnelManager.prototype) as SshTunnelManager;
+  Object.assign(manager, { mapping: { ...mapping }, tunnels: new Map(), settings: { save } });
+  return { manager, save, internals: manager as unknown as TunnelManagerInternals };
+}
+
+describe('SshTunnelManager context mapping', () => {
+  it('moves a mapping to a context new key and persists it once', () => {
+    const { manager, save, internals } = managerWith({ old: 'jump' });
+
+    manager.rekeyContext('old', 'new');
+
+    expect(internals.mapping).toEqual({ new: 'jump' });
+    expect(save).toHaveBeenCalledWith({ sshTunnels: { new: 'jump' } });
+  });
+
+  it('keeps an explicit destination mapping while removing the stale source key', () => {
+    const { manager, internals } = managerWith({ old: 'old-jump', new: 'new-jump' });
+
+    manager.rekeyContext('old', 'new');
+
+    expect(internals.mapping).toEqual({ new: 'new-jump' });
+  });
+});

--- a/tests/unit/server/tunnel-manager.test.ts
+++ b/tests/unit/server/tunnel-manager.test.ts
@@ -15,6 +15,16 @@ function managerWith(mapping: Record<string, string>) {
 }
 
 describe('SshTunnelManager context mapping', () => {
+  it('stores different hosts independently for different context keys', () => {
+    const { manager } = managerWith({});
+
+    manager.setHostForContextKey('context-a', 'jump-a');
+    manager.setHostForContextKey('context-b', 'jump-b');
+
+    expect(manager.hostForContextKey('context-a')).toBe('jump-a');
+    expect(manager.hostForContextKey('context-b')).toBe('jump-b');
+  });
+
   it('moves a mapping to a context new key and persists it once', () => {
     const { manager, save, internals } = managerWith({ old: 'jump' });
 


### PR DESCRIPTION
## Summary

- expose SOCKS/HTTP proxy selection for pasted kubeconfigs
- apply SSH jump or proxy settings as part of the import operation
- preserve context-scoped SSH jump mappings when a reload changes which kubeconfig file supplies a context
- keep distinct jump hosts isolated for contexts sharing the same cluster entry
- document the connection options and add regression coverage for multi-file and multi-jump scenarios

## Root cause

Kubus stores managed SSH jump metadata outside the kubeconfig, keyed by kubeconfig source path and context name. An import into the primary file of a multi-file `KUBECONFIG` could change the file supplying an existing context. Reload then looked up the context with a new key, leaving its previous SSH jump mapping behind and making the context appear direct.

The pasted-config flow also attached SSH metadata in a second client request and did not expose the existing proxy option.

## Impact

Existing SSH jump settings now follow the same logical context across imports and reloads when its API server is unchanged. Pasted kubeconfigs can select a managed SSH jump or an existing SOCKS/HTTP proxy. Multiple contexts retain independent jump mappings, including when they share a kubeconfig cluster entry.

## Validation

- `pnpm test` — 874 tests passed
- `pnpm lint`
- shared, client, and server production builds
- isolated Playwright verification for pasted proxy imports, multi-file context moves, and multiple SSH jump mappings