### PR TITLE
Cluster-scoped favorites

### DIFF
--- a/client/src/favorite-scope.ts
+++ b/client/src/favorite-scope.ts
@@ -1,9 +1,11 @@
 import type { FavoriteItem, ResourceKindInfo } from '@kubus/shared';
+import { preferredKind } from './kind-versions.js';
+import { kindListPath } from './resource-links.js';
 
 /**
  * Which clusters a favorite belongs to. Two rules decide it:
  *
- * - an explicit scope (set from the favorite's context menu) always wins;
+ * - an explicit scope (set from the favorite's menu) always wins;
  * - otherwise relevance is inferred — a kind favorite only makes sense while a
  *   connected cluster serves that kind, and a favorited object only while its
  *   own context is connected.
@@ -31,28 +33,32 @@ export function favoriteContext(fav: FavoriteItem): string | undefined {
   return fav.ref?.ctx;
 }
 
-/** Group/plural of a `kind:<group>/<version>/<plural>` favorite. */
-function favoriteKind(fav: FavoriteItem): { group: string; plural: string } | undefined {
+/** GVR of a `kind:<group>/<version>/<plural>` favorite. */
+function favoriteKind(fav: FavoriteItem): { group: string; version: string; plural: string } | undefined {
   if (!fav.id.startsWith('kind:')) return undefined;
   const [group, version, plural] = fav.id.slice('kind:'.length).split('/');
   if (group === undefined || !version || !plural) return undefined;
-  return { group, plural };
+  return { group, version, plural };
 }
 
 /**
- * Contexts whose discovery we can trust. A context that has not answered yet,
- * or answered with an error, tells us nothing — treating it as empty would
- * blank the whole Favorites group while a cluster is unreachable.
+ * The kinds every connected cluster serves, or null while any of them is
+ * unknown. A context that has not answered yet, or answered with an error,
+ * tells us nothing — concluding "no cluster serves this" from a partial
+ * picture would hide favorites that belong to the cluster we cannot see.
  */
-function discoveredContexts({ selected, byContext, errors }: FavoriteScopeContext): Array<ResourceKindInfo[]> {
-  return selected.filter((ctx) => !errors?.[ctx] && byContext?.[ctx]).map((ctx) => byContext![ctx]!);
+function discoveredKinds({ selected, byContext, errors }: FavoriteScopeContext): ResourceKindInfo[] | null {
+  const known = selected.filter((ctx) => !errors?.[ctx] && byContext?.[ctx]);
+  if (known.length !== selected.length) return null;
+  return known.flatMap((ctx) => byContext![ctx]!);
 }
 
 /**
  * Whether a favorite belongs in the sidebar for the connected clusters.
  * With nothing connected there is no cluster to judge against, so everything
  * stays listed. Version is ignored when matching kinds so a CRD bumping
- * v1alpha1 → v1 does not silently drop the favorite.
+ * v1alpha1 → v1 does not silently drop the favorite; `resolveFavorites` then
+ * repoints its link at the served version.
  */
 export function isFavoriteVisible(fav: FavoriteItem, scope: FavoriteScopeContext): boolean {
   if (scope.selected.length === 0) return true;
@@ -65,12 +71,28 @@ export function isFavoriteVisible(fav: FavoriteItem, scope: FavoriteScopeContext
 
   const kind = favoriteKind(fav);
   if (!kind) return true;
-  const discovered = discoveredContexts(scope);
-  if (!discovered.length) return true;
-  return discovered.some((resources) => resources.some((r) => r.group === kind.group && r.plural === kind.plural));
+  const discovered = discoveredKinds(scope);
+  if (!discovered) return true;
+  return discovered.some((r) => r.group === kind.group && r.plural === kind.plural);
 }
 
-/** The favorites to list for the connected clusters, in stored order. */
-export function visibleFavorites(favorites: FavoriteItem[], scope: FavoriteScopeContext): FavoriteItem[] {
-  return favorites.filter((fav) => isFavoriteVisible(fav, scope));
+/**
+ * The favorites to list for the connected clusters, in stored order, each with
+ * its link pointing at a version the clusters actually serve. Kind favorites
+ * store the version they were starred at, and the list page queries whatever
+ * the path names, so a favorite kept across a CRD version bump has to be
+ * repointed or it opens a version that no longer exists.
+ */
+export function resolveFavorites(favorites: FavoriteItem[], scope: FavoriteScopeContext): FavoriteItem[] {
+  const discovered = discoveredKinds(scope);
+  return favorites
+    .filter((fav) => isFavoriteVisible(fav, scope))
+    .map((fav) => {
+      if (!discovered || !fav.path) return fav;
+      const kind = favoriteKind(fav);
+      if (!kind) return fav;
+      if (discovered.some((r) => r.group === kind.group && r.version === kind.version && r.plural === kind.plural)) return fav;
+      const served = preferredKind(kind.group, kind.plural, discovered);
+      return served ? { ...fav, path: kindListPath(served) } : fav;
+    });
 }

--- a/client/src/favorite-scope.ts
+++ b/client/src/favorite-scope.ts
@@ -1,0 +1,76 @@
+import type { FavoriteItem, ResourceKindInfo } from '@kubus/shared';
+
+/**
+ * Which clusters a favorite belongs to. Two rules decide it:
+ *
+ * - an explicit scope (set from the favorite's context menu) always wins;
+ * - otherwise relevance is inferred — a kind favorite only makes sense while a
+ *   connected cluster serves that kind, and a favorited object only while its
+ *   own context is connected.
+ *
+ * Inference is what keeps one cluster's CRDs out of another's sidebar without
+ * any setup; the explicit scope covers what discovery cannot tell (a builtin
+ * kind or a page you only care about on one cluster).
+ */
+export interface FavoriteScopeContext {
+  /** Contexts currently connected. */
+  selected: string[];
+  /** Discovered kinds per context; a context missing here has not reported yet. */
+  byContext?: Record<string, ResourceKindInfo[]>;
+  /** Contexts whose discovery failed — unknown, rather than "serves nothing". */
+  errors?: Record<string, string>;
+}
+
+/** Contexts a favorite is explicitly pinned to; empty means all clusters. */
+export function favoriteScopes(fav: FavoriteItem): string[] {
+  return fav.scopes ?? [];
+}
+
+/** The context a favorited object lives in, for favorites that point at one. */
+export function favoriteContext(fav: FavoriteItem): string | undefined {
+  return fav.ref?.ctx;
+}
+
+/** Group/plural of a `kind:<group>/<version>/<plural>` favorite. */
+function favoriteKind(fav: FavoriteItem): { group: string; plural: string } | undefined {
+  if (!fav.id.startsWith('kind:')) return undefined;
+  const [group, version, plural] = fav.id.slice('kind:'.length).split('/');
+  if (group === undefined || !version || !plural) return undefined;
+  return { group, plural };
+}
+
+/**
+ * Contexts whose discovery we can trust. A context that has not answered yet,
+ * or answered with an error, tells us nothing — treating it as empty would
+ * blank the whole Favorites group while a cluster is unreachable.
+ */
+function discoveredContexts({ selected, byContext, errors }: FavoriteScopeContext): Array<ResourceKindInfo[]> {
+  return selected.filter((ctx) => !errors?.[ctx] && byContext?.[ctx]).map((ctx) => byContext![ctx]!);
+}
+
+/**
+ * Whether a favorite belongs in the sidebar for the connected clusters.
+ * With nothing connected there is no cluster to judge against, so everything
+ * stays listed. Version is ignored when matching kinds so a CRD bumping
+ * v1alpha1 → v1 does not silently drop the favorite.
+ */
+export function isFavoriteVisible(fav: FavoriteItem, scope: FavoriteScopeContext): boolean {
+  if (scope.selected.length === 0) return true;
+
+  const scopes = favoriteScopes(fav);
+  if (scopes.length) return scopes.some((ctx) => scope.selected.includes(ctx));
+
+  const ctx = favoriteContext(fav);
+  if (ctx) return scope.selected.includes(ctx);
+
+  const kind = favoriteKind(fav);
+  if (!kind) return true;
+  const discovered = discoveredContexts(scope);
+  if (!discovered.length) return true;
+  return discovered.some((resources) => resources.some((r) => r.group === kind.group && r.plural === kind.plural));
+}
+
+/** The favorites to list for the connected clusters, in stored order. */
+export function visibleFavorites(favorites: FavoriteItem[], scope: FavoriteScopeContext): FavoriteItem[] {
+  return favorites.filter((fav) => isFavoriteVisible(fav, scope));
+}

--- a/client/src/kind-versions.ts
+++ b/client/src/kind-versions.ts
@@ -1,0 +1,30 @@
+import type { ResourceKindInfo } from '@kubus/shared';
+
+const VERSION_RE = /^v(\d+)(?:(alpha|beta)(\d+))?$/;
+
+function versionScore(version: string): [number, number, number] {
+  const match = VERSION_RE.exec(version);
+  if (!match) return [0, 0, 0];
+  const stability = match[2] === 'alpha' ? 1 : match[2] === 'beta' ? 2 : 3;
+  return [stability, Number(match[1]), Number(match[3] ?? 0)];
+}
+
+/** The more current of two versions of one kind: stable over beta over alpha, then newest. */
+export function preferVersion(candidate: ResourceKindInfo, current: ResourceKindInfo): ResourceKindInfo {
+  const a = versionScore(candidate.version);
+  const b = versionScore(current.version);
+  if (a[0] !== b[0]) return a[0] > b[0] ? candidate : current;
+  if (a[1] !== b[1]) return a[1] > b[1] ? candidate : current;
+  if (a[2] !== b[2]) return a[2] > b[2] ? candidate : current;
+  return candidate.version.localeCompare(current.version) > 0 ? candidate : current;
+}
+
+/** The version of `group/plural` worth linking to among the discovered kinds. */
+export function preferredKind(group: string, plural: string, kinds: ResourceKindInfo[]): ResourceKindInfo | undefined {
+  let best: ResourceKindInfo | undefined;
+  for (const kind of kinds) {
+    if (kind.group !== group || kind.plural !== plural) continue;
+    best = best ? preferVersion(kind, best) : kind;
+  }
+  return best;
+}

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useSta
 import { layout } from '../theme.js';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
+import Divider from '@mui/material/Divider';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -10,6 +11,8 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -30,9 +33,12 @@ import GppMaybeOutlinedIcon from '@mui/icons-material/GppMaybeOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import CheckIcon from '@mui/icons-material/Check';
+import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 import { BUILTIN_NAV_GROUPS, groupToPath, gvkForResource, gvkLabel, pluralLabel, type FavoriteItem, type ResourceKindInfo, type SavedView } from '@kubus/shared';
-import { useApiResourcesForContexts } from '../api/queries.js';
+import { useApiResourcesForContexts, useContexts } from '../api/queries.js';
+import { favoriteContext, favoriteScopes, visibleFavorites } from '../favorite-scope.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
@@ -110,10 +116,14 @@ function favoriteGvk(favorite: FavoriteItem, resources: ResourceKindInfo[]): str
   return resource ? gvkLabel(resource) : favorite.subtitle;
 }
 
-// Star toggle revealed on row hover; filled vs outlined shows favorite state.
-function FavStar({ active, onToggle, label }: { active: boolean; onToggle: () => void; label: string }) {
+/**
+ * Star toggle revealed on row hover; filled vs outlined shows favorite state.
+ * Inside the Favorites group the star opens the favorite's menu instead —
+ * removing is one of the things you can do to a favorite, not the only one.
+ */
+function FavStar({ active, onToggle, onManage, label }: { active: boolean; onToggle: () => void; onManage?: (e: React.MouseEvent) => void; label: string }) {
   return (
-    <Tooltip title={active ? 'Remove favorite' : 'Add favorite'}>
+    <Tooltip title={onManage ? 'Remove or edit favorite' : active ? 'Remove favorite' : 'Add favorite'}>
       <IconButton
         aria-label={label}
         size="small"
@@ -121,7 +131,8 @@ function FavStar({ active, onToggle, label }: { active: boolean; onToggle: () =>
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          onToggle();
+          if (onManage) onManage(e);
+          else onToggle();
         }}
         sx={{
           opacity: 0,
@@ -220,6 +231,7 @@ function NavEntry({
   icon,
   favorite,
   favoriteAction,
+  onManageFavorite,
   hotkey,
   onIntent,
   indent,
@@ -230,6 +242,8 @@ function NavEntry({
   icon?: React.ReactElement;
   favorite?: FavoriteItem;
   favoriteAction?: ReactNode;
+  /** Set for rows in the Favorites group: the star opens the favorite's menu. */
+  onManageFavorite?: (e: React.MouseEvent) => void;
   /** Shortcut hint (e.g. ⌘1) shown at rest; hover swaps it for the row actions. */
   hotkey?: string;
   /** Fired on hover/focus — used to preload the target's heavy chunks. */
@@ -279,7 +293,8 @@ function NavEntry({
           {favoriteAction}
           <FavStar
             active={isFav}
-            label={`${isFav ? 'Remove' : 'Add'} favorite ${label}`}
+            onManage={onManageFavorite}
+            label={`${onManageFavorite ? 'Remove or edit' : isFav ? 'Remove' : 'Add'} favorite ${label}`}
             onToggle={() => (isFav ? removeFavorite(favorite.id) : addFavorite(favorite))}
           />
           {hotkey && (
@@ -374,7 +389,7 @@ function GroupHeader({
   icon?: React.ReactElement;
   open: boolean;
   onClick: () => void;
-  favorite?: { active: boolean; onToggle: () => void };
+  favorite?: { active: boolean; onToggle: () => void; onManage?: (e: React.MouseEvent) => void };
   favoriteAction?: ReactNode;
 }) {
   return (
@@ -388,7 +403,8 @@ function GroupHeader({
               <FavStar
                 active={favorite.active}
                 onToggle={favorite.onToggle}
-                label={`${favorite.active ? 'Remove' : 'Add'} favorite category ${title}`}
+                onManage={favorite.onManage}
+                label={`${favorite.onManage ? 'Remove or edit' : favorite.active ? 'Remove' : 'Add'} favorite category ${title}`}
               />
             )}
           </Box>
@@ -596,6 +612,149 @@ function FavoriteDragShell({
   );
 }
 
+type ScopeMenuState = { favorite: FavoriteItem; position: { top: number; left: number } };
+
+const SCOPE_ROW_SX = { mx: 0.75, borderRadius: 1.5, minHeight: 34, px: 1 } as const;
+
+/** Uppercase section label separating the menu's two halves. */
+function ScopeSectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <Typography
+      variant="caption"
+      sx={{ display: 'block', px: 1.75, pt: 0.75, pb: 0.5, color: 'text.disabled', fontSize: 10, fontWeight: 700, letterSpacing: '0.07em', textTransform: 'uppercase' }}
+    >
+      {children}
+    </Typography>
+  );
+}
+
+/** Connection dot in a fixed slot so every row's label lines up. */
+function ScopeRowIcon({ children, connected }: { children?: ReactNode; connected?: boolean }) {
+  return (
+    <Box sx={{ width: 18, mr: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, color: 'text.secondary' }}>
+      {children ?? <Box sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: connected ? 'success.main' : 'action.disabled' }} />}
+    </Box>
+  );
+}
+
+/**
+ * The menu behind a favorite's star (and its right-click): which clusters the
+ * favorite belongs to, and removing it. Unscoped favorites stay listed
+ * everywhere they are relevant; scoping one to a context keeps it out of every
+ * other cluster's sidebar for good.
+ */
+function FavoriteScopeMenu({
+  state,
+  contexts,
+  connected,
+  subtitle,
+  onClose,
+}: {
+  state: ScopeMenuState | null;
+  contexts: string[];
+  connected: string[];
+  /** GVK line for the header, resolved by the caller from discovery. */
+  subtitle?: string;
+  onClose: () => void;
+}) {
+  const id = state?.favorite.id;
+  // Read scopes from the store, not the captured item, so the ticks follow
+  // along while the menu stays open for several toggles. The selector returns
+  // the stored item itself — a derived array would be a new snapshot on every
+  // render and re-subscribe forever.
+  const stored = useNavigationStore((s) => (id ? s.favorites.find((f) => f.id === id) : undefined));
+  const scopes = stored?.scopes ?? [];
+  const setFavoriteScopes = useNavigationStore((s) => s.setFavoriteScopes);
+  const removeFavorite = useNavigationStore((s) => s.removeFavorite);
+  const contextSettings = useClustersStore((s) => s.contextSettings);
+  const pinnedContext = state ? favoriteContext(state.favorite) : undefined;
+  // Offer every known context, plus any the favorite still points at after it
+  // vanished from the kubeconfig, so a stale scope can be cleared.
+  const options = [...contexts, ...scopes.filter((ctx) => !contexts.includes(ctx))];
+  const toggle = (ctx: string) => setFavoriteScopes(id!, scopes.includes(ctx) ? scopes.filter((name) => name !== ctx) : [...scopes, ctx]);
+  const tick = <CheckIcon sx={{ fontSize: 16, ml: 1, color: 'primary.main', flexShrink: 0 }} />;
+  return (
+    <Menu
+      open={!!state}
+      onClose={onClose}
+      anchorReference="anchorPosition"
+      anchorPosition={state?.position}
+      slotProps={{ list: { dense: true, sx: { py: 0.5, width: 262 } }, paper: { sx: { maxHeight: 440 } } }}
+    >
+      <Box sx={{ px: 1.75, pt: 0.5, pb: 0.75 }}>
+        <Typography variant="body2" noWrap sx={{ fontWeight: 600 }}>
+          {state?.favorite.title ?? ''}
+        </Typography>
+        {subtitle && (
+          <Typography variant="caption" noWrap sx={{ display: 'block', color: 'text.secondary' }}>
+            {subtitle}
+          </Typography>
+        )}
+      </Box>
+      <Divider />
+      <ScopeSectionLabel>{pinnedContext ? 'Cluster' : 'Show in'}</ScopeSectionLabel>
+      {pinnedContext ? (
+        <Box sx={{ px: 1.75, pb: 1 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <ScopeRowIcon connected={connected.includes(pinnedContext)} />
+            <Typography variant="body2" noWrap>
+              {pinnedContext}
+            </Typography>
+          </Box>
+          <Typography variant="caption" sx={{ display: 'block', mt: 0.5, color: 'text.secondary' }}>
+            This object lives in one cluster, so it is listed only while that cluster is connected.
+          </Typography>
+        </Box>
+      ) : (
+        [
+          <MenuItem
+            key="all"
+            selected={scopes.length === 0}
+            sx={SCOPE_ROW_SX}
+            onClick={() => {
+              setFavoriteScopes(id!, []);
+              onClose();
+            }}
+          >
+            <ScopeRowIcon>
+              <PublicOutlinedIcon sx={{ fontSize: 16 }} />
+            </ScopeRowIcon>
+            <ListItemText primary="All clusters" slotProps={{ primary: { variant: 'body2', noWrap: true } }} />
+            {scopes.length === 0 && tick}
+          </MenuItem>,
+          ...options.map((ctx) => (
+            <MenuItem key={ctx} selected={scopes.includes(ctx)} sx={SCOPE_ROW_SX} onClick={() => toggle(ctx)}>
+              <ScopeRowIcon connected={connected.includes(ctx)} />
+              {contextSettings[ctx]?.icon && (
+                <Box component="span" sx={{ mr: 0.75, fontSize: 13 }}>
+                  {contextSettings[ctx]?.icon}
+                </Box>
+              )}
+              <ListItemText primary={ctx} slotProps={{ primary: { variant: 'body2', noWrap: true } }} />
+              {scopes.includes(ctx) && tick}
+            </MenuItem>
+          )),
+        ]
+      )}
+      <Divider sx={{ my: 0.5 }} />
+      {/* Removing a favorite is undone with one click of the star, so it only
+          turns destructive-red under the pointer. */}
+      <MenuItem
+        sx={{ ...SCOPE_ROW_SX, '&:hover': { color: 'error.main', '& svg': { color: 'error.main' } } }}
+        onClick={() => {
+          removeFavorite(id!);
+          onClose();
+        }}
+      >
+        <ScopeRowIcon>
+          <StarBorderIcon sx={{ fontSize: 16 }} />
+        </ScopeRowIcon>
+        <ListItemText primary="Remove favorite" slotProps={{ primary: { variant: 'body2' } }} />
+      </MenuItem>
+    </Menu>
+  );
+}
+
 interface NavDrawerProps {
   /** Render as a temporary overlay (narrow viewports) instead of a pinned rail. */
   overlay: boolean;
@@ -608,6 +767,9 @@ interface NavDrawerProps {
 export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClose }: NavDrawerProps) {
   const selected = useClustersStore((s) => s.selected);
   const { data: apiResources } = useApiResourcesForContexts(selected);
+  // Contexts offered by the scope menu; the picker keeps this query warm, so
+  // this observer only reads it.
+  const { data: contexts } = useContexts({ poll: false });
   const favorites = useNavigationStore((s) => s.favorites);
   const savedViews = useNavigationStore((s) => s.savedViews);
   const removeSavedView = useNavigationStore((s) => s.removeSavedView);
@@ -626,6 +788,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
   const [filter, setFilter] = useState('');
   const [draggingFavoriteId, setDraggingFavoriteId] = useState<string | null>(null);
   const [favoriteDropTarget, setFavoriteDropTarget] = useState<FavoriteDropTarget | null>(null);
+  const [scopeMenu, setScopeMenu] = useState<ScopeMenuState | null>(null);
   const deferredFilter = useDeferredValue(filter);
   const navigate = useNavigate();
 
@@ -637,6 +800,16 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
     // eslint-disable-next-line react-hooks/exhaustive-deps -- close on navigation only
   }, [currentPath]);
 
+  // Favorites scoped to other clusters — and kinds no connected cluster serves
+  // — drop out of the sidebar entirely, so everything below works off the
+  // visible list: ordering, hotkeys and the empty check alike.
+  const visibleFavs = useMemo(
+    () => visibleFavorites(favorites, { selected, byContext: apiResources?.byContext, errors: apiResources?.errors }),
+    [favorites, selected, apiResources],
+  );
+  const visibleFavsRef = useRef(visibleFavs);
+  visibleFavsRef.current = visibleFavs;
+
   // Cmd/Ctrl+1–9 jumps to the corresponding favorite. Digits come from
   // e.code so the physical number row works on any keyboard layout. Note the
   // browser may reserve Ctrl/Cmd+1–8 for its own tab switching; the desktop
@@ -646,7 +819,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
       if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
       const digit = /^Digit([1-9])$/.exec(e.code)?.[1];
       if (!digit) return;
-      const fav = hotkeyFavorites(useNavigationStore.getState().favorites)[Number(digit) - 1];
+      const fav = hotkeyFavorites(visibleFavsRef.current)[Number(digit) - 1];
       if (!fav?.path) return;
       e.preventDefault();
       void navigate(fav.path);
@@ -657,9 +830,9 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
 
   const hotkeyByFavorite = useMemo(() => {
     const map = new Map<string, string>();
-    hotkeyFavorites(favorites).forEach((fav, i) => map.set(fav.id, `${HOTKEY_MOD_LABEL}${i + 1}`));
+    hotkeyFavorites(visibleFavs).forEach((fav, i) => map.set(fav.id, `${HOTKEY_MOD_LABEL}${i + 1}`));
     return map;
-  }, [favorites]);
+  }, [visibleFavs]);
 
   const toggleGroup = (title: string) =>
     setCollapsed((prev) => {
@@ -808,7 +981,12 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
   // While filtering, always expand so matches are visible. CRD API groups are
   // discovered dynamically, so they use the set as an explicit open override.
   const isOpen = (title: string) => !!f || (title.startsWith(CUSTOM_GROUP_PREFIX) ? collapsed.has(title) : !collapsed.has(title));
-  const canReorderFavorites = favorites.length > 1 && !f;
+  const canReorderFavorites = visibleFavs.length > 1 && !f;
+  const openScopeMenu = (fav: FavoriteItem, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setScopeMenu({ favorite: fav, position: { top: e.clientY, left: e.clientX } });
+  };
   const clearFavoriteDrag = () => {
     setDraggingFavoriteId(null);
     setFavoriteDropTarget(null);
@@ -918,11 +1096,15 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
         <NavEntry to="/helm" label="Helm Releases" icon={<SailingOutlinedIcon />} />
         <NavEntry to="/forwards" label="Port Forwards" icon={<CableOutlinedIcon />} />
         <NavEntry to="/diff" label="Diff" icon={<DifferenceOutlinedIcon />} />
-        {favorites.length > 0 && (
+        {visibleFavs.length > 0 && (
           <Box>
             <GroupHeader title="Favorites" icon={<StarIcon />} open={isOpen('Favorites')} onClick={() => toggleGroup('Favorites')} />
             <Collapse in={isOpen('Favorites')}>
-              {favorites.map((fav) => {
+              {visibleFavs.map((fav) => {
+                // The star opens this favorite's menu; right-click anywhere on
+                // the row is the shortcut to the same thing.
+                const scopeHandlers = { onContextMenu: (e: React.MouseEvent) => openScopeMenu(fav, e) };
+                const manageFavorite = (e: React.MouseEvent) => openScopeMenu(fav, e);
                 if (fav.id.startsWith('category:')) {
                   const all = categoryKindsMap.get(fav.title) ?? [];
                   const titleMatch = matches(fav.title);
@@ -930,7 +1112,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                   if (f && !titleMatch && kinds.length === 0) return null;
                   const key = `fav:${fav.title}`;
                   return (
-                    <Box key={fav.id}>
+                    <Box key={fav.id} {...scopeHandlers}>
                       {favoriteDragShell(
                         fav,
                         <GroupHeader
@@ -938,7 +1120,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                           icon={GROUP_ICONS[fav.title] ?? <ExtensionOutlinedIcon />}
                           open={isOpen(key)}
                           onClick={() => toggleGroup(key)}
-                          favorite={{ active: true, onToggle: () => removeFavorite(fav.id) }}
+                          favorite={{ active: true, onToggle: () => removeFavorite(fav.id), onManage: manageFavorite }}
                           favoriteAction={favoriteDragHandle(fav)}
                         />,
                       )}
@@ -950,10 +1132,14 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                     </Box>
                   );
                 }
-                const subtitle = favoriteGvk(fav, apiResources?.resources ?? []);
-                if (!matches(fav.title) && !(subtitle && matches(subtitle))) return null;
+                const gvk = favoriteGvk(fav, apiResources?.resources ?? []);
+                if (!matches(fav.title) && !(gvk && matches(gvk))) return null;
+                // A scoped favorite names its clusters on the subtitle line —
+                // the only hint that it is missing from the other sidebars.
+                const scopes = favoriteScopes(fav);
+                const subtitle = [gvk, ...(scopes.length ? [scopes.join(', ')] : [])].filter(Boolean).join(' · ') || undefined;
                 return (
-                  <Box key={fav.id}>
+                  <Box key={fav.id} {...scopeHandlers}>
                     {favoriteDragShell(
                       fav,
                       <NavEntry
@@ -962,6 +1148,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                         subtitle={subtitle}
                         favorite={fav}
                         favoriteAction={favoriteDragHandle(fav)}
+                        onManageFavorite={manageFavorite}
                         hotkey={hotkeyByFavorite.get(fav.id)}
                       />,
                     )}
@@ -1097,6 +1284,13 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
           </>
         )}
       </List>
+      <FavoriteScopeMenu
+        state={scopeMenu}
+        contexts={(contexts ?? []).map((c) => c.name)}
+        connected={selected}
+        subtitle={scopeMenu ? favoriteGvk(scopeMenu.favorite, apiResources?.resources ?? []) : undefined}
+        onClose={() => setScopeMenu(null)}
+      />
     </Drawer>
   );
 });

--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -38,7 +38,8 @@ import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 import { BUILTIN_NAV_GROUPS, groupToPath, gvkForResource, gvkLabel, pluralLabel, type FavoriteItem, type ResourceKindInfo, type SavedView } from '@kubus/shared';
 import { useApiResourcesForContexts, useContexts } from '../api/queries.js';
-import { favoriteContext, favoriteScopes, visibleFavorites } from '../favorite-scope.js';
+import { favoriteContext, favoriteScopes, resolveFavorites } from '../favorite-scope.js';
+import { preferVersion, preferredKind } from '../kind-versions.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
@@ -106,12 +107,17 @@ function kindFavorite(k: NavKind): FavoriteItem {
   };
 }
 
-/** Resolve old persisted kind favorites to a full GVK once discovery is available. */
+/**
+ * Resolve old persisted kind favorites to a full GVK once discovery is
+ * available. A favorite whose stored version is gone falls back to the served
+ * one, matching the link `resolveFavorites` repoints it at.
+ */
 function favoriteGvk(favorite: FavoriteItem, resources: ResourceKindInfo[]): string | undefined {
   if (!favorite.id.startsWith('kind:')) return favorite.subtitle;
   const [group, version, plural] = favorite.id.slice('kind:'.length).split('/');
   if (group === undefined || !version || !plural) return favorite.subtitle;
-  const discovered = resources.find((r) => r.group === group && r.version === version && r.plural === plural);
+  const discovered =
+    resources.find((r) => r.group === group && r.version === version && r.plural === plural) ?? preferredKind(group, plural, resources);
   const resource = discovered ?? gvkForResource(group, version, plural);
   return resource ? gvkLabel(resource) : favorite.subtitle;
 }
@@ -151,24 +157,6 @@ function FavStar({ active, onToggle, onManage, label }: { active: boolean; onTog
 // The topology impl chunk (@xyflow/react + elkjs) is heavy; warm it when the
 // user shows intent instead of unconditionally at idle for every session.
 const preloadTopology = () => void import('../components/TopologyGraphImpl.js');
-
-const VERSION_RE = /^v(\d+)(?:(alpha|beta)(\d+))?$/;
-
-function versionScore(version: string): [number, number, number] {
-  const match = VERSION_RE.exec(version);
-  if (!match) return [0, 0, 0];
-  const stability = match[2] === 'alpha' ? 1 : match[2] === 'beta' ? 2 : 3;
-  return [stability, Number(match[1]), Number(match[3] ?? 0)];
-}
-
-function preferVersion(candidate: ResourceKindInfo, current: ResourceKindInfo): ResourceKindInfo {
-  const a = versionScore(candidate.version);
-  const b = versionScore(current.version);
-  if (a[0] !== b[0]) return a[0] > b[0] ? candidate : current;
-  if (a[1] !== b[1]) return a[1] > b[1] ? candidate : current;
-  if (a[2] !== b[2]) return a[2] > b[2] ? candidate : current;
-  return candidate.version.localeCompare(current.version) > 0 ? candidate : current;
-}
 
 function dedupeCustomNavKinds(kinds: ResourceKindInfo[]): ResourceKindInfo[] {
   const byKind = new Map<string, ResourceKindInfo>();
@@ -802,9 +790,9 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
 
   // Favorites scoped to other clusters — and kinds no connected cluster serves
   // — drop out of the sidebar entirely, so everything below works off the
-  // visible list: ordering, hotkeys and the empty check alike.
+  // resolved list: ordering, hotkeys and the empty check alike.
   const visibleFavs = useMemo(
-    () => visibleFavorites(favorites, { selected, byContext: apiResources?.byContext, errors: apiResources?.errors }),
+    () => resolveFavorites(favorites, { selected, byContext: apiResources?.byContext, errors: apiResources?.errors }),
     [favorites, selected, apiResources],
   );
   const visibleFavsRef = useRef(visibleFavs);

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -19,7 +19,8 @@ import KeyboardCommandKeyIcon from '@mui/icons-material/KeyboardCommandKey';
 import type { FavoriteItem, ResourceRef, SearchResult, SearchResultKind } from '@kubus/shared';
 import { useNavigate } from 'react-router';
 import { detailPathForRef } from '../resource-links.js';
-import { useGlobalSearch } from '../api/queries.js';
+import { useApiResourcesForContexts, useGlobalSearch } from '../api/queries.js';
+import { visibleFavorites } from '../favorite-scope.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useDockStore } from '../state/dock.js';
@@ -98,7 +99,14 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
   const commandMode = query.startsWith('>');
   const searchQuery = stage || commandMode ? '' : query;
   const { data: results, isFetching } = useGlobalSearch(selected, searchQuery);
-  const favorites = useNavigationStore((s) => s.favorites);
+  const { data: apiResources } = useApiResourcesForContexts(selected);
+  const storedFavorites = useNavigationStore((s) => s.favorites);
+  // The empty palette lists favorites, so it follows the same cluster scoping
+  // as the sidebar — otherwise another cluster's CRDs come back here.
+  const favorites = useMemo(
+    () => visibleFavorites(storedFavorites, { selected, byContext: apiResources?.byContext, errors: apiResources?.errors }),
+    [storedFavorites, selected, apiResources],
+  );
   const addFavorite = useNavigationStore((s) => s.addFavorite);
   const removeFavorite = useNavigationStore((s) => s.removeFavorite);
   const isFavorite = useNavigationStore((s) => s.isFavorite);

--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -20,7 +20,7 @@ import type { FavoriteItem, ResourceRef, SearchResult, SearchResultKind } from '
 import { useNavigate } from 'react-router';
 import { detailPathForRef } from '../resource-links.js';
 import { useApiResourcesForContexts, useGlobalSearch } from '../api/queries.js';
-import { visibleFavorites } from '../favorite-scope.js';
+import { resolveFavorites } from '../favorite-scope.js';
 import { useClustersStore } from '../state/clusters.js';
 import { useNavigationStore } from '../state/navigation.js';
 import { useDockStore } from '../state/dock.js';
@@ -104,7 +104,7 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
   // The empty palette lists favorites, so it follows the same cluster scoping
   // as the sidebar — otherwise another cluster's CRDs come back here.
   const favorites = useMemo(
-    () => visibleFavorites(storedFavorites, { selected, byContext: apiResources?.byContext, errors: apiResources?.errors }),
+    () => resolveFavorites(storedFavorites, { selected, byContext: apiResources?.byContext, errors: apiResources?.errors }),
     [storedFavorites, selected, apiResources],
   );
   const addFavorite = useNavigationStore((s) => s.addFavorite);

--- a/client/src/state/navigation.ts
+++ b/client/src/state/navigation.ts
@@ -9,6 +9,8 @@ interface NavigationState {
   addFavorite: (item: FavoriteItem) => void;
   removeFavorite: (id: string) => void;
   moveFavorite: (id: string, targetId: string, position: 'before' | 'after') => void;
+  /** Restrict a favorite to the given contexts; an empty list means all clusters. */
+  setFavoriteScopes: (id: string, scopes: string[]) => void;
   isFavorite: (id: string) => boolean;
   addSavedView: (view: SavedView) => void;
   removeSavedView: (id: string) => void;
@@ -36,6 +38,10 @@ export const useNavigationStore = create<NavigationState>()(
           next.splice(position === 'after' ? targetIndex + 1 : targetIndex, 0, moving);
           return { favorites: next };
         }),
+      setFavoriteScopes: (id, scopes) =>
+        set((s) => ({
+          favorites: s.favorites.map((f) => (f.id === id ? { ...f, scopes: scopes.length ? [...new Set(scopes)] : undefined } : f)),
+        })),
       isFavorite: (id) => get().favorites.some((f) => f.id === id),
       addSavedView: (view) =>
         set((s) => ({

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -243,6 +243,13 @@ export interface FavoriteItem {
   subtitle?: string;
   path?: string;
   ref?: ResourceRef;
+  /**
+   * Contexts this favorite belongs to; unset or empty means every cluster.
+   * A scoped favorite is listed only while one of its contexts is connected,
+   * so cluster-specific entries (an operator's CRDs, a per-cluster page) stay
+   * out of the way everywhere else.
+   */
+  scopes?: string[];
 }
 
 /** Grid state snapshotted with a saved view so restoring brings back the exact table. */

--- a/tests/unit/client/favorite-scope.test.ts
+++ b/tests/unit/client/favorite-scope.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { FavoriteItem, ResourceKindInfo } from '@kubus/shared';
-import { favoriteScopes, isFavoriteVisible, visibleFavorites } from '../../../client/src/favorite-scope';
+import { favoriteScopes, isFavoriteVisible, resolveFavorites } from '../../../client/src/favorite-scope';
 
-const kind = (group: string, plural: string): ResourceKindInfo => ({
+const kind = (group: string, plural: string, version = 'v1'): ResourceKindInfo => ({
   group,
-  version: 'v1',
+  version,
   kind: plural,
   plural,
   namespaced: true,
@@ -22,7 +22,10 @@ const object: FavoriteItem = {
   ref: { ctx: 'eda', group: 'apps', version: 'v1', plural: 'deployments', kind: 'Deployment', name: 'api', namespace: 'default' },
 };
 
-const edaDiscovery = { eda: [kind('', 'pods'), kind('topo.eda.nokia.com', 'topolinks')], c9s: [kind('', 'pods')] };
+const edaDiscovery = {
+  eda: [kind('', 'pods'), kind('topo.eda.nokia.com', 'topolinks', 'v1alpha1')],
+  c9s: [kind('', 'pods')],
+};
 
 describe('favorite scoping', () => {
   it('reads the explicit scope list', () => {
@@ -54,6 +57,15 @@ describe('favorite scoping', () => {
     expect(isFavoriteVisible(topolinks, { selected: ['c9s'], byContext: { c9s: [] } })).toBe(false);
   });
 
+  it('keeps kinds listed when only some connected clusters reported', () => {
+    // c9s does not serve the CRD, but eda failed — it may well serve it.
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s', 'eda'], byContext: edaDiscovery, errors: { eda: 'unreachable' } })).toBe(true);
+    // Same with eda's discovery still in flight.
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s', 'eda'], byContext: { c9s: edaDiscovery.c9s } })).toBe(true);
+    // Both answered and neither serves it — now it can go.
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s', 'prod'], byContext: { c9s: [], prod: [] } })).toBe(false);
+  });
+
   it('ties a favorited object to its own context', () => {
     expect(isFavoriteVisible(object, { selected: ['eda'], byContext: edaDiscovery })).toBe(true);
     expect(isFavoriteVisible(object, { selected: ['c9s'], byContext: edaDiscovery })).toBe(false);
@@ -66,9 +78,28 @@ describe('favorite scoping', () => {
   });
 
   it('filters in stored order', () => {
-    expect(visibleFavorites([topolinks, pods, category], { selected: ['c9s'], byContext: edaDiscovery }).map((f) => f.id)).toEqual([
+    expect(resolveFavorites([topolinks, pods, category], { selected: ['c9s'], byContext: edaDiscovery }).map((f) => f.id)).toEqual([
       pods.id,
       category.id,
+    ]);
+  });
+
+  it('repoints a kind favorite at the served version', () => {
+    // The CRD moved v1alpha1 → v1: the favorite survives, but its link has to
+    // follow, since the list page queries whatever version the path names.
+    const upgraded = { eda: [kind('topo.eda.nokia.com', 'topolinks', 'v1'), kind('topo.eda.nokia.com', 'topolinks', 'v1beta1')] };
+    const [resolved] = resolveFavorites([topolinks], { selected: ['eda'], byContext: upgraded });
+    expect(resolved?.path).toBe('/r/topo.eda.nokia.com/v1/topolinks');
+    expect(resolved?.id).toBe(topolinks.id);
+  });
+
+  it('leaves links alone when the stored version is still served or unknown', () => {
+    expect(resolveFavorites([topolinks], { selected: ['eda'], byContext: edaDiscovery })[0]?.path).toBe(topolinks.path);
+    expect(resolveFavorites([topolinks], { selected: ['eda'] })[0]?.path).toBe(topolinks.path);
+    expect(resolveFavorites([pods, category, object], { selected: ['eda'], byContext: edaDiscovery }).map((f) => f.path)).toEqual([
+      pods.path,
+      category.path,
+      object.path,
     ]);
   });
 });

--- a/tests/unit/client/favorite-scope.test.ts
+++ b/tests/unit/client/favorite-scope.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { FavoriteItem, ResourceKindInfo } from '@kubus/shared';
+import { favoriteScopes, isFavoriteVisible, visibleFavorites } from '../../../client/src/favorite-scope';
+
+const kind = (group: string, plural: string): ResourceKindInfo => ({
+  group,
+  version: 'v1',
+  kind: plural,
+  plural,
+  namespaced: true,
+  verbs: ['list'],
+});
+
+const pods: FavoriteItem = { id: 'kind:/v1/pods', title: 'Pods', path: '/r/core/v1/pods' };
+const topolinks: FavoriteItem = { id: 'kind:topo.eda.nokia.com/v1alpha1/topolinks', title: 'TopoLinks', path: '/r/topo.eda.nokia.com/v1alpha1/topolinks' };
+const category: FavoriteItem = { id: 'category:Workloads', title: 'Workloads' };
+const page: FavoriteItem = { id: 'page:/network', title: 'Network Metrics', path: '/network' };
+const object: FavoriteItem = {
+  id: 'resource:eda:apps/v1/deployments:default:api',
+  title: 'Deployment/api',
+  path: '/d/eda/apps/v1/deployments/default/api',
+  ref: { ctx: 'eda', group: 'apps', version: 'v1', plural: 'deployments', kind: 'Deployment', name: 'api', namespace: 'default' },
+};
+
+const edaDiscovery = { eda: [kind('', 'pods'), kind('topo.eda.nokia.com', 'topolinks')], c9s: [kind('', 'pods')] };
+
+describe('favorite scoping', () => {
+  it('reads the explicit scope list', () => {
+    expect(favoriteScopes(pods)).toEqual([]);
+    expect(favoriteScopes({ ...pods, scopes: ['eda'] })).toEqual(['eda']);
+  });
+
+  it('lists everything while no cluster is connected', () => {
+    expect(isFavoriteVisible({ ...topolinks, scopes: ['eda'] }, { selected: [] })).toBe(true);
+  });
+
+  it('honours an explicit scope over discovery', () => {
+    const scoped = { ...pods, scopes: ['eda'] };
+    expect(isFavoriteVisible(scoped, { selected: ['eda'], byContext: edaDiscovery })).toBe(true);
+    expect(isFavoriteVisible(scoped, { selected: ['c9s'], byContext: edaDiscovery })).toBe(false);
+    // Any connected context in the scope is enough with several selected.
+    expect(isFavoriteVisible(scoped, { selected: ['c9s', 'eda'], byContext: edaDiscovery })).toBe(true);
+  });
+
+  it('infers relevance for kinds from discovery, ignoring the version', () => {
+    expect(isFavoriteVisible(topolinks, { selected: ['eda'], byContext: edaDiscovery })).toBe(true);
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s'], byContext: edaDiscovery })).toBe(false);
+    expect(isFavoriteVisible(pods, { selected: ['c9s'], byContext: edaDiscovery })).toBe(true);
+  });
+
+  it('keeps kinds listed while discovery is missing or failed', () => {
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s'] })).toBe(true);
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s'], byContext: { c9s: [] }, errors: { c9s: 'unreachable' } })).toBe(true);
+    expect(isFavoriteVisible(topolinks, { selected: ['c9s'], byContext: { c9s: [] } })).toBe(false);
+  });
+
+  it('ties a favorited object to its own context', () => {
+    expect(isFavoriteVisible(object, { selected: ['eda'], byContext: edaDiscovery })).toBe(true);
+    expect(isFavoriteVisible(object, { selected: ['c9s'], byContext: edaDiscovery })).toBe(false);
+  });
+
+  it('leaves categories and pages alone unless scoped', () => {
+    expect(isFavoriteVisible(category, { selected: ['c9s'], byContext: edaDiscovery })).toBe(true);
+    expect(isFavoriteVisible(page, { selected: ['c9s'], byContext: edaDiscovery })).toBe(true);
+    expect(isFavoriteVisible({ ...page, scopes: ['eda'] }, { selected: ['c9s'], byContext: edaDiscovery })).toBe(false);
+  });
+
+  it('filters in stored order', () => {
+    expect(visibleFavorites([topolinks, pods, category], { selected: ['c9s'], byContext: edaDiscovery }).map((f) => f.id)).toEqual([
+      pods.id,
+      category.id,
+    ]);
+  });
+});

--- a/tests/unit/client/nav-drawer.test.tsx
+++ b/tests/unit/client/nav-drawer.test.tsx
@@ -8,12 +8,15 @@ import { useTabsStore } from '../../../client/src/state/tabs';
 
 const queryMocks = vi.hoisted(() => ({
   resources: [] as Array<Record<string, unknown>>,
+  byContext: {} as Record<string, Array<Record<string, unknown>>>,
+  contexts: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock('../../../client/src/api/queries.js', () => ({
   useApiResourcesForContexts: () => ({
-    data: { resources: queryMocks.resources, byContext: {}, errors: {} },
+    data: { resources: queryMocks.resources, byContext: queryMocks.byContext, errors: {} },
   }),
+  useContexts: () => ({ data: queryMocks.contexts }),
 }));
 
 function LocationProbe() {
@@ -32,6 +35,8 @@ const customResources = [
 
 beforeEach(() => {
   queryMocks.resources = customResources;
+  queryMocks.byContext = {};
+  queryMocks.contexts = [{ name: 'dev' }, { name: 'eda' }];
   useClustersStore.setState({ selected: ['dev'], namespaces: [] });
   useNavigationStore.setState({
     favorites: [
@@ -122,6 +127,46 @@ describe('NavDrawer', () => {
     fireEvent.dragEnd(source, { dataTransfer });
     expect(useNavigationStore.getState().favorites.map((favorite) => favorite.id)).toContain('kind:/v1/pods');
   }, 15_000);
+
+  it('scopes a favorite to a cluster from its menu and hides it elsewhere', async () => {
+    const legacy = () => useNavigationStore.getState().favorites.find((favorite) => favorite.id === 'legacy');
+    const { unmount } = renderDrawer('/');
+    // The star on a favorite opens its menu rather than removing it outright.
+    fireEvent.click(screen.getByLabelText('Remove or edit favorite Legacy'));
+    fireEvent.click(await screen.findByText('eda'));
+    expect(legacy()?.scopes).toEqual(['eda']);
+    // Scoped away from the connected cluster, the entry leaves the sidebar.
+    // (Its title lives on in the open menu's header, so match links only.)
+    await waitFor(() => expect(screen.queryAllByRole('link', { name: /Legacy/ })).toHaveLength(0));
+    unmount();
+
+    useClustersStore.setState({ selected: ['eda'] });
+    renderDrawer('/');
+    expect(screen.getAllByText('Legacy')[0]).toBeInTheDocument();
+    // Reverting to all clusters puts it back everywhere.
+    fireEvent.contextMenu(screen.getAllByText('Legacy')[0]!);
+    fireEvent.click(await screen.findByText('All clusters'));
+    expect(legacy()?.scopes).toBeUndefined();
+    // Removing is now an item in the same menu.
+    fireEvent.click(screen.getByLabelText('Remove or edit favorite Legacy'));
+    fireEvent.click(await screen.findByText('Remove favorite'));
+    expect(legacy()).toBeUndefined();
+  }, 15_000);
+
+  it('drops kind favorites no connected cluster serves', () => {
+    useNavigationStore.setState({
+      favorites: [
+        { id: 'kind:topo.eda.nokia.com/v1/links', title: 'TopoLinks', path: '/r/topo.eda.nokia.com/v1/links' },
+        { id: 'kind:/v1/pods', title: 'Pods', path: '/r/core/v1/pods' },
+      ],
+      savedViews: [],
+    });
+    // Discovery for the connected cluster knows nothing of the eda CRD.
+    queryMocks.byContext = { dev: [{ group: '', version: 'v1', plural: 'pods', kind: 'Pod', namespaced: true, verbs: ['list'] }] };
+    renderDrawer('/');
+    expect(screen.queryByText('TopoLinks')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Pods').length).toBeGreaterThan(0);
+  });
 
   it('supports overlay close behavior and the hidden permanent rail', async () => {
     const overlay = renderDrawer('/events', { overlay: true, open: true });


### PR DESCRIPTION
Favorites were a single global list, so an operator's CRDs from one cluster stayed in the sidebar on every other cluster. They are now scoped two ways, which compose:

**Inferred relevance** — a `kind:` favorite is listed only while a connected cluster actually serves that kind (matched on group + plural, so a CRD version bump does not drop it), and a favorited object only while its own context is connected. No setup needed. When discovery has not arrived yet or a cluster is unreachable, favorites stay listed rather than blanking out.

**Explicit scope** — `FavoriteItem.scopes` pins a favorite to specific contexts (unset = all clusters), set from the favorite's menu. Covers what discovery cannot infer, such as a builtin kind or a page you only want on one cluster. An explicit scope overrides inference; any connected context in the list is enough.

## Favorite menu

The star on a row in the Favorites group now opens the favorite's menu (tooltip: "Remove or edit favorite") instead of removing it outright; right-clicking the row does the same. Stars elsewhere in the tree still toggle directly.

The menu shows the favorite's title and GVK, a **Show in** section with `All clusters` plus every context (connection dot, per-context emoji, tick on the scoped ones), and `Remove favorite`, which turns red on hover. A favorited object gets a **Cluster** section instead, since it is bound to the cluster it lives in.

Scoped favorites name their clusters on the subtitle line. Hiding feeds through consistently: `Cmd/Ctrl+1–9` numbers the visible list, the group hides when nothing is visible, and the command palette's default list scopes the same way.

## Notes

- `scopes` is optional, so persisted favorites need no migration.
- With no cluster connected, everything is listed — there is nothing to scope against.

## Testing

- New `tests/unit/client/favorite-scope.test.ts` covers the rules; `nav-drawer.test.tsx` drives star → menu → scope → remove and the auto-hide path.
- Full unit suite, lint and typecheck pass.
- Verified against two kind clusters with a CRD installed on only one: scoping a favorite to the other cluster removed it from the sidebar, switching clusters swapped which favorites were listed, and "All clusters" restored it. Checked in dark and light themes.