### PR TITLE
docs: add Buy Me a Coffee button

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ pnpm start
 For development setup, release steps, architecture, security details, and test
 clusters, use the docs.
 
+## Support
+
+<a href="https://www.buymeacoffee.com/FloSch62">
+  <img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" height="60">
+</a>
+
 ## License
 
 [MIT](./LICENSE)


### PR DESCRIPTION
## Summary

- add a Support section to the README
- link a GitHub-compatible Buy Me a Coffee image button to the FloSch62 page

## Why

GitHub removes executable `<script>` tags from rendered Markdown, so the README uses a linked image that renders correctly while keeping the support action accessible.

## Impact

Repository visitors can open the Buy Me a Coffee page directly from the README. There are no application or runtime changes.

## Validation

- `git diff --check`
- confirmed the button image URL returns HTTP 200