### PR TITLE
chore: bump version to 0.6.4

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/tests",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump the root package version from 0.6.3 to 0.6.4
- keep all workspace package versions aligned at 0.6.4

## Impact

Release metadata now reports version 0.6.4 consistently across the application and its workspaces.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- manifest version validation
- `git diff --check`