### PR TITLE
Improve terminal dock shortcuts

### DIFF
--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -6,7 +6,7 @@ const TerminalPaneImpl = lazy(() => import('./TerminalPaneImpl.js'));
 
 const terminalLoading = <Box sx={{ height: '100%', bgcolor: '#16161e' }} />;
 
-export function TerminalPane(props: { tab: TerminalTab | NodeShellTab; active: boolean }) {
+export function TerminalPane(props: { tab: TerminalTab | NodeShellTab; active: boolean; focusRequest: number }) {
   return (
     <Suspense fallback={terminalLoading}>
       <TerminalPaneImpl {...props} />

--- a/client/src/components/TerminalPaneImpl.tsx
+++ b/client/src/components/TerminalPaneImpl.tsx
@@ -8,13 +8,16 @@ import type { ExecServerControl } from '@kubus/shared';
 import { wsUrl } from '../api/http.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
 import type { NodeShellTab, TerminalTab } from '../state/dock.js';
+import { useDockStore } from '../state/dock.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { showToast } from '../state/toast.js';
 
-export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | NodeShellTab; active: boolean }) {
+export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: TerminalTab | NodeShellTab; active: boolean; focusRequest: number }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const termRef = useRef<Terminal | null>(null);
+  const activeRef = useRef(active);
+  activeRef.current = active;
   const theme = useTheme();
 
   // Right-click copies the selection when there is one, otherwise pastes —
@@ -100,7 +103,11 @@ export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | N
       if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ op: 'resize', cols, rows }));
     });
 
-    const observer = new ResizeObserver(() => fit.fit());
+    // Inactive tabs and a collapsed dock have zero height. Ignore those
+    // resize notifications so the remote PTY keeps its last usable size.
+    const observer = new ResizeObserver(() => {
+      if (activeRef.current) fit.fit();
+    });
     observer.observe(el);
 
     return () => {
@@ -118,6 +125,18 @@ export default function TerminalPaneImpl({ tab, active }: { tab: TerminalTab | N
   useEffect(() => {
     if (active) requestAnimationFrame(() => fitRef.current?.fit());
   }, [active]);
+
+  useEffect(() => {
+    if (!focusRequest) return;
+    const frame = requestAnimationFrame(() => {
+      const dock = useDockStore.getState();
+      if (dock.open && dock.activeId === tab.id) {
+        fitRef.current?.fit();
+        termRef.current?.focus();
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [focusRequest, tab.id]);
 
   return (
     <Box sx={{ height: '100%', p: 1, pt: 0.75 }}>

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -112,7 +112,13 @@ export function AppShell() {
           <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
             <TabPanes />
           </Box>
-          <Box ref={dockRef} style={{ height: dockOpen ? (maximized ? '100%' : dockHeight) : 0 }} sx={{ flexShrink: 0, transition: 'height 120ms ease' }}>
+          <Box
+            ref={dockRef}
+            aria-hidden={!dockOpen}
+            inert={dockOpen ? undefined : true}
+            style={{ height: dockOpen ? (maximized ? '100%' : dockHeight) : 0 }}
+            sx={{ flexShrink: 0, overflow: 'hidden', transition: 'height 120ms ease' }}
+          >
             <BottomDock containerRef={dockRef} />
           </Box>
         </Box>

--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -24,10 +24,13 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
   const setHeight = useDockStore((s) => s.setHeight);
   const maximized = useDockStore((s) => s.maximized);
   const setMaximized = useDockStore((s) => s.setMaximized);
+  const terminalFocusRequest = useDockStore((s) => s.terminalFocusRequest);
 
   // Escape restores a maximized dock via the global dismiss chain in
   // GlobalShortcuts — guarded there so a focused terminal keeps its Escape.
-  if (!open || tabs.length === 0) return null;
+  // Keep existing tabs mounted while collapsed. In particular, an exec
+  // terminal's WebSocket and remote shell must survive hiding the dock.
+  if (tabs.length === 0) return null;
 
   // Resize by writing the container height directly to the DOM (one write per
   // frame), keeping React out of the drag loop; the store is committed once on
@@ -63,7 +66,18 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
   };
 
   return (
-    <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', borderTop: 1, borderColor: 'divider', bgcolor: 'background.paper' }}>
+    <Box
+      className="kubus-bottom-dock"
+      sx={{
+        height: '100%',
+        display: 'flex',
+        visibility: open ? 'visible' : 'hidden',
+        flexDirection: 'column',
+        borderTop: 1,
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+      }}
+    >
       {!maximized && (
         <Box
           onMouseDown={startResize}
@@ -129,7 +143,15 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
         {tabs.map((tab) => (
           <Box key={tab.id} sx={{ position: 'absolute', inset: 0, display: tab.id === activeId ? 'block' : 'none' }}>
-            {tab.kind === 'terminal' || tab.kind === 'node-shell' ? <TerminalPane tab={tab} active={tab.id === activeId} /> : <LogViewer tab={tab} />}
+            {tab.kind === 'terminal' || tab.kind === 'node-shell' ? (
+              <TerminalPane
+                tab={tab}
+                active={open && tab.id === activeId}
+                focusRequest={terminalFocusRequest?.tabId === tab.id ? terminalFocusRequest.sequence : 0}
+              />
+            ) : open ? (
+              <LogViewer tab={tab} />
+            ) : null}
           </Box>
         ))}
       </Box>

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -238,7 +238,6 @@ export function GlobalShortcuts() {
           return;
         }
         if (key === 'j') {
-          if (e.repeat) return;
           const eventTarget = e.target instanceof HTMLElement ? e.target : null;
           // Text fields and modal surfaces keep their normal keyboard
           // behavior. xterm is the exception: Cmd/Ctrl+J must be able to hide
@@ -253,6 +252,15 @@ export function GlobalShortcuts() {
           const dock = useDockStore.getState();
           const activeTab = dock.tabs.find((tab) => tab.id === dock.activeId);
           if (!activeTab) return;
+
+          // A held shortcut repeats after focus may already have moved into
+          // xterm. Consume the repeat completely so it cannot become shell
+          // input or trigger Chromium's default Ctrl+J action.
+          if (e.repeat) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
 
           e.preventDefault();
           if (isTerminalTab(activeTab)) {

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -6,7 +6,7 @@ import { NAV_OVERLAY_MEDIA_QUERY, useNavUiStore } from './state/nav-ui.js';
 import { useUiPrefsStore } from './state/prefs.js';
 import { useUiStore } from './state/ui.js';
 import { useTabsStore } from './state/tabs.js';
-import { useDockStore } from './state/dock.js';
+import { useDockStore, type DockTab } from './state/dock.js';
 import { useDetailStore } from './state/detail.js';
 
 /** How long a pending `g` waits for its second key (the which-key panel shows meanwhile). */
@@ -56,6 +56,10 @@ export interface ShortcutRowDef {
 
 const MOD = MOD_KEY_LABEL;
 
+function isTerminalTab(tab: DockTab | undefined): boolean {
+  return tab?.kind === 'terminal' || tab?.kind === 'node-shell';
+}
+
 /** Single source of truth for the cheatsheet — every binding below is wired here or next to its owner. */
 export const SHORTCUT_SECTIONS: Array<{ title: string; shortcuts: ShortcutRowDef[] }> = [
   {
@@ -64,7 +68,8 @@ export const SHORTCUT_SECTIONS: Array<{ title: string; shortcuts: ShortcutRowDef
       { combos: [[MOD, 'K']], description: 'Command palette (toggle)' },
       { combos: [['?']], description: 'Keyboard shortcuts (this dialog)' },
       { combos: [[MOD, 'B']], description: 'Toggle the navigation rail' },
-      { combos: [[MOD, 'J']], description: 'Toggle the terminal / logs dock' },
+      { combos: [[MOD, 'J']], description: 'Focus / hide the terminal · toggle the logs dock' },
+      { combos: [['Alt', 'J']], description: 'Focus the terminal' },
       { combos: [[MOD, ',']], description: 'Open settings' },
       { combos: [[MOD, '1–9']], description: 'Open pinned favorite 1–9' },
       { combos: [['Esc']], description: 'Close dialogs & menus · close the details panel · restore a maximized dock' },
@@ -162,6 +167,11 @@ export function GlobalShortcuts() {
   navRef.current = navigate;
 
   useEffect(() => {
+    // Where focus should return when Cmd/Ctrl+J hides the terminal. Kept
+    // outside React state because it is transient interaction state and must
+    // not trigger a render on every focus handoff.
+    let terminalReturnFocus: HTMLElement | null = null;
+
     // After any tab-store mutation, land the router on the (new) active tab —
     // the same store→router sync TabsBar does for its mouse interactions.
     // Compare against window.location, not useLocation: navigate() is
@@ -227,11 +237,41 @@ export function GlobalShortcuts() {
           toggleNavRail();
           return;
         }
-        // Guarded: in a shell Ctrl+J is a real control character (linefeed).
-        if (key === 'j' && !isTextEntryTarget(e.target)) {
-          e.preventDefault();
+        if (key === 'j') {
+          if (e.repeat) return;
+          const eventTarget = e.target instanceof HTMLElement ? e.target : null;
+          // Text fields and modal surfaces keep their normal keyboard
+          // behavior. xterm is the exception: Cmd/Ctrl+J must be able to hide
+          // the dock after the shortcut handed focus to the shell.
+          if (
+            (isTextEntryTarget(eventTarget) && !eventTarget?.closest('.xterm')) ||
+            eventTarget?.closest('[role="dialog"], [role="menu"], [role="listbox"]')
+          ) {
+            return;
+          }
+
           const dock = useDockStore.getState();
-          if (dock.tabs.length) dock.setOpen(!dock.open);
+          const activeTab = dock.tabs.find((tab) => tab.id === dock.activeId);
+          if (!activeTab) return;
+
+          e.preventDefault();
+          if (isTerminalTab(activeTab)) {
+            const terminalOwnsFocus = dock.open && !!eventTarget?.closest('.xterm');
+            if (terminalOwnsFocus) {
+              const fallback = document.querySelector<HTMLElement>('main');
+              const returnTarget = terminalReturnFocus?.isConnected ? terminalReturnFocus : fallback;
+              returnTarget?.focus({ preventScroll: true });
+              dock.setOpen(false);
+            } else {
+              const activeElement = document.activeElement;
+              if (activeElement instanceof HTMLElement && !activeElement.closest('.kubus-bottom-dock')) {
+                terminalReturnFocus = activeElement;
+              }
+              dock.requestTerminalFocus(activeTab.id);
+            }
+          } else {
+            dock.setOpen(!dock.open);
+          }
           return;
         }
         if (e.key === ',' && !isTextEntryTarget(e.target)) {
@@ -245,6 +285,24 @@ export function GlobalShortcuts() {
       // ctrl+alt on Windows), and never while a terminal/editor owns Alt
       // sequences (Alt+digit is an escape sequence in shells).
       if (e.altKey && !e.ctrlKey && !e.metaKey && !isEditorOrTerminalTarget(e.target)) {
+        if (!e.shiftKey && e.code === 'KeyJ') {
+          if (e.repeat) return;
+          const eventTarget = e.target instanceof HTMLElement ? e.target : null;
+          if (eventTarget?.closest('[role="dialog"], [role="menu"], [role="listbox"]')) return;
+
+          const dock = useDockStore.getState();
+          const activeTab = dock.tabs.find((tab) => tab.id === dock.activeId);
+          const terminal = isTerminalTab(activeTab) ? activeTab : dock.tabs.findLast(isTerminalTab);
+          if (!terminal) return;
+
+          e.preventDefault();
+          const activeElement = document.activeElement;
+          if (activeElement instanceof HTMLElement && !activeElement.closest('.kubus-bottom-dock')) {
+            terminalReturnFocus = activeElement;
+          }
+          dock.requestTerminalFocus(terminal.id);
+          return;
+        }
         const digit = e.shiftKey ? undefined : /^Digit([1-9])$/.exec(e.code)?.[1];
         if (digit) {
           e.preventDefault();

--- a/client/src/state/dock.ts
+++ b/client/src/state/dock.ts
@@ -44,12 +44,14 @@ interface DockState {
   open: boolean;
   height: number;
   maximized: boolean;
+  terminalFocusRequest?: { tabId: string; sequence: number };
   addTab: (tab: DockTab) => void;
   closeTab: (id: string) => void;
   setActive: (id: string) => void;
   setOpen: (open: boolean) => void;
   setHeight: (height: number) => void;
   setMaximized: (maximized: boolean) => void;
+  requestTerminalFocus: (id: string) => void;
 }
 
 let counter = 0;
@@ -67,6 +69,7 @@ export const useDockStore = create<DockState>((set) => ({
   open: false,
   height: 320,
   maximized: false,
+  terminalFocusRequest: undefined,
   addTab: (tab) => {
     // The detail drawer is modal and would cover the dock — close it so the
     // freshly opened terminal/log tab is actually visible.
@@ -81,10 +84,24 @@ export const useDockStore = create<DockState>((set) => ({
         activeId: s.activeId === id ? tabs[tabs.length - 1]?.id : s.activeId,
         open: tabs.length > 0 ? s.open : false,
         maximized: tabs.length > 0 ? s.maximized : false,
+        terminalFocusRequest: s.terminalFocusRequest?.tabId === id ? undefined : s.terminalFocusRequest,
       };
     }),
   setActive: (id) => set({ activeId: id, open: true }),
   setOpen: (open) => set(open ? { open } : { open, maximized: false }),
   setHeight: (height) => set({ height: clampDockHeight(height) }),
   setMaximized: (maximized) => set({ maximized }),
+  requestTerminalFocus: (id) =>
+    set((s) => {
+      const tab = s.tabs.find((candidate) => candidate.id === id);
+      if (tab?.kind !== 'terminal' && tab?.kind !== 'node-shell') return s;
+      return {
+        activeId: id,
+        open: true,
+        terminalFocusRequest: {
+          tabId: id,
+          sequence: (s.terminalFocusRequest?.sequence ?? 0) + 1,
+        },
+      };
+    }),
 }));

--- a/tests/e2e/specs/shortcuts.spec.ts
+++ b/tests/e2e/specs/shortcuts.spec.ts
@@ -30,3 +30,53 @@ test('g-sequences jump between pages', async ({ page }) => {
   await page.keyboard.press('o');
   await expect(page).toHaveURL(/\/$/);
 });
+
+test('alt+j focuses and mod+j toggles an existing terminal without closing its session', async ({ page }) => {
+  let execSocketCount = 0;
+  let execSocketClosed = false;
+  page.on('websocket', (socket) => {
+    if (!socket.url().includes('/ws/exec?')) return;
+    execSocketCount += 1;
+    socket.on('close', () => {
+      execSocketClosed = true;
+    });
+  });
+
+  await gotoApp(page, '/r/core/v1/pods');
+  const row = page.getByRole('row').filter({ hasText: 'logger' }).filter({ hasText: 'kubus-e2e' }).first();
+  await expect(row).toBeVisible({ timeout: 20_000 });
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Shell' }).click();
+
+  const terminal = page.locator('.xterm');
+  const terminalInput = page.locator('.xterm-helper-textarea');
+  await expect(terminal).toBeVisible({ timeout: 20_000 });
+  await expect.poll(() => execSocketCount).toBe(1);
+
+  const searchButton = page.getByRole('button', { name: 'Search' });
+  await searchButton.focus();
+  await page.keyboard.press('Alt+j');
+  await expect(terminalInput).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+j');
+  await expect(searchButton).toBeFocused();
+  await expect(terminal).toBeHidden();
+  // The terminal stays mounted and its exec connection remains alive while
+  // the dock is collapsed.
+  await expect(terminal).toHaveCount(1);
+  await page.waitForTimeout(300);
+  expect(execSocketClosed).toBe(false);
+
+  await page.keyboard.press('ControlOrMeta+j');
+  await expect(terminal).toBeVisible();
+  await expect(terminalInput).toBeFocused();
+  await page.keyboard.press('ControlOrMeta+j');
+  await expect(searchButton).toBeFocused();
+  await expect(terminal).toBeHidden();
+
+  await page.keyboard.press('Alt+j');
+  await expect(terminal).toBeVisible();
+  await expect(terminalInput).toBeFocused();
+  expect(execSocketCount).toBe(1);
+  expect(execSocketClosed).toBe(false);
+});

--- a/tests/e2e/specs/shortcuts.spec.ts
+++ b/tests/e2e/specs/shortcuts.spec.ts
@@ -34,9 +34,13 @@ test('g-sequences jump between pages', async ({ page }) => {
 test('alt+j focuses and mod+j toggles an existing terminal without closing its session', async ({ page }) => {
   let execSocketCount = 0;
   let execSocketClosed = false;
+  let terminalDataFrameCount = 0;
   page.on('websocket', (socket) => {
     if (!socket.url().includes('/ws/exec?')) return;
     execSocketCount += 1;
+    socket.on('framesent', ({ payload }) => {
+      if (typeof payload !== 'string') terminalDataFrameCount += 1;
+    });
     socket.on('close', () => {
       execSocketClosed = true;
     });
@@ -74,6 +78,19 @@ test('alt+j focuses and mod+j toggles an existing terminal without closing its s
   await expect(searchButton).toBeFocused();
   await expect(terminal).toBeHidden();
 
+  const dataFramesBeforeRepeat = terminalDataFrameCount;
+  await page.keyboard.down('Control');
+  await page.keyboard.down('j');
+  await expect(terminal).toBeVisible();
+  await expect(terminalInput).toBeFocused();
+  await page.keyboard.down('j');
+  await page.keyboard.up('j');
+  await page.keyboard.up('Control');
+  await page.waitForTimeout(100);
+  expect(terminalDataFrameCount).toBe(dataFramesBeforeRepeat);
+
+  await page.keyboard.press('ControlOrMeta+j');
+  await expect(terminal).toBeHidden();
   await page.keyboard.press('Alt+j');
   await expect(terminal).toBeVisible();
   await expect(terminalInput).toBeFocused();

--- a/tests/unit/client/state.test.ts
+++ b/tests/unit/client/state.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clampDetailWidth } from '../../../client/src/state/detail';
-import { clampDockHeight } from '../../../client/src/state/dock';
+import { clampDockHeight, useDockStore, type DockTab } from '../../../client/src/state/dock';
 import { forwardPrefKey } from '../../../client/src/state/portforward-prefs';
 import { errorDetails } from '../../../client/src/state/toast';
 import { namespaceVisible } from '../../../client/src/state/clusters';
@@ -35,6 +35,55 @@ describe('clampDockHeight', () => {
     expect(clampDockHeight(10)).toBe(160);
     expect(clampDockHeight(300)).toBe(300);
     expect(clampDockHeight(9999)).toBe(600);
+  });
+});
+
+describe('useDockStore terminal focus requests', () => {
+  const terminal: DockTab = {
+    kind: 'terminal',
+    id: 'terminal',
+    title: 'shell',
+    ctx: 'kind-a',
+    namespace: 'default',
+    pod: 'web',
+    container: 'web',
+  };
+  const logs: DockTab = {
+    kind: 'logs',
+    id: 'logs',
+    title: 'logs',
+    ctx: 'kind-a',
+    namespace: 'default',
+    pods: ['web'],
+  };
+
+  beforeEach(() => {
+    useDockStore.setState({
+      tabs: [terminal, logs],
+      activeId: logs.id,
+      open: false,
+      maximized: false,
+      terminalFocusRequest: undefined,
+    });
+  });
+
+  it('opens, activates, and issues a fresh request for an existing terminal', () => {
+    useDockStore.getState().requestTerminalFocus(terminal.id);
+    const first = useDockStore.getState();
+    expect(first.open).toBe(true);
+    expect(first.activeId).toBe(terminal.id);
+    expect(first.terminalFocusRequest).toEqual({ tabId: terminal.id, sequence: 1 });
+
+    first.setOpen(false);
+    useDockStore.getState().requestTerminalFocus(terminal.id);
+    expect(useDockStore.getState().terminalFocusRequest).toEqual({ tabId: terminal.id, sequence: 2 });
+  });
+
+  it('ignores log tabs and unknown ids', () => {
+    const before = useDockStore.getState();
+    before.requestTerminalFocus(logs.id);
+    before.requestTerminalFocus('missing');
+    expect(useDockStore.getState()).toBe(before);
   });
 });
 


### PR DESCRIPTION
## Summary

- add `Alt+J` as a keyboard-layout-independent shortcut to show and focus an existing terminal
- make `Cmd/Ctrl+J` focus the active terminal when opening the dock and hide it when the terminal owns focus, while retaining normal toggle behavior for log tabs
- keep terminal sessions mounted while the dock is hidden so their WebSocket and remote shell survive the toggle
- restore focus to the previous app control when hiding a focused terminal
- document both shortcuts in the keyboard help and add unit/E2E regression coverage

## Why

The existing dock shortcut changed visibility but did not reliably hand focus to the terminal. A backtick-based shortcut is also layout-dependent and does not work reliably on German keyboards.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- unit suite: 901 tests passed
- `pnpm --filter @kubus/tests exec playwright test e2e/specs/shortcuts.spec.ts` (3 passed against a real exec session)

Closes #72