### PR TITLE
Detail panel: quick actions, fact rows and per-container shell/logs

### DIFF
--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -19,7 +19,7 @@ import type { SxProps, Theme } from '@mui/material/styles';
 import { dump as dumpYaml } from 'js-yaml';
 import { gvkForResource, type KubeObject } from '@kubus/shared';
 import { useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
-import { withoutManagedFields } from '../kube-display.js';
+import { jobPhase, nodeStatus, podSummary, withoutManagedFields } from '../kube-display.js';
 import { isTextEntryTarget } from '../text-entry.js';
 import { YamlEditor, useYamlSchema } from './YamlEditor.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
@@ -36,8 +36,10 @@ import { CrdDetail, CrdSchemaDetail, crdVersions } from './detail/CrdDetail.js';
 import { CustomResourceDetail } from './detail/CustomResourceDetail.js';
 import { RolloutHistory } from './detail/RolloutHistory.js';
 import { AgeCell } from './AgeCell.js';
+import { CopyValueButton } from './CellCopy.js';
 import { MetricsChart } from './MetricsChart.js';
-import { RowActions, RowLogsButton } from './RowActions.js';
+import { DetailQuickActions } from './RowActions.js';
+import { StatusChip } from './StatusChip.js';
 import { TruncationTooltip } from './truncation.js';
 import { TopologyGraph } from './TopologyGraph.js';
 import { useDetailStore } from '../state/detail.js';
@@ -233,21 +235,28 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
                     <AgeCell timestamp={obj.metadata.creationTimestamp} variant="caption" /> old
                   </>
                 )}
+                {obj && headerStatus(behaviorKind, obj) && (
+                  <>
+                    {' · '}
+                    <StatusChip status={headerStatus(behaviorKind, obj)!} />
+                  </>
+                )}
               </Typography>
-              <TruncationTooltip text={sel.namespace ? `${sel.namespace} / ${sel.name}` : sel.name}>
-                <Typography variant="subtitle1" noWrap sx={{ fontWeight: 600, lineHeight: 1.3 }}>
-                  {sel.namespace && (
-                    <Typography component="span" variant="subtitle1" color="text.secondary" sx={{ fontWeight: 500 }}>
-                      {sel.namespace}{' / '}
-                    </Typography>
-                  )}
-                  {sel.name}
-                </Typography>
-              </TruncationTooltip>
+              <Stack direction="row" sx={{ alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                <TruncationTooltip text={sel.namespace ? `${sel.namespace} / ${sel.name}` : sel.name}>
+                  <Typography variant="subtitle1" noWrap sx={{ fontWeight: 600, lineHeight: 1.3, minWidth: 0 }}>
+                    {sel.namespace && (
+                      <Typography component="span" variant="subtitle1" color="text.secondary" sx={{ fontWeight: 500 }}>
+                        {sel.namespace}{' / '}
+                      </Typography>
+                    )}
+                    {sel.name}
+                  </Typography>
+                </TruncationTooltip>
+                <CopyValueButton text={sel.name} label={`Copy name ${sel.name}`} />
+              </Stack>
             </Box>
             <Box sx={{ flex: 1 }} />
-            {obj && <RowLogsButton target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
-            {obj && <RowActions target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
             {(!inline || tab === 'map') && (
               <Tooltip title={fullScreen ? 'Restore drawer' : 'Full screen'}>
                 <IconButton onClick={() => setFullScreen((v) => !v)} aria-label={fullScreen ? 'Restore drawer' : 'Full screen'}>
@@ -259,6 +268,7 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
               <CloseIcon />
             </IconButton>
           </Stack>
+          {obj && <DetailQuickActions target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
           <Tabs
             value={tab}
             onChange={(_e, v) => guardLeave(() => setTab(v as string))}
@@ -349,6 +359,23 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
 
 export function ResourceDetailPanel(props: Omit<Props, 'inline'>) {
   return <ResourceDetailDrawer {...props} inline />;
+}
+
+/** Summary status word shown next to the kind in the header, for kinds with a
+ *  cheap one-word answer. Others rely on their overview's Status fact. */
+function headerStatus(kind: string | undefined, obj: KubeObject): string | undefined {
+  switch (kind) {
+    case 'Pod':
+      return podSummary(obj).status;
+    case 'Node':
+      return nodeStatus(obj);
+    case 'Job':
+      return jobPhase(obj);
+    case 'CronJob':
+      return (obj.spec as { suspend?: boolean } | undefined)?.suspend ? 'Suspended' : undefined;
+    default:
+      return undefined;
+  }
 }
 
 function OverviewForKind({ kind, obj, ctx, crd, version }: { kind: string | undefined; obj: KubeObject; ctx: string; crd?: KubeObject; version: string }) {

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -258,6 +258,7 @@ export function DetailQuickActions({ target }: { target: RowActionTarget }) {
   const canViewLogs = isLogTargetKind(actionKind ?? '');
   const canForward = isForwardableKind(actionKind);
   const isPod = actionKind === 'Pod';
+  const podExecContainer = isPod ? execTargetContainer(obj) : '';
   const isNode = actionKind === 'Node';
   const isJob = actionKind === 'Job';
   const isCronJob = actionKind === 'CronJob';
@@ -275,13 +276,13 @@ export function DetailQuickActions({ target }: { target: RowActionTarget }) {
 
   return (
     <Stack direction="row" sx={{ px: 2, pt: 1.25, pb: 1, gap: 0.75, flexWrap: 'wrap', alignItems: 'center' }}>
-      {isPod && (
+      {podExecContainer && (
         <QuickActionButton
           emphasis
           icon={<TerminalIcon />}
           label="Shell"
           onClick={() => {
-            addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container: execTargetContainer(obj) });
+            addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container: podExecContainer });
           }}
         />
       )}
@@ -417,6 +418,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const restartable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'DaemonSet';
   const isReplicaSet = actionKind === 'ReplicaSet';
   const isPod = actionKind === 'Pod';
+  const podExecContainer = isPod ? execTargetContainer(obj) : '';
   const isNode = actionKind === 'Node';
   const isCronJob = actionKind === 'CronJob';
   const isJob = actionKind === 'Job';
@@ -462,10 +464,10 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
             <ListItemText>Logs</ListItemText>
           </MenuItem>
         )}
-        {isPod && (
+        {podExecContainer && (
           <MenuItem
             onClick={() => {
-              addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container: execTargetContainer(obj) });
+              addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container: podExecContainer });
               close();
             }}
           >

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
+import { alpha } from '@mui/material/styles';
 import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Chip from '@mui/material/Chip';
@@ -72,7 +74,7 @@ import { ConfirmDialog } from './ConfirmDialog.js';
 import { FileCopyDialog } from './FileCopyDialog.js';
 import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
 import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
-import { podContainerNames } from '../kube-display.js';
+import { execTargetContainer, podContainerNames } from '../kube-display.js';
 import { splitImageRef } from '../image-ref.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detailPathForRef, favoriteForRef, kindListPath, shareLinkForPath } from '../resource-links.js';
@@ -157,6 +159,202 @@ export function RowLogsButton({ target }: { target: RowActionTarget }) {
         </IconButton>
       </span>
     </Tooltip>
+  );
+}
+
+function NodeShellConfirmDialog({
+  open,
+  name,
+  isProtected,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  name: string;
+  isProtected: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <ConfirmDialog
+      open={open}
+      title={`Node shell — ${name}`}
+      message={
+        <>
+          This starts a <b>privileged pod</b> on <b>{name}</b> (host PID/network/IPC) and opens a root shell on the node via nsenter.
+          The pod is deleted when the terminal closes.
+        </>
+      }
+      confirmLabel="Open shell"
+      danger
+      confirmText={isProtected ? name : undefined}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+/** Soft-tonal labeled button for the detail panel's quick-action bar. */
+function QuickActionButton({
+  icon,
+  label,
+  onClick,
+  disabled,
+  emphasis,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  emphasis?: boolean;
+}) {
+  return (
+    <Button
+      size="small"
+      startIcon={icon}
+      disabled={disabled}
+      onClick={onClick}
+      sx={(t) => {
+        const dark = t.palette.mode === 'dark';
+        const base = dark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)';
+        const baseHover = dark ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.08)';
+        return {
+          px: 1.25,
+          flexShrink: 0,
+          color: emphasis ? 'primary.main' : 'text.primary',
+          backgroundColor: emphasis ? alpha(t.palette.primary.main, dark ? 0.15 : 0.09) : base,
+          '&:hover': { backgroundColor: emphasis ? alpha(t.palette.primary.main, dark ? 0.22 : 0.14) : baseHover },
+          '& .MuiButton-startIcon': { mr: 0.5, color: emphasis ? 'inherit' : 'text.secondary', '& svg': { fontSize: 16 } },
+        };
+      }}
+    >
+      {label}
+    </Button>
+  );
+}
+
+/**
+ * The detail panel's action bar: the two or three operations someone opens a
+ * resource for, as labeled buttons, with everything else behind the `⋮` menu
+ * at the right end. Kind-specific actions lead; the first one is emphasized.
+ */
+export function DetailQuickActions({ target }: { target: RowActionTarget }) {
+  const [dialog, setDialog] = useState<'forward' | 'scale' | 'trigger' | 'node-shell' | null>(null);
+  const [logsBusy, setLogsBusy] = useState(false);
+  const addTab = useDockStore((s) => s.addTab);
+  const restart = useRolloutRestart();
+  const rerun = useRerunJob();
+  const suspendCj = useSuspendCronJob();
+  const cordon = useCordon();
+
+  const { kind, obj, ctx } = target;
+  const actionKind = gvkForResource(target.group, target.version, target.plural)?.kind === kind ? kind : undefined;
+  const name = obj.metadata.name;
+  const namespace = obj.metadata.namespace;
+  const isProtected = useIsProtected(ctx);
+  const ok = (text: string) => showToast('success', text);
+  const fail = (err: unknown) => showErrorToast(err);
+
+  const canViewLogs = isLogTargetKind(actionKind ?? '');
+  const canForward = isForwardableKind(actionKind);
+  const isPod = actionKind === 'Pod';
+  const isNode = actionKind === 'Node';
+  const isJob = actionKind === 'Job';
+  const isCronJob = actionKind === 'CronJob';
+  const restartable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'DaemonSet';
+  const scalable = actionKind === 'Deployment' || actionKind === 'StatefulSet' || actionKind === 'ReplicaSet';
+  const unschedulable = isNode && !!(obj.spec as { unschedulable?: boolean })?.unschedulable;
+  const cjSuspended = isCronJob && !!(obj.spec as { suspend?: boolean })?.suspend;
+
+  const openLogs = () => {
+    setLogsBusy(true);
+    openLogsForTarget(target, addTab)
+      .catch(fail)
+      .finally(() => setLogsBusy(false));
+  };
+
+  return (
+    <Stack direction="row" sx={{ px: 2, pt: 1.25, pb: 1, gap: 0.75, flexWrap: 'wrap', alignItems: 'center' }}>
+      {isPod && (
+        <QuickActionButton
+          emphasis
+          icon={<TerminalIcon />}
+          label="Shell"
+          onClick={() => {
+            addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container: execTargetContainer(obj) });
+          }}
+        />
+      )}
+      {isNode && <QuickActionButton emphasis icon={<TerminalIcon />} label="Shell" onClick={() => setDialog('node-shell')} />}
+      {isCronJob && <QuickActionButton emphasis icon={<PlayArrowIcon />} label="Trigger" onClick={() => setDialog('trigger')} />}
+      {canViewLogs && (
+        <QuickActionButton emphasis={!isPod} icon={<SubjectIcon />} label="Logs" disabled={logsBusy} onClick={openLogs} />
+      )}
+      {canForward && <QuickActionButton icon={<CableIcon />} label="Forward" onClick={() => setDialog('forward')} />}
+      {scalable && <QuickActionButton icon={<OpenInFullIcon />} label="Scale" onClick={() => setDialog('scale')} />}
+      {restartable && (
+        <QuickActionButton
+          icon={<RestartAltIcon />}
+          label="Restart"
+          disabled={restart.isPending}
+          onClick={() =>
+            restart.mutate(
+              { ctx, body: { kind: kind as 'Deployment', namespace: namespace ?? '', name } },
+              { onSuccess: () => ok(`Rollout restart triggered for ${name}`), onError: fail },
+            )
+          }
+        />
+      )}
+      {isJob && (
+        <QuickActionButton
+          icon={<ReplayIcon />}
+          label="Re-run"
+          disabled={rerun.isPending}
+          onClick={() => rerun.mutate({ ctx, body: { namespace: namespace ?? '', name } }, { onSuccess: (r) => ok(`Created job ${r.jobName}`), onError: fail })}
+        />
+      )}
+      {isCronJob && (
+        <QuickActionButton
+          icon={cjSuspended ? <PlayCircleOutlinedIcon /> : <PauseCircleOutlinedIcon />}
+          label={cjSuspended ? 'Resume' : 'Suspend'}
+          disabled={suspendCj.isPending}
+          onClick={() =>
+            suspendCj.mutate(
+              { ctx, body: { namespace: namespace ?? '', name, suspend: !cjSuspended } },
+              { onSuccess: () => ok(`${cjSuspended ? 'Resumed' : 'Suspended'} ${name}`), onError: fail },
+            )
+          }
+        />
+      )}
+      {isNode && (
+        <QuickActionButton
+          icon={<BlockIcon />}
+          label={unschedulable ? 'Uncordon' : 'Cordon'}
+          disabled={cordon.isPending}
+          onClick={() =>
+            cordon.mutate(
+              { ctx, body: { node: name, unschedulable: !unschedulable } },
+              { onSuccess: () => ok(`${unschedulable ? 'Uncordoned' : 'Cordoned'} ${name}`), onError: fail },
+            )
+          }
+        />
+      )}
+      <Box sx={{ flex: 1 }} />
+      <RowActions target={target} />
+      <NodeShellConfirmDialog
+        open={dialog === 'node-shell'}
+        name={name}
+        isProtected={isProtected}
+        onClose={() => setDialog(null)}
+        onConfirm={() => {
+          setDialog(null);
+          addTab({ kind: 'node-shell', id: dockTabId(), title: `node: ${name}`, ctx, node: name });
+        }}
+      />
+      {dialog === 'trigger' && <TriggerCronJobDialog ctx={ctx} obj={obj} onClose={() => setDialog(null)} onDone={ok} />}
+      {dialog === 'scale' && <ScaleDialog target={target} onClose={() => setDialog(null)} onDone={ok} onError={fail} />}
+      {dialog === 'forward' && <PortForwardDialog ctx={ctx} kind={actionKind ?? kind} obj={obj} onClose={() => setDialog(null)} />}
+    </Stack>
   );
 }
 
@@ -267,8 +465,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
         {isPod && (
           <MenuItem
             onClick={() => {
-              const container = podContainerNames(obj)[0] ?? '';
-              addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container });
+              addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${name}`, ctx, namespace: namespace ?? '', pod: name, container: execTargetContainer(obj) });
               close();
             }}
           >
@@ -595,18 +792,10 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
           )
         }
       />
-      <ConfirmDialog
+      <NodeShellConfirmDialog
         open={dialog === 'node-shell'}
-        title={`Node shell — ${name}`}
-        message={
-          <>
-            This starts a <b>privileged pod</b> on <b>{name}</b> (host PID/network/IPC) and opens a root shell on the node via nsenter.
-            The pod is deleted when the terminal closes.
-          </>
-        }
-        confirmLabel="Open shell"
-        danger
-        confirmText={isProtected ? name : undefined}
+        name={name}
+        isProtected={isProtected}
         onClose={() => setDialog(null)}
         onConfirm={() => {
           setDialog(null);

--- a/client/src/components/detail/ConfigMapDetail.tsx
+++ b/client/src/components/detail/ConfigMapDetail.tsx
@@ -1,16 +1,40 @@
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
-import Stack from '@mui/material/Stack';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import type { KubeObject } from '@kubus/shared';
 import { formatBytes } from '../format.js';
 import { GenericDetail } from './GenericDetail.js';
+import { Fact, Facts } from './Facts.js';
 import { Section } from './Section.js';
 import { b64ByteLength } from './data-editor.js';
+import { statusTextColor } from '../../theme.js';
 
 function stringEntries(obj: KubeObject, field: 'data' | 'binaryData'): Array<[string, string]> {
   const map = obj[field] as Record<string, unknown> | undefined;
   return Object.entries(map ?? {}).filter((kv): kv is [string, string] => typeof kv[1] === 'string');
+}
+
+/** Borderless key/size rows for data keys — the values live in the Data tab. */
+export function DataKeyRows({ rows }: { rows: Array<{ key: string; size?: number; note?: string }> }) {
+  return (
+    <Table size="small">
+      <TableBody>
+        {rows.map((r) => (
+          <TableRow key={`${r.note ?? ''}:${r.key}`}>
+            <TableCell sx={{ border: 0, py: 0.25, pl: 0, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all' }}>{r.key}</TableCell>
+            <TableCell align="right" sx={{ border: 0, py: 0.25, whiteSpace: 'nowrap', width: '1%' }}>
+              <Typography variant="caption" color="text.secondary">
+                {[r.note, r.size !== undefined ? formatBytes(r.size) : undefined].filter(Boolean).join(' · ')}
+              </Typography>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
 }
 
 export function ConfigMapDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
@@ -20,21 +44,27 @@ export function ConfigMapDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) 
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ px: 2, pt: 2, flexWrap: 'wrap' }}>
-        <Chip label={`${total} key${total === 1 ? '' : 's'}`} variant="outlined" />
-        {obj.immutable === true && <Chip label="immutable" variant="outlined" color="warning" />}
-      </Stack>
+      <Box sx={{ px: 2, pt: 2 }}>
+        <Facts>
+          <Fact label="Keys">{total}</Fact>
+          <Fact label="Immutable" hint="Immutable ConfigMaps cannot be edited — only replaced.">
+            {obj.immutable === true && (
+              <Box component="span" sx={{ fontWeight: 550, color: statusTextColor('warning') }}>
+                Yes
+              </Box>
+            )}
+          </Fact>
+        </Facts>
+      </Box>
       {total > 0 && (
         <Box sx={{ px: 2, pt: 2 }}>
           <Section title="Data keys" count={total}>
-            <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
-              {textKeys.map(([k, v]) => (
-                <Chip key={k} label={`${k} · ${formatBytes(new TextEncoder().encode(v).length)}`} variant="outlined" title={k} />
-              ))}
-              {binaryKeys.map(([k, v]) => (
-                <Chip key={k} label={`${k} · binary ${formatBytes(b64ByteLength(v))}`} variant="outlined" title={k} />
-              ))}
-            </Stack>
+            <DataKeyRows
+              rows={[
+                ...textKeys.map(([k, v]) => ({ key: k, size: new TextEncoder().encode(v).length })),
+                ...binaryKeys.map(([k, v]) => ({ key: k, size: b64ByteLength(v), note: 'binary' })),
+              ]}
+            />
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
               View and edit values per key in the Data tab.
             </Typography>

--- a/client/src/components/detail/ContainerCards.tsx
+++ b/client/src/components/detail/ContainerCards.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
@@ -5,6 +6,8 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import SubjectIcon from '@mui/icons-material/Subject';
+import TerminalIcon from '@mui/icons-material/Terminal';
 import { AgeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
 import { UsageMeter } from '../UsageMeter.js';
@@ -19,6 +22,12 @@ export interface ContainerCardData {
   kind?: 'init' | 'sidecar';
   /** StatusChip label, e.g. Running / Completed / CrashLoopBackOff. */
   state?: string;
+  /**
+   * A live process exists for `onShell` to attach to. Pods derive it from the
+   * container's own state; workload templates from whether any of their pods
+   * currently runs this container.
+   */
+  shellable?: boolean;
   /** Why the container is in `state` (waiting/terminated message). */
   stateMessage?: string;
   restarts?: number;
@@ -30,40 +39,70 @@ export interface ContainerCardData {
   podCount?: number;
 }
 
-/** Card grid for a pod's (or workload template's) containers. */
-export function ContainerCards({
-  items,
-  onForwardPort,
-  onEditImage,
-}: {
-  items: ContainerCardData[];
+export interface ContainerActions {
+  /** Stream this container's logs. */
+  onLogs?: (container: string) => void;
+  /** Open a shell in this container (pods only — a template has no process). */
+  onShell?: (container: string) => void;
   onForwardPort?: (port: number) => void;
   onEditImage?: (container: string) => void;
-}) {
+}
+
+/** Card grid for a pod's (or workload template's) containers. */
+export function ContainerCards({ items, ...actions }: { items: ContainerCardData[] } & ContainerActions) {
   if (!items.length) return null;
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(270px, 1fr))', gap: 1.5 }}>
       {items.map((c) => (
-        <ContainerCard key={`${c.kind ?? 'app'}:${c.name}`} c={c} onForwardPort={onForwardPort} onEditImage={onEditImage} />
+        <ContainerCard key={`${c.kind ?? 'app'}:${c.name}`} c={c} {...actions} />
       ))}
     </Box>
   );
 }
 
-function ContainerCard({ c, onForwardPort, onEditImage }: { c: ContainerCardData; onForwardPort?: (port: number) => void; onEditImage?: (container: string) => void }) {
+/** Small square action button sized to sit inline with the container name. */
+function CardAction({ title, label, onClick, children }: { title: string; label: string; onClick: () => void; children: ReactNode }) {
+  return (
+    <Tooltip title={title}>
+      <IconButton
+        size="small"
+        aria-label={label}
+        onClick={onClick}
+        sx={{ p: 0.375, flexShrink: 0, color: 'text.secondary', '&:hover': { color: 'text.primary' }, '& svg': { fontSize: 15 } }}
+      >
+        {children}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+function ContainerCard({ c, onLogs, onShell, onForwardPort, onEditImage }: { c: ContainerCardData } & ContainerActions) {
   const showRestarts = (c.restarts ?? 0) > 0 || c.lastRestart;
+  // exec needs a live process, so only a running container gets a shell —
+  // a crashlooping one still gets logs, which is where its output is.
+  const shellable = onShell && c.shellable;
   return (
     <Box sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1.5, p: 1.5, minWidth: 0 }}>
-      <Stack direction="row" sx={{ alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+      <Stack direction="row" sx={{ alignItems: 'center', gap: 0.5, minWidth: 0 }}>
         <Typography variant="subtitle2" noWrap title={c.name} sx={{ minWidth: 0 }}>
           {c.name}
         </Typography>
         {c.kind && <Chip label={c.kind} sx={{ height: 16, fontSize: 10, flexShrink: 0 }} />}
         <Box sx={{ flex: 1 }} />
         {c.state && (
-          <Box sx={{ flexShrink: 0 }}>
+          <Box sx={{ flexShrink: 0, mr: 0.25 }}>
             <StatusChip status={c.state} />
           </Box>
+        )}
+        {onLogs && (
+          <CardAction title={`Logs for ${c.name}`} label={`Logs for container ${c.name}`} onClick={() => onLogs(c.name)}>
+            <SubjectIcon />
+          </CardAction>
+        )}
+        {shellable && (
+          <CardAction title={`Shell into ${c.name}`} label={`Shell into container ${c.name}`} onClick={() => onShell(c.name)}>
+            <TerminalIcon />
+          </CardAction>
         )}
       </Stack>
       {c.image && (

--- a/client/src/components/detail/CustomResourceDetail.tsx
+++ b/client/src/components/detail/CustomResourceDetail.tsx
@@ -1,10 +1,5 @@
 import { useMemo } from 'react';
 import Stack from '@mui/material/Stack';
-import Table from '@mui/material/Table';
-import TableBody from '@mui/material/TableBody';
-import TableCell from '@mui/material/TableCell';
-import TableRow from '@mui/material/TableRow';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import type { KubeObject } from '@kubus/shared';
 import { evalPrinterColumnPath } from '@kubus/shared';
@@ -12,6 +7,7 @@ import { RelativeTimeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
 import { statusLikeName } from '../../kube-display.js';
 import { ConditionsTable, KeyValueSection, MetadataSection } from './GenericDetail.js';
+import { Fact, Facts } from './Facts.js';
 import { Section } from './Section.js';
 import { crdVersions } from './CrdDetail.js';
 
@@ -74,26 +70,13 @@ export function CustomResourceDetail({ obj, ctx, crd, version }: { obj: KubeObje
     <Stack spacing={2} sx={{ p: 2 }}>
       {rows.length > 0 && (
         <Section title="Status">
-          <Table size="small">
-            <TableBody>
-              {rows.map((row) => (
-                <TableRow key={row.label}>
-                  <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>
-                    {row.description ? (
-                      <Tooltip title={row.description}>
-                        <span>{row.label}</span>
-                      </Tooltip>
-                    ) : (
-                      row.label
-                    )}
-                  </TableCell>
-                  <TableCell sx={{ border: 0, wordBreak: 'break-all' }}>
-                    <StatusRowValue row={row} />
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+          <Facts>
+            {rows.map((row) => (
+              <Fact key={row.label} label={row.label} hint={row.description}>
+                <StatusRowValue row={row} />
+              </Fact>
+            ))}
+          </Facts>
         </Section>
       )}
       <ConditionsTable obj={obj} />

--- a/client/src/components/detail/DeploymentDetail.tsx
+++ b/client/src/components/detail/DeploymentDetail.tsx
@@ -1,15 +1,17 @@
-import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
-import Tooltip from '@mui/material/Tooltip';
 import type { ContainerUsage, KubeObject } from '@kubus/shared';
 import { useMemo, useState } from 'react';
 import { PortForwardDialog } from '../PortForwardDialog.js';
 import { SetImageDialog } from '../RowActions.js';
 import { useResourceList, useResourceMetrics } from '../../api/queries.js';
-import { containerResources, workloadReady } from '../../kube-display.js';
+import { containerResources, podContainerNames, runningContainerNames, workloadReady } from '../../kube-display.js';
+import { useDockStore, dockTabId } from '../../state/dock.js';
 import { showToast } from '../../state/toast.js';
 import { ReadyCounter } from '../ReadyCounter.js';
-import { ConditionChips, ConditionRows, KeyValueSection, MetadataSection, hasUnhealthyCondition } from './GenericDetail.js';
+import { ConditionRows, KeyValueSection, MetadataSection, hasUnhealthyCondition } from './GenericDetail.js';
+import { Fact, Facts } from './Facts.js';
+import { statusTextColor } from '../../theme.js';
 import { ContainerCards, type ContainerCardData } from './ContainerCards.js';
 import { PodMiniList } from './PodMiniList.js';
 import { Section } from './Section.js';
@@ -97,6 +99,19 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
     return totals;
   }, [metricsQuery.data, ctx, namespace, pods]);
 
+  // Which template containers are live somewhere, and in which pod — a shell
+  // has to land in a concrete pod, so the card offers one only when a pod is
+  // actually running that container.
+  const podByContainer = useMemo(() => {
+    const map = new Map<string, KubeObject>();
+    for (const pod of pods) {
+      for (const container of runningContainerNames(pod)) {
+        if (!map.has(container)) map.set(container, pod);
+      }
+    }
+    return map;
+  }, [pods]);
+
   const cards = useMemo(() => {
     const toCard = (c: TemplateContainer, kind?: 'init' | 'sidecar'): ContainerCardData => {
       const usage = containerUsage.get(c.name);
@@ -104,6 +119,7 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
         name: c.name,
         image: c.image,
         kind,
+        shellable: podByContainer.has(c.name),
         ports: (c.ports ?? []).map((p) => ({ port: p.containerPort, protocol: p.protocol, name: p.name })),
         resources: containerResources(c),
         usage: usage ? { cpuMilli: usage.cpuMilli, memBytes: usage.memBytes } : undefined,
@@ -114,26 +130,101 @@ export function DeploymentDetail({ obj, ctx }: { obj: KubeObject; ctx: string })
       ...(spec?.template?.spec?.containers ?? []).map((c) => toCard(c)),
       ...(spec?.template?.spec?.initContainers ?? []).map((c) => toCard(c, c.restartPolicy === 'Always' ? 'sidecar' : 'init')),
     ];
-  }, [spec, containerUsage]);
+  }, [spec, containerUsage, podByContainer]);
+
+  // One container's logs across every pod of this Deployment — the picker
+  // still lists the rest, they just start unselected.
+  const addTab = useDockStore((s) => s.addTab);
+  const openContainerLogs = (container: string) => {
+    if (!pods.length) {
+      showToast('error', `No running pods for ${obj.metadata.name}`);
+      return;
+    }
+    addTab({
+      kind: 'logs',
+      id: dockTabId(),
+      title: `logs: ${obj.metadata.name}/${container}`,
+      ctx,
+      namespace: namespace ?? '',
+      pods: pods.map((pod) => pod.metadata.name),
+      sources: pods.map((pod) => ({ pod: pod.metadata.name, containers: podContainerNames(pod) })),
+      target: { kind: 'Deployment', name: obj.metadata.name },
+      container,
+      follow: true,
+    });
+  };
+
+  // Any pod running the container will do — the tab title names the one you
+  // landed in, and the Pods section below is there to pick a specific one.
+  const openContainerShell = (container: string) => {
+    const pod = podByContainer.get(container);
+    if (!pod) {
+      showToast('error', `No running pod for container ${container}`);
+      return;
+    }
+    addTab({
+      kind: 'terminal',
+      id: dockTabId(),
+      title: `sh: ${pod.metadata.name}/${container}`,
+      ctx,
+      namespace: namespace ?? '',
+      pod: pod.metadata.name,
+      container,
+    });
+  };
 
   const strategy = spec?.strategy?.type;
   const rolling = spec?.strategy?.rollingUpdate;
   const hasConditions = ((obj.status as { conditions?: unknown[] } | undefined)?.conditions?.length ?? 0) > 0;
+  const dstatus = obj.status as { updatedReplicas?: number; availableReplicas?: number; unavailableReplicas?: number } | undefined;
 
   return (
     <Stack spacing={2} sx={{ p: 2 }}>
-      <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1, alignItems: 'center' }}>
-        <Chip label={<>Ready <ReadyCounter value={workloadReady(obj)} /></>} variant="outlined" />
-        {strategy && (
-          <Tooltip title={rolling ? `maxUnavailable ${rolling.maxUnavailable ?? '-'} · maxSurge ${rolling.maxSurge ?? '-'}` : ''}>
-            <Chip label={`Strategy ${strategy}`} variant="outlined" />
-          </Tooltip>
-        )}
-        {spec?.paused && <Chip label="Paused" color="warning" size="small" />}
-        <ConditionChips obj={obj} goodWhen={deploymentGoodWhen} />
-      </Stack>
+      <Facts>
+        <Fact label="Ready">
+          <ReadyCounter value={workloadReady(obj)} />
+        </Fact>
+        <Fact label="Replicas">
+          {dstatus &&
+            [
+              dstatus.updatedReplicas !== undefined ? `${dstatus.updatedReplicas} updated` : undefined,
+              dstatus.availableReplicas !== undefined ? `${dstatus.availableReplicas} available` : undefined,
+              dstatus.unavailableReplicas ? `${dstatus.unavailableReplicas} unavailable` : undefined,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
+        </Fact>
+        <Fact label="Strategy">
+          {strategy && (
+            <>
+              {strategy}
+              {rolling && (
+                <Box component="span" sx={{ color: 'text.secondary' }}>
+                  {` · max unavailable ${rolling.maxUnavailable ?? '-'} · max surge ${rolling.maxSurge ?? '-'}`}
+                </Box>
+              )}
+            </>
+          )}
+        </Fact>
+        <Fact label="Selector" mono>
+          {labelSelector}
+        </Fact>
+        <Fact label="Rollout">
+          {spec?.paused && (
+            <Box component="span" sx={{ fontWeight: 550, color: statusTextColor('warning') }}>
+              Paused
+            </Box>
+          )}
+        </Fact>
+      </Facts>
       <Section title="Containers" count={cards.length}>
-        <ContainerCards items={cards} onForwardPort={setForwardPort} onEditImage={setEditImageContainer} />
+        <ContainerCards
+          items={cards}
+          onLogs={openContainerLogs}
+          onShell={openContainerShell}
+          onForwardPort={setForwardPort}
+          onEditImage={setEditImageContainer}
+        />
       </Section>
       <Section title="Pods" count={pods.length}>
         <PodMiniList

--- a/client/src/components/detail/Facts.tsx
+++ b/client/src/components/detail/Facts.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+
+/**
+ * Label→value rows for a resource's key facts — the summary block at the top
+ * of every detail overview. Values read as a scannable column; chips are
+ * reserved for genuine tags (labels, selectors), not facts.
+ */
+export function Facts({ children }: { children: ReactNode }) {
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(110px, 150px) 1fr',
+        columnGap: 2,
+        rowGap: 0.75,
+        alignItems: 'baseline',
+      }}
+    >
+      {children}
+    </Box>
+  );
+}
+
+/** One fact row. Renders nothing when the value is empty, so callers can pass
+ *  optional fields straight through without conditionals. */
+export function Fact({ label, hint, mono, children }: { label: string; hint?: string; mono?: boolean; children: ReactNode }) {
+  if (children === undefined || children === null || children === '' || children === false) return null;
+  const labelNode = (
+    <Typography
+      variant="body2"
+      color="text.secondary"
+      noWrap
+      sx={hint ? { textDecoration: 'underline dotted', textDecorationColor: 'text.disabled', textUnderlineOffset: 3, cursor: 'help' } : undefined}
+    >
+      {label}
+    </Typography>
+  );
+  return (
+    <>
+      {hint ? <Tooltip title={hint}>{labelNode}</Tooltip> : labelNode}
+      <Box
+        sx={{
+          typography: 'body2',
+          minWidth: 0,
+          wordBreak: 'break-word',
+          ...(mono ? { fontFamily: 'monospace', fontSize: 12 } : {}),
+        }}
+      >
+        {children}
+      </Box>
+    </>
+  );
+}
+
+/** Fact value that navigates — related resources, backing objects. */
+export function FactLink({ onClick, title, children }: { onClick: () => void; title?: string; children: ReactNode }) {
+  return (
+    <Link
+      component="button"
+      variant="body2"
+      underline="hover"
+      title={title}
+      onClick={onClick}
+      sx={{ textAlign: 'left', wordBreak: 'break-word', verticalAlign: 'baseline' }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/client/src/components/detail/GenericDetail.tsx
+++ b/client/src/components/detail/GenericDetail.tsx
@@ -7,12 +7,12 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type { KubeObject } from '@kubus/shared';
-import { AgeCell, formatAge } from '../AgeCell.js';
+import { AgeCell } from '../AgeCell.js';
 import { StatusChip } from '../StatusChip.js';
+import { Fact, Facts } from './Facts.js';
 import { Section } from './Section.js';
 
 export function KeyValueChips({ title, entries }: { title: string; entries: Record<string, string> | undefined }) {
@@ -88,40 +88,6 @@ export function hasUnhealthyCondition(obj: KubeObject, goodWhen?: (type: string)
   return objConditions(obj).some((c) => c.status !== (goodWhen?.(c.type) ?? 'True'));
 }
 
-/**
- * Compact one-chip-per-condition row; reason/message/age live in the
- * tooltip. Healthy conditions are subtle, unhealthy ones pop.
- */
-export function ConditionChips({ obj, goodWhen }: { obj: KubeObject; goodWhen?: (type: string) => 'True' | 'False' }) {
-  const conditions = objConditions(obj);
-  if (!conditions.length) return null;
-  return (
-    <>
-      {conditions.map((c) => {
-        const expected = goodWhen?.(c.type) ?? 'True';
-        const healthy = c.status === expected;
-        const unknown = c.status === 'Unknown';
-        const tip = [`${c.type}: ${c.status}`, c.reason, c.message, c.lastTransitionTime ? `for ${formatAge(c.lastTransitionTime)}` : undefined]
-          .filter(Boolean)
-          .join(' · ');
-        return (
-          <Tooltip key={c.type} title={tip}>
-            <Chip
-              // A red "Available" reads as a contradiction — spell out the
-              // status whenever the condition is off its healthy value.
-              label={healthy ? c.type : `${c.type}: ${c.status}`}
-              size="small"
-              variant="outlined"
-              color={unknown ? 'default' : healthy ? 'success' : 'error'}
-              sx={healthy && !unknown ? { color: 'text.secondary' } : undefined}
-            />
-          </Tooltip>
-        );
-      })}
-    </>
-  );
-}
-
 export function ConditionsTable({ obj, goodWhen, defaultOpen = true }: { obj: KubeObject; goodWhen?: (type: string) => 'True' | 'False'; defaultOpen?: boolean }) {
   const conditions = objConditions(obj);
   if (!conditions.length) return null;
@@ -173,21 +139,18 @@ export function ConditionRows({ conditions, goodWhen }: { conditions: Condition[
 export function MetadataSection({ obj, ctx, defaultOpen = true }: { obj: KubeObject; ctx: string; defaultOpen?: boolean }) {
   return (
     <Section title="Metadata" defaultOpen={defaultOpen}>
-      <Table size="small">
-        <TableBody>
-          <Row label="Name" value={obj.metadata.name} />
-          {obj.metadata.namespace && <Row label="Namespace" value={obj.metadata.namespace} />}
-          <Row label="Cluster" value={ctx} />
-          <Row label="Kind" value={`${obj.kind ?? ''} (${obj.apiVersion ?? ''})`} />
-          <TableRow>
-            <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>Created</TableCell>
-            <TableCell sx={{ border: 0 }}>
-              <AgeCell timestamp={obj.metadata.creationTimestamp} /> ago
-            </TableCell>
-          </TableRow>
-          <Row label="UID" value={obj.metadata.uid} />
-        </TableBody>
-      </Table>
+      <Facts>
+        <Fact label="Name">{obj.metadata.name}</Fact>
+        <Fact label="Namespace">{obj.metadata.namespace}</Fact>
+        <Fact label="Cluster">{ctx}</Fact>
+        <Fact label="Kind">{`${obj.kind ?? ''} (${obj.apiVersion ?? ''})`}</Fact>
+        <Fact label="Created">
+          <AgeCell timestamp={obj.metadata.creationTimestamp} /> ago
+        </Fact>
+        <Fact label="UID" mono>
+          {obj.metadata.uid}
+        </Fact>
+      </Facts>
     </Section>
   );
 }
@@ -204,11 +167,3 @@ export function GenericDetail({ obj, ctx, hideConditions, children }: { obj: Kub
   );
 }
 
-function Row({ label, value }: { label: string; value: string }) {
-  return (
-    <TableRow>
-      <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{label}</TableCell>
-      <TableCell sx={{ border: 0, wordBreak: 'break-word' }}>{value}</TableCell>
-    </TableRow>
-  );
-}

--- a/client/src/components/detail/NodeDetail.tsx
+++ b/client/src/components/detail/NodeDetail.tsx
@@ -1,5 +1,4 @@
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -8,6 +7,7 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import type { KubeObject } from '@kubus/shared';
 import { GenericDetail, ConditionsTable, hasUnhealthyCondition } from './GenericDetail.js';
+import { Fact, Facts } from './Facts.js';
 import { PodMiniList } from './PodMiniList.js';
 import { Section } from './Section.js';
 import { CopyValueButton } from '../CellCopy.js';
@@ -44,35 +44,36 @@ export function NodeDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ px: 2, pt: 2, flexWrap: 'wrap' }}>
-        <StatusChip status={nodeStatus(obj)} />
-        {roles && <Chip label={roles} variant="outlined" />}
-        {status.nodeInfo?.kubeletVersion && <Chip label={status.nodeInfo.kubeletVersion} variant="outlined" />}
-        {status.nodeInfo?.osImage && <Chip label={status.nodeInfo.osImage} variant="outlined" />}
-        {status.nodeInfo?.architecture && <Chip label={status.nodeInfo.architecture} variant="outlined" />}
-        {status.nodeInfo?.containerRuntimeVersion && <Chip label={status.nodeInfo.containerRuntimeVersion} variant="outlined" />}
-      </Stack>
+      <Box sx={{ px: 2, pt: 2 }}>
+        <Facts>
+          <Fact label="Status">
+            <StatusChip status={nodeStatus(obj)} />
+          </Fact>
+          <Fact label="Roles">{roles}</Fact>
+          <Fact label="Kubelet">{status.nodeInfo?.kubeletVersion}</Fact>
+          <Fact label="OS">{status.nodeInfo?.osImage}</Fact>
+          <Fact label="Architecture">{status.nodeInfo?.architecture}</Fact>
+          <Fact label="Runtime">{status.nodeInfo?.containerRuntimeVersion}</Fact>
+          <Fact label="Kernel">{status.nodeInfo?.kernelVersion}</Fact>
+        </Facts>
+      </Box>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
         {(!!status.addresses?.length || providerID) && (
           <Section title="Addresses">
-            <Table size="small">
-              <TableBody>
-                {(status.addresses ?? []).map((a) => (
-                  <TableRow key={`${a.type}:${a.address}`}>
-                    <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>{a.type}</TableCell>
-                    <TableCell sx={{ border: 0 }}>{a.address}</TableCell>
-                  </TableRow>
-                ))}
+            <Facts>
+              {(status.addresses ?? []).map((a) => (
+                <Fact key={`${a.type}:${a.address}`} label={a.type}>
+                  {a.address}
+                </Fact>
+              ))}
+              <Fact label="Provider ID" mono>
                 {providerID && (
-                  <TableRow>
-                    <TableCell sx={{ width: 140, color: 'text.secondary', border: 0 }}>Provider ID</TableCell>
-                    <TableCell sx={{ border: 0, fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-word' }}>
-                      {providerID} <CopyValueButton text={providerID} label="Copy provider ID" />
-                    </TableCell>
-                  </TableRow>
+                  <>
+                    {providerID} <CopyValueButton text={providerID} label="Copy provider ID" />
+                  </>
                 )}
-              </TableBody>
-            </Table>
+              </Fact>
+            </Facts>
           </Section>
         )}
         {resourceKeys.length > 0 && (

--- a/client/src/components/detail/PodDetail.tsx
+++ b/client/src/components/detail/PodDetail.tsx
@@ -18,7 +18,8 @@ import TerminalIcon from '@mui/icons-material/Terminal';
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import type { ContainerUsage, KubeObject, PodEnvVar } from '@kubus/shared';
 import { gvkForKind } from '@kubus/shared';
-import { ConditionChips, KeyValueChips, KeyValueSection, MetadataSection } from './GenericDetail.js';
+import { ConditionsTable, KeyValueChips, KeyValueSection, MetadataSection } from './GenericDetail.js';
+import { Fact, FactLink, Facts } from './Facts.js';
 import { CopyValueButton } from '../CellCopy.js';
 import { PortForwardDialog } from '../PortForwardDialog.js';
 import { PodProblems } from './PodProblems.js';
@@ -27,7 +28,7 @@ import { ContainerCards, type ContainerCardData } from './ContainerCards.js';
 import { ReadyCounter } from '../ReadyCounter.js';
 import { StatusChip } from '../StatusChip.js';
 import { AgeCell } from '../AgeCell.js';
-import { containerResources, podDebugContainers, podSummary } from '../../kube-display.js';
+import { containerResources, ownerReference, podContainerNames, podDebugContainers, podSummary } from '../../kube-display.js';
 import { usePodEnv, useResourceMetrics, useStopDebug } from '../../api/queries.js';
 import { useDetailStore } from '../../state/detail.js';
 import { showToast } from '../../state/toast.js';
@@ -100,6 +101,7 @@ function containerCard(c: ContainerSpec, st: ContainerStatus | undefined, usage:
     image: c.image,
     kind,
     state: reason ? (reason === 'running' ? 'Running' : reason === 'waiting' ? 'Waiting' : reason === 'terminated' ? 'Terminated' : reason) : undefined,
+    shellable: stateKey === 'running',
     stateMessage: stateKey && stateKey !== 'running' ? st!.state![stateKey]?.message : undefined,
     restarts: st?.restartCount,
     lastRestart: last ? { reason: last.reason, at: last.finishedAt } : undefined,
@@ -111,7 +113,9 @@ function containerCard(c: ContainerSpec, st: ContainerStatus | undefined, usage:
 
 export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
   const spec = obj.spec as PodSpec | undefined;
-  const status = obj.status as { phase?: string; podIP?: string; containerStatuses?: ContainerStatus[]; initContainerStatuses?: ContainerStatus[]; qosClass?: string } | undefined;
+  const status = obj.status as
+    | { phase?: string; podIP?: string; hostIP?: string; containerStatuses?: ContainerStatus[]; initContainerStatuses?: ContainerStatus[]; qosClass?: string }
+    | undefined;
   // Conditions on finished pods are stale (Ready=False is expected there).
   const terminal = status?.phase === 'Succeeded' || status?.phase === 'Failed';
   const summary = podSummary(obj);
@@ -134,6 +138,26 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
     if (!gvk) return;
     push({ ctx, group: gvk.group, version: gvk.version, plural: gvk.plural, kind, name, namespace: gvk.namespaced ? namespace : undefined });
   };
+  const owner = ownerReference(obj);
+  const ownerGvk = owner ? gvkForKind(owner.kind) : undefined;
+
+  // Per-container logs/shell: the pod-level actions cover every container at
+  // once, so these exist to isolate one of a multi-container pod.
+  const addTab = useDockStore((s) => s.addTab);
+  const openContainerLogs = (container: string) =>
+    addTab({
+      kind: 'logs',
+      id: dockTabId(),
+      title: `logs: ${obj.metadata.name}/${container}`,
+      ctx,
+      namespace: namespace ?? '',
+      pods: [obj.metadata.name],
+      sources: [{ pod: obj.metadata.name, containers: podContainerNames(obj) }],
+      container,
+      follow: true,
+    });
+  const openContainerShell = (container: string) =>
+    addTab({ kind: 'terminal', id: dockTabId(), title: `sh: ${obj.metadata.name}/${container}`, ctx, namespace: namespace ?? '', pod: obj.metadata.name, container });
 
   // Restartable init containers are sidecars: they run alongside the app
   // containers, so they card with them; one-shot inits get their own section.
@@ -147,27 +171,73 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
 
   return (
     <Stack spacing={2} sx={{ p: 2 }}>
-      <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap', rowGap: 1, alignItems: 'center' }}>
-        <StatusChip status={summary.status} />
-        <Chip label={<>Ready <ReadyCounter value={summary.ready} /></>} variant="outlined" />
-        <Chip label={`Restarts ${summary.restarts}`} variant="outlined" />
-        {status?.podIP && <Chip label={`IP ${status.podIP}`} variant="outlined" />}
-        {spec?.nodeName && (
-          <Chip label={`Node ${spec.nodeName}`} variant="outlined" clickable onClick={() => openRelated('Node', spec.nodeName!)} />
-        )}
-        {status?.qosClass && <Chip label={`QoS ${status.qosClass}`} variant="outlined" />}
-        {spec?.serviceAccountName && (
-          <Chip label={`SA ${spec.serviceAccountName}`} variant="outlined" clickable onClick={() => openRelated('ServiceAccount', spec.serviceAccountName!)} />
-        )}
-        {!terminal && <ConditionChips obj={obj} />}
-      </Stack>
+      <Facts>
+        <Fact label="Status">
+          <StatusChip status={summary.status} />
+        </Fact>
+        <Fact label="Ready">
+          <ReadyCounter value={summary.ready} />
+        </Fact>
+        <Fact label="Restarts">{summary.restarts}</Fact>
+        <Fact label="Node">
+          {spec?.nodeName && (
+            <FactLink title={`Open node ${spec.nodeName}`} onClick={() => openRelated('Node', spec.nodeName!)}>
+              {spec.nodeName}
+            </FactLink>
+          )}
+        </Fact>
+        <Fact label="Pod IP" mono>
+          {status?.podIP}
+        </Fact>
+        <Fact label="Host IP" mono>
+          {status?.hostIP}
+        </Fact>
+        <Fact label="QoS class" hint="Guaranteed: all containers have limits = requests. Burstable: some requests set. BestEffort: none.">
+          {status?.qosClass}
+        </Fact>
+        <Fact label="Service account">
+          {spec?.serviceAccountName && (
+            <FactLink title={`Open ServiceAccount ${spec.serviceAccountName}`} onClick={() => openRelated('ServiceAccount', spec.serviceAccountName!)}>
+              {spec.serviceAccountName}
+            </FactLink>
+          )}
+        </Fact>
+        <Fact label="Controlled by">
+          {owner &&
+            (ownerGvk ? (
+              <FactLink
+                title={`Open ${owner.kind} ${owner.name}`}
+                onClick={() =>
+                  push({
+                    ctx,
+                    group: ownerGvk.group,
+                    version: ownerGvk.version,
+                    plural: ownerGvk.plural,
+                    kind: owner.kind,
+                    name: owner.name,
+                    namespace: ownerGvk.namespaced ? namespace : undefined,
+                  })
+                }
+              >
+                {owner.kind}/{owner.name}
+              </FactLink>
+            ) : (
+              `${owner.kind}/${owner.name}`
+            ))}
+        </Fact>
+      </Facts>
       <PodProblems obj={obj} ctx={ctx} />
       <Section title="Containers" count={mainCards.length}>
-        <ContainerCards items={mainCards} onForwardPort={terminal ? undefined : setForwardPort} />
+        <ContainerCards
+          items={mainCards}
+          onLogs={openContainerLogs}
+          onShell={terminal ? undefined : openContainerShell}
+          onForwardPort={terminal ? undefined : setForwardPort}
+        />
       </Section>
       {initCards.length > 0 && (
         <Section title="Init containers" count={initCards.length}>
-          <ContainerCards items={initCards} />
+          <ContainerCards items={initCards} onLogs={openContainerLogs} />
         </Section>
       )}
       <DebugContainersSection obj={obj} ctx={ctx} />
@@ -175,6 +245,7 @@ export function PodDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
       {namespace && <EnvSection ctx={ctx} namespace={namespace} pod={obj.metadata.name} onOpenRef={openRelated} />}
       <VolumesSection spec={spec} onOpenRef={openRelated} />
       <SchedulingSection spec={spec} />
+      {!terminal && <ConditionsTable obj={obj} defaultOpen={false} />}
       <KeyValueSection title="Labels" entries={obj.metadata.labels} />
       <KeyValueSection title="Annotations" entries={obj.metadata.annotations} defaultOpen={false} />
       <MetadataSection obj={obj} ctx={ctx} defaultOpen={false} />

--- a/client/src/components/detail/SecretDetail.tsx
+++ b/client/src/components/detail/SecretDetail.tsx
@@ -1,25 +1,31 @@
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { KubeObject, TlsCertInfo } from '@kubus/shared';
 import { GenericDetail } from './GenericDetail.js';
+import { DataKeyRows } from './ConfigMapDetail.js';
+import { Fact, Facts } from './Facts.js';
 import { Section } from './Section.js';
 import { useSecretTls } from '../../api/queries.js';
+import { statusTextColor } from '../../theme.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const CN_RE = /(?:^|\n|,\s*)CN=([^\n,]+)/;
 const NEWLINE_RE = /\n/g;
 
-function expiryChip(cert: TlsCertInfo) {
+function CertExpiry({ cert }: { cert: TlsCertInfo }) {
   const expiresAt = Date.parse(cert.notAfter);
   const daysLeft = Math.floor((expiresAt - Date.now()) / DAY_MS);
-  if (daysLeft < 0) return <Chip label={`Expired ${-daysLeft}d ago`} color="error" />;
-  if (daysLeft < 30) return <Chip label={`Expires in ${daysLeft}d`} color="warning" />;
-  return <Chip label={`Expires in ${daysLeft}d`} color="success" variant="outlined" />;
+  const color = daysLeft < 0 ? 'error' : daysLeft < 30 ? 'warning' : 'success';
+  const text = daysLeft < 0 ? `Expired ${-daysLeft}d ago` : `Expires in ${daysLeft}d`;
+  return (
+    <Typography component="span" variant="caption" sx={{ fontWeight: 550, color: statusTextColor(color), whiteSpace: 'nowrap' }}>
+      {text}
+    </Typography>
+  );
 }
 
 /** Extract the CN from an X.509 subject/issuer string ("CN=foo\nO=bar"). */
@@ -35,18 +41,25 @@ export function SecretDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ px: 2, pt: 2, flexWrap: 'wrap' }}>
-        {typeof obj.type === 'string' && <Chip label={obj.type} variant="outlined" color="primary" />}
-        <Chip label={`${keys.length} key${keys.length === 1 ? '' : 's'}`} variant="outlined" />
-      </Stack>
+      <Box sx={{ px: 2, pt: 2 }}>
+        <Facts>
+          <Fact label="Type" mono>
+            {typeof obj.type === 'string' ? obj.type : undefined}
+          </Fact>
+          <Fact label="Keys">{keys.length}</Fact>
+          <Fact label="Immutable" hint="Immutable Secrets cannot be edited — only replaced.">
+            {obj.immutable === true && (
+              <Box component="span" sx={{ fontWeight: 550, color: statusTextColor('warning') }}>
+                Yes
+              </Box>
+            )}
+          </Fact>
+        </Facts>
+      </Box>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
         {keys.length > 0 && (
           <Section title="Data keys" count={keys.length}>
-            <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
-              {keys.map((k) => (
-                <Chip key={k} label={k} variant="outlined" />
-              ))}
-            </Stack>
+            <DataKeyRows rows={keys.map((k) => ({ key: k }))} />
             <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
               Values are redacted — reveal, copy or edit them per key in the Data tab.
             </Typography>
@@ -56,34 +69,28 @@ export function SecretDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
           (tls.data?.certificates ?? []).map((cert, i) => (
             <Card key={`${cert.source ?? ''}:${cert.serialNumber || i}`} variant="outlined">
               <CardContent sx={{ '&:last-child': { pb: 2 } }}>
-                <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+                <Stack direction="row" sx={{ mb: 1, alignItems: 'baseline', gap: 1, flexWrap: 'wrap' }}>
                   <Typography variant="subtitle2">{commonName(cert.subject)}</Typography>
-                  {expiryChip(cert)}
-                  {cert.isCA && <Chip label="CA" variant="outlined" />}
-                  {cert.selfSigned && <Chip label="self-signed" variant="outlined" />}
-                  {cert.source && cert.source !== 'tls.crt' && <Chip label={cert.source} variant="outlined" color="secondary" />}
+                  <CertExpiry cert={cert} />
+                  {(cert.isCA || cert.selfSigned || (cert.source && cert.source !== 'tls.crt')) && (
+                    <Typography variant="caption" color="text.secondary">
+                      {[cert.isCA ? 'CA' : undefined, cert.selfSigned ? 'self-signed' : undefined, cert.source !== 'tls.crt' ? cert.source : undefined]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </Typography>
+                  )}
                 </Stack>
-                <Typography variant="body2" color="text.secondary">
-                  Issuer: {commonName(cert.issuer)}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Valid: {new Date(cert.notBefore).toLocaleDateString()} → {new Date(cert.notAfter).toLocaleDateString()}
-                </Typography>
-                {cert.publicKeyAlgorithm && (
-                  <Typography variant="body2" color="text.secondary">
-                    Algorithm: {cert.publicKeyAlgorithm}
-                  </Typography>
-                )}
-                <Typography variant="body2" color="text.secondary" sx={{ wordBreak: 'break-all' }}>
-                  Serial: {cert.serialNumber}
-                </Typography>
-                {cert.sans.length > 0 && (
-                  <Stack direction="row" sx={{ mt: 1, flexWrap: 'wrap', gap: 0.5 }}>
-                    {cert.sans.map((san) => (
-                      <Chip key={san} label={san} variant="outlined" sx={{ maxWidth: 360 }} title={san} />
-                    ))}
-                  </Stack>
-                )}
+                <Facts>
+                  <Fact label="Issuer">{commonName(cert.issuer)}</Fact>
+                  <Fact label="Valid">{`${new Date(cert.notBefore).toLocaleDateString()} → ${new Date(cert.notAfter).toLocaleDateString()}`}</Fact>
+                  <Fact label="Algorithm">{cert.publicKeyAlgorithm}</Fact>
+                  <Fact label="Serial" mono>
+                    {cert.serialNumber}
+                  </Fact>
+                  <Fact label="SANs" mono>
+                    {cert.sans.length > 0 ? cert.sans.join(', ') : undefined}
+                  </Fact>
+                </Facts>
               </CardContent>
             </Card>
           ))}

--- a/client/src/components/detail/ServiceDetail.tsx
+++ b/client/src/components/detail/ServiceDetail.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
@@ -13,6 +12,7 @@ import Typography from '@mui/material/Typography';
 import CableIcon from '@mui/icons-material/Cable';
 import type { KubeObject } from '@kubus/shared';
 import { GenericDetail, KeyValueSection } from './GenericDetail.js';
+import { Fact, Facts } from './Facts.js';
 import { PodMiniList } from './PodMiniList.js';
 import { PortForwardDialog } from '../PortForwardDialog.js';
 import { Section } from './Section.js';
@@ -22,6 +22,9 @@ interface ServiceSpec {
   type?: string;
   clusterIP?: string;
   externalIPs?: string[];
+  externalName?: string;
+  sessionAffinity?: string;
+  externalTrafficPolicy?: string;
   selector?: Record<string, string>;
   ports?: Array<{ name?: string; port: number; targetPort?: number | string; nodePort?: number; protocol?: string }>;
 }
@@ -48,16 +51,25 @@ export function ServiceDetail({ obj, ctx }: { obj: KubeObject; ctx: string }) {
 
   return (
     <Box>
-      <Stack direction="row" spacing={1} sx={{ px: 2, pt: 2, flexWrap: 'wrap' }}>
-        {spec.type && <Chip label={spec.type} variant="outlined" color="primary" />}
-        {spec.clusterIP && <Chip label={`ClusterIP ${spec.clusterIP}`} variant="outlined" />}
-        {(spec.externalIPs ?? []).map((ip) => (
-          <Chip key={ip} label={`External ${ip}`} variant="outlined" />
-        ))}
-        {lbAddresses.map((addr) => (
-          <Chip key={addr} label={`LB ${addr}`} variant="outlined" />
-        ))}
-      </Stack>
+      <Box sx={{ px: 2, pt: 2 }}>
+        <Facts>
+          <Fact label="Type">{spec.type}</Fact>
+          <Fact label="Cluster IP" mono>
+            {spec.clusterIP}
+          </Fact>
+          <Fact label="External name" mono>
+            {spec.externalName}
+          </Fact>
+          <Fact label="External IPs" mono>
+            {(spec.externalIPs ?? []).join(', ')}
+          </Fact>
+          <Fact label="Load balancer" mono>
+            {lbAddresses.join(', ')}
+          </Fact>
+          <Fact label="Session affinity">{spec.sessionAffinity !== 'None' ? spec.sessionAffinity : undefined}</Fact>
+          <Fact label="Traffic policy">{spec.externalTrafficPolicy}</Fact>
+        </Facts>
+      </Box>
       <Stack spacing={2} sx={{ px: 2, pt: 2 }}>
         {!!spec.ports?.length && (
           <Section title="Ports" count={spec.ports.length}>

--- a/client/src/kube-display.ts
+++ b/client/src/kube-display.ts
@@ -271,7 +271,9 @@ export function runningContainerNames(pod: KubeObject): string[] {
  * when no status is available yet.
  */
 export function execTargetContainer(pod: KubeObject): string {
-  return runningContainerNames(pod)[0] ?? podContainerNames(pod)[0] ?? '';
+  const running = runningContainerNames(pod)[0];
+  if (running) return running;
+  return pod.status === undefined ? (podContainerNames(pod)[0] ?? '') : '';
 }
 
 export interface DebugContainerInfo {

--- a/client/src/kube-display.ts
+++ b/client/src/kube-display.ts
@@ -256,6 +256,24 @@ export function podContainerNames(pod: KubeObject): string[] {
   return [...(spec?.containers ?? []), ...(spec?.initContainers ?? [])].map((c) => c.name);
 }
 
+/** Containers of a pod with a live process — the ones exec can attach to. */
+export function runningContainerNames(pod: KubeObject): string[] {
+  const status = pod.status as
+    | { containerStatuses?: Array<{ name: string; state?: { running?: unknown } }>; initContainerStatuses?: Array<{ name: string; state?: { running?: unknown } }> }
+    | undefined;
+  return [...(status?.containerStatuses ?? []), ...(status?.initContainerStatuses ?? [])].filter((c) => c.state?.running).map((c) => c.name);
+}
+
+/**
+ * Container a pod-level shell should attach to: the first one actually
+ * running, since exec needs a live process — `containers[0]` may be the very
+ * container that is crashlooping. Falls back to the first declared container
+ * when no status is available yet.
+ */
+export function execTargetContainer(pod: KubeObject): string {
+  return runningContainerNames(pod)[0] ?? podContainerNames(pod)[0] ?? '';
+}
+
 export interface DebugContainerInfo {
   name: string;
   image?: string;

--- a/tests/e2e/specs/pod-detail.spec.ts
+++ b/tests/e2e/specs/pod-detail.spec.ts
@@ -14,7 +14,9 @@ test('pod detail drawer opens from a row click and deep-links via ?sel=', async 
   );
 
   // Live pod facts from the cluster.
-  await expect(page.getByText('Ready 1/1')).toBeVisible();
+  const readyLabel = page.locator('.MuiDrawer-paper').getByText('Ready', { exact: true }).first();
+  await expect(readyLabel).toBeVisible();
+  await expect(readyLabel.locator('xpath=following-sibling::*[1]')).toHaveText('1/1');
   await expect(page.getByText('busybox:1.37')).toBeVisible();
 });
 

--- a/tests/unit/client/deployment-detail.test.tsx
+++ b/tests/unit/client/deployment-detail.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { KubeObject } from '@kubus/shared';
+import { DeploymentDetail } from '../../../client/src/components/detail/DeploymentDetail';
+import { useDockStore } from '../../../client/src/state/dock';
+import { useDetailStore } from '../../../client/src/state/detail';
+
+const queries = vi.hoisted(() => ({
+  replicaSets: [] as KubeObject[],
+  pods: [] as KubeObject[],
+  metrics: undefined as Map<string, unknown> | undefined,
+}));
+
+const effects = vi.hoisted(() => ({ toast: vi.fn() }));
+
+vi.mock('../../../client/src/api/queries.js', () => ({
+  useResourceList: (selection: { plural?: string } | undefined) => ({
+    data: !selection ? undefined : { items: selection.plural === 'replicasets' ? queries.replicaSets : queries.pods },
+    isLoading: false,
+  }),
+  useResourceMetrics: () => ({ data: queries.metrics }),
+}));
+vi.mock('../../../client/src/state/toast.js', () => ({ showToast: effects.toast }));
+vi.mock('../../../client/src/components/PortForwardDialog.js', () => ({ PortForwardDialog: () => <div>Forward dialog</div> }));
+vi.mock('../../../client/src/components/RowActions.js', () => ({ SetImageDialog: () => <div>Set image dialog</div> }));
+
+function deployment(): KubeObject {
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: { name: 'web', namespace: 'team-a', uid: 'deploy-uid', labels: {}, annotations: {} },
+    spec: {
+      replicas: 2,
+      selector: { matchLabels: { app: 'web' } },
+      strategy: { type: 'RollingUpdate', rollingUpdate: { maxUnavailable: 1, maxSurge: '25%' } },
+      template: { spec: { containers: [{ name: 'app' }, { name: 'broken' }] } },
+    },
+    status: { readyReplicas: 1, updatedReplicas: 2, availableReplicas: 1, unavailableReplicas: 1 },
+  } as KubeObject;
+}
+
+function pod(name: string, running: string[]): KubeObject {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name, namespace: 'team-a', uid: `uid-${name}`, ownerReferences: [{ kind: 'ReplicaSet', uid: 'rs-uid', controller: true, name: 'web-1' }] },
+    spec: { containers: [{ name: 'app' }, { name: 'broken' }] },
+    status: {
+      phase: 'Running',
+      containerStatuses: ['app', 'broken'].map((name) => ({
+        name,
+        ready: running.includes(name),
+        state: running.includes(name) ? { running: {} } : { waiting: { reason: 'CrashLoopBackOff' } },
+      })),
+    },
+  } as unknown as KubeObject;
+}
+
+beforeEach(() => {
+  queries.replicaSets = [
+    { apiVersion: 'apps/v1', kind: 'ReplicaSet', metadata: { name: 'web-1', namespace: 'team-a', uid: 'rs-uid', ownerReferences: [{ kind: 'Deployment', uid: 'deploy-uid', controller: true, name: 'web' }] } } as KubeObject,
+  ];
+  // The first pod never got `app` running, so a shell must land in the second.
+  queries.pods = [pod('web-aaa', ['broken']), pod('web-bbb', ['app', 'broken'])];
+  queries.metrics = undefined;
+  effects.toast.mockClear();
+  useDockStore.setState({ tabs: [], activeId: undefined, open: false, maximized: false });
+  useDetailStore.setState({ stack: [], embedded: false, collapsed: false, width: 640, focusSeq: 0, dataDirty: false, pendingDiscard: undefined });
+});
+
+describe('DeploymentDetail', () => {
+  it('summarizes rollout facts without chips', () => {
+    render(<DeploymentDetail obj={deployment()} ctx="dev" />);
+
+    expect(screen.getByText('2 updated · 1 available · 1 unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/RollingUpdate/)).toBeInTheDocument();
+    expect(screen.getByText(/max unavailable 1 · max surge 25%/)).toBeInTheDocument();
+    expect(screen.getByText('app=web')).toBeInTheDocument();
+    // Ready fact for the Deployment, plus one per pod row.
+    expect(screen.getAllByText('1/2').length).toBeGreaterThan(1);
+  });
+
+  it('streams one container across every pod and shells into a pod running it', () => {
+    render(<DeploymentDetail obj={deployment()} ctx="dev" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logs for container app' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({
+      kind: 'logs',
+      title: 'logs: web/app',
+      container: 'app',
+      pods: ['web-aaa', 'web-bbb'],
+      target: { kind: 'Deployment', name: 'web' },
+    });
+
+    // web-aaa's `app` is crashlooping, so the shell has to pick web-bbb.
+    fireEvent.click(screen.getByRole('button', { name: 'Shell into container app' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({
+      kind: 'terminal',
+      title: 'sh: web-bbb/app',
+      pod: 'web-bbb',
+      container: 'app',
+    });
+  });
+
+  it('offers no shell for a container no pod is running', () => {
+    queries.pods = [pod('web-aaa', ['app'])];
+    render(<DeploymentDetail obj={deployment()} ctx="dev" />);
+
+    expect(screen.getByRole('button', { name: 'Shell into container app' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Shell into container broken' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Logs for container broken' })).toBeInTheDocument();
+  });
+
+  it('reports when a container has no pods to stream at all', () => {
+    queries.pods = [];
+    render(<DeploymentDetail obj={deployment()} ctx="dev" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logs for container app' }));
+    expect(effects.toast).toHaveBeenCalledWith('error', expect.stringContaining('No running pods'));
+    expect(useDockStore.getState().tabs).toHaveLength(0);
+  });
+});

--- a/tests/unit/client/kube-display.test.ts
+++ b/tests/unit/client/kube-display.test.ts
@@ -166,6 +166,24 @@ describe('execTargetContainer', () => {
     expect(execTargetContainer(kobj({ spec }))).toBe('app');
     expect(execTargetContainer(kobj({}))).toBe('');
   });
+
+  it('does not fall back when status has loaded without a running container', () => {
+    expect(
+      execTargetContainer(
+        kobj({
+          spec,
+          status: {
+            phase: 'Succeeded',
+            containerStatuses: [
+              { name: 'app', state: { terminated: {} } },
+              { name: 'sidecar', state: { terminated: {} } },
+            ],
+          },
+        }),
+      ),
+    ).toBe('');
+    expect(execTargetContainer(kobj({ spec, status: {} }))).toBe('');
+  });
 });
 
 describe('workloadReady', () => {

--- a/tests/unit/client/kube-display.test.ts
+++ b/tests/unit/client/kube-display.test.ts
@@ -1,6 +1,7 @@
 import type { KubeObject } from '@kubus/shared';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  execTargetContainer,
   hpaProblems,
   ingressHosts,
   jobPhase,
@@ -131,6 +132,39 @@ describe('podSummary', () => {
   it('caches per object identity', () => {
     const pod = kobj({ status: { phase: 'Running' } });
     expect(podSummary(pod)).toBe(podSummary(pod));
+  });
+});
+
+describe('execTargetContainer', () => {
+  const spec = { containers: [{ name: 'app' }, { name: 'sidecar' }], initContainers: [{ name: 'setup' }] };
+
+  it('skips a crashlooping first container for one that is running', () => {
+    const pod = kobj({
+      spec,
+      status: {
+        containerStatuses: [
+          { name: 'app', state: { waiting: { reason: 'CrashLoopBackOff' } } },
+          { name: 'sidecar', state: { running: {} } },
+        ],
+      },
+    });
+    expect(execTargetContainer(pod)).toBe('sidecar');
+  });
+
+  it('accepts a running sidecar from the init statuses', () => {
+    const pod = kobj({
+      spec,
+      status: {
+        containerStatuses: [{ name: 'app', state: { terminated: {} } }],
+        initContainerStatuses: [{ name: 'setup', state: { running: {} } }],
+      },
+    });
+    expect(execTargetContainer(pod)).toBe('setup');
+  });
+
+  it('falls back to the first declared container without status', () => {
+    expect(execTargetContainer(kobj({ spec }))).toBe('app');
+    expect(execTargetContainer(kobj({}))).toBe('');
   });
 });
 

--- a/tests/unit/client/pod-detail.test.tsx
+++ b/tests/unit/client/pod-detail.test.tsx
@@ -255,8 +255,8 @@ describe('PodDetail', () => {
     expect(screen.getAllByText('Ready').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Pending').length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByText('Node node-a'));
-    fireEvent.click(screen.getByText('SA workload-sa'));
+    fireEvent.click(screen.getByRole('button', { name: 'node-a' }));
+    fireEvent.click(screen.getByRole('button', { name: 'workload-sa' }));
     fireEvent.click(screen.getByRole('button', { name: 'configmap/app-config → feature' }));
     fireEvent.click(screen.getByRole('button', { name: 'persistentVolumeClaim/data-pvc' }));
     expect(useDetailStore.getState().stack.map((selection) => selection.kind)).toEqual([
@@ -279,6 +279,31 @@ describe('PodDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close forward' }));
     expect(screen.queryByText('Forward 8080')).not.toBeInTheDocument();
   }, 15_000);
+
+  it('opens logs and a shell scoped to a single container', () => {
+    render(<PodDetail obj={richPod()} ctx="dev" />);
+
+    // Only the running container can be exec'd into; the crashlooping one and
+    // the finished init container still expose their logs.
+    expect(screen.getByRole('button', { name: 'Shell into container app' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Shell into container worker' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Shell into container migrate' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logs for container worker' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({
+      kind: 'logs',
+      title: 'logs: web-0/worker',
+      namespace: 'team-a',
+      pods: ['web-0'],
+      container: 'worker',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Logs for container migrate' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({ kind: 'logs', container: 'migrate' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Shell into container app' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({ kind: 'terminal', pod: 'web-0', container: 'app' });
+  });
 
   it('handles unavailable metrics, loading and empty environment data, and stop failures', () => {
     queries.metrics = new Map([['dev', { available: false, items: [] }]]);

--- a/tests/unit/client/resource-detail-drawer.test.tsx
+++ b/tests/unit/client/resource-detail-drawer.test.tsx
@@ -112,8 +112,7 @@ vi.mock('../../../client/src/components/detail/RolloutHistory.js', () => ({ Roll
 vi.mock('../../../client/src/components/MetricsChart.js', () => ({ MetricsChart: ({ kind, name }: { kind: string; name: string }) => <div>Metrics {kind} {name}</div> }));
 vi.mock('../../../client/src/components/TopologyGraph.js', () => ({ TopologyGraph: ({ focus }: { focus: { name: string } }) => <div>Topology {focus.name}</div> }));
 vi.mock('../../../client/src/components/RowActions.js', () => ({
-  RowLogsButton: ({ target }: { target: { obj: KubeObject } }) => <button>Logs {target.obj.metadata.name}</button>,
-  RowActions: ({ target }: { target: { obj: KubeObject } }) => <button>Actions {target.obj.metadata.name}</button>,
+  DetailQuickActions: ({ target }: { target: { obj: KubeObject } }) => <button>Quick actions {target.obj.metadata.name}</button>,
 }));
 vi.mock('../../../client/src/components/AgeCell.js', () => ({ AgeCell: ({ timestamp }: { timestamp?: string }) => <span>{timestamp ? 'age' : 'unknown age'}</span> }));
 vi.mock('../../../client/src/components/truncation.js', () => ({ TruncationTooltip: ({ children }: { children: ReactNode }) => <>{children}</> }));

--- a/tests/unit/client/row-actions.test.tsx
+++ b/tests/unit/client/row-actions.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { KubeObject } from '@kubus/shared';
 import {
+  DetailQuickActions,
   isLogTargetKind,
   RowActionMenu,
   RowActions,
@@ -207,10 +208,14 @@ describe('row action helpers', () => {
 });
 
 describe('pod actions', () => {
-  const pod = target('Pod', {
-    containers: [{ name: 'app', ports: [{ containerPort: 8080, name: 'http' }] }],
-    initContainers: [{ name: 'setup' }],
-  });
+  const pod = target(
+    'Pod',
+    {
+      containers: [{ name: 'app', ports: [{ containerPort: 8080, name: 'http' }] }],
+      initContainers: [{ name: 'setup' }],
+    },
+    { status: { containerStatuses: [{ name: 'app', state: { running: {} } }] } },
+  );
 
   it('opens logs, a shell, files, debug, and port-forward flows', async () => {
     let view = clickMenuAction(pod, 'Logs');
@@ -243,6 +248,59 @@ describe('pod actions', () => {
     fireEvent.click(screen.getByLabelText('Open in browser when started'));
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     expect(queryMocks.startPort.mutate).toHaveBeenCalled();
+    view.unmount();
+  });
+
+  it('hides shell actions when status has loaded without a running container', () => {
+    const completed = target(
+      'Pod',
+      { containers: [{ name: 'app' }] },
+      { status: { phase: 'Succeeded', containerStatuses: [{ name: 'app', state: { terminated: {} } }] } },
+    );
+
+    let view = render(
+      <MemoryRouter>
+        <DetailQuickActions target={completed} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('button', { name: 'Shell' })).not.toBeInTheDocument();
+    view.unmount();
+
+    view = renderMenu(completed);
+    expect(screen.queryByRole('menuitem', { name: 'Shell' })).not.toBeInTheDocument();
+    view.unmount();
+  });
+
+  it('keeps shell available before status arrives and targets a running sidecar once it does', () => {
+    const pendingStatus = target('Pod', { containers: [{ name: 'app' }] }, { status: undefined });
+    let view = render(
+      <MemoryRouter>
+        <DetailQuickActions target={pendingStatus} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Shell' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({ kind: 'terminal', container: 'app' });
+    view.unmount();
+
+    const sidecarRunning = target(
+      'Pod',
+      { containers: [{ name: 'app' }, { name: 'sidecar' }] },
+      {
+        status: {
+          containerStatuses: [
+            { name: 'app', state: { waiting: { reason: 'CrashLoopBackOff' } } },
+            { name: 'sidecar', state: { running: {} } },
+          ],
+        },
+      },
+    );
+    view = render(
+      <MemoryRouter>
+        <DetailQuickActions target={sidecarRunning} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Shell' }));
+    expect(useDockStore.getState().tabs.at(-1)).toMatchObject({ kind: 'terminal', container: 'sidecar' });
     view.unmount();
   });
 


### PR DESCRIPTION
Reworks the resource detail panel so the operations people open a resource for are one click away, and the summary reads as data rather than a row of chips.

## Quick-action bar

A labeled action bar sits under the panel header, above the tabs, so it stays available on every tab:

| Kind | Actions |
| --- | --- |
| Pod | Shell · Logs · Forward |
| Deployment / StatefulSet / DaemonSet | Logs · Forward · Scale · Restart |
| Node | Shell · Cordon |
| CronJob | Trigger · Suspend |
| Job | Logs · Re-run |

The overflow menu keeps every other action, Delete included.

## Fact rows instead of chip strips

A new shared `Facts` / `Fact` primitive renders the per-kind summary as label→value rows. Along the way it picks up detail that was missing and collapses the three copy-pasted label/value table patterns into one:

- **Pod** — adds Host IP and a link to the controlling ReplicaSet/Job, plus a QoS explainer tooltip
- **Deployment** — adds the replica breakdown (updated / available / unavailable) and the selector
- **Node** — adds the kernel version

Chips are dropped where they were only decorating data: condition chips (conditions already have their own sections), ConfigMap/Secret data keys (now key/size rows), and TLS certificate attributes. They remain for genuine tags — labels, annotations, selectors and the clickable port-forward ports.

## Per-container actions

Container cards gain Logs and Shell buttons:

- **Logs** open a container-scoped stream. The other containers are not filtered away, they just start unselected in the picker.
- **Shell** attaches to that container directly. On a Deployment the card resolves a pod that is actually running the container and names it in the tab title, so it is never ambiguous which replica you landed in.
- A shell is only offered where a live process exists — a crashlooping container still offers its logs, which is where its output is.

## Fix

The pod-level shell targeted `containers[0]` unconditionally, so on a pod whose first container is crashlooping but which has a healthy sidecar, exec would fail. It now targets the first running container (`execTargetContainer`), falling back to the first declared one when status has not loaded yet, so the grid row menu keeps working.

## Header

The resource status shows next to the kind, and the name has a copy button.

## Testing

- 896 unit tests pass, including a new `deployment-detail.test.tsx` covering container-scoped logs, pod selection for the shell, and the no-running-pods cases, plus new coverage for `execTargetContainer` and the per-container pod actions.
- `pnpm typecheck` and `pnpm lint` clean.
- Driven manually against kind clusters in light and dark mode across Pod, Deployment, Service, Node, ConfigMap and Secret — including opening a container-scoped log stream and a shell from a Deployment card.