### PR TITLE
Show cluster capacity in overview

### DIFF
--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -296,15 +296,20 @@ function OverviewSkeleton() {
 function NodeUsageCard({ ctx, nodeMetrics }: { ctx: string; nodeMetrics: ReturnType<typeof useNodeMetrics>['data'] }) {
   const total = useMemo(() => {
     if (!nodeMetrics?.available || nodeMetrics.items.length === 0) return undefined;
-    return nodeMetrics.items.reduce(
+    const sampledTotal = nodeMetrics.items.reduce(
       (acc, item) => ({
         cpuMilli: acc.cpuMilli + item.cpuMilli,
         memBytes: acc.memBytes + item.memBytes,
-        cpuCapacityMilli: acc.cpuCapacityMilli + (item.cpuNodeCapacityMilli ?? item.cpuCapacityMilli ?? 0),
-        memCapacityBytes: acc.memCapacityBytes + (item.memNodeCapacityBytes ?? item.memCapacityBytes ?? 0),
+        cpuCapacityMilli: acc.cpuCapacityMilli + (item.cpuCapacityMilli ?? 0),
+        memCapacityBytes: acc.memCapacityBytes + (item.memCapacityBytes ?? 0),
       }),
       { cpuMilli: 0, memBytes: 0, cpuCapacityMilli: 0, memCapacityBytes: 0 },
     );
+    return {
+      ...sampledTotal,
+      cpuCapacityMilli: nodeMetrics.totalCpuCapacityMilli ?? sampledTotal.cpuCapacityMilli,
+      memCapacityBytes: nodeMetrics.totalMemCapacityBytes ?? sampledTotal.memCapacityBytes,
+    };
   }, [nodeMetrics]);
 
   return (

--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -300,8 +300,8 @@ function NodeUsageCard({ ctx, nodeMetrics }: { ctx: string; nodeMetrics: ReturnT
       (acc, item) => ({
         cpuMilli: acc.cpuMilli + item.cpuMilli,
         memBytes: acc.memBytes + item.memBytes,
-        cpuCapacityMilli: acc.cpuCapacityMilli + (item.cpuCapacityMilli ?? 0),
-        memCapacityBytes: acc.memCapacityBytes + (item.memCapacityBytes ?? 0),
+        cpuCapacityMilli: acc.cpuCapacityMilli + (item.cpuNodeCapacityMilli ?? item.cpuCapacityMilli ?? 0),
+        memCapacityBytes: acc.memCapacityBytes + (item.memNodeCapacityBytes ?? item.memCapacityBytes ?? 0),
       }),
       { cpuMilli: 0, memBytes: 0, cpuCapacityMilli: 0, memCapacityBytes: 0 },
     );
@@ -342,8 +342,14 @@ function NodeUsageCard({ ctx, nodeMetrics }: { ctx: string; nodeMetrics: ReturnT
                 <Typography variant="body2" sx={{ width: 220, fontWeight: 600 }} noWrap>
                   Total
                 </Typography>
-                <UsageBar label={`CPU ${formatCpu(total.cpuMilli)}`} pct={total.cpuCapacityMilli > 0 ? (total.cpuMilli / total.cpuCapacityMilli) * 100 : undefined} />
-                <UsageBar label={`Mem ${formatBytes(total.memBytes)}`} pct={total.memCapacityBytes > 0 ? (total.memBytes / total.memCapacityBytes) * 100 : undefined} />
+                <UsageBar
+                  label={`CPU ${formatCpu(total.cpuMilli)}${total.cpuCapacityMilli > 0 ? ` / ${formatCpu(total.cpuCapacityMilli)}` : ''}`}
+                  pct={total.cpuCapacityMilli > 0 ? (total.cpuMilli / total.cpuCapacityMilli) * 100 : undefined}
+                />
+                <UsageBar
+                  label={`Mem ${formatBytes(total.memBytes)}${total.memCapacityBytes > 0 ? ` / ${formatBytes(total.memCapacityBytes)}` : ''}`}
+                  pct={total.memCapacityBytes > 0 ? (total.memBytes / total.memCapacityBytes) * 100 : undefined}
+                />
               </Box>
             )}
             {nodeMetrics.items.map((n) => (
@@ -371,7 +377,7 @@ function UsageBar({ label, pct }: { label: string; pct?: number }) {
         color={(pct ?? 0) > 90 ? 'error' : (pct ?? 0) > 75 ? 'warning' : 'primary'}
         sx={{ flex: 1, height: 6, borderRadius: 3 }}
       />
-      <Typography variant="caption" sx={{ width: 130 }} color="text.secondary">
+      <Typography variant="caption" sx={{ width: 220, flexShrink: 0 }} color="text.secondary" noWrap>
         {label}
         {pct !== undefined ? ` (${pct.toFixed(0)}%)` : ''}
       </Typography>

--- a/server/src/routes/metrics.ts
+++ b/server/src/routes/metrics.ts
@@ -26,22 +26,29 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
       const handle = ctx.clusters.get(req.params.ctx);
       const poller = handle.metricsPoller;
       const items = poller.nodeSnapshot();
-      // Join allocatable capacity from the nodes watcher for utilization %.
+      // Join both total capacity and allocatable resources from the nodes watcher.
+      // Per-node utilization remains based on allocatable resources; the overview
+      // can separately report the cluster's full capacity.
       const nodesWatcher = handle.watchers.peek('', 'v1', 'nodes');
-      const capacity = new Map<string, { cpu?: string; memory?: string }>();
+      const resources = new Map<string, { capacity?: { cpu?: string; memory?: string }; allocatable?: { cpu?: string; memory?: string } }>();
       for (const node of nodesWatcher?.items() ?? []) {
-        const alloc = (node.status as { allocatable?: { cpu?: string; memory?: string } })?.allocatable;
-        if (alloc) capacity.set(node.metadata.name, alloc);
+        const status = node.status as {
+          capacity?: { cpu?: string; memory?: string };
+          allocatable?: { cpu?: string; memory?: string };
+        };
+        resources.set(node.metadata.name, status);
       }
       const snapshot: MetricsSnapshot = {
         available: poller.available,
         probed: poller.probed,
         items: items.map((n) => {
-          const alloc = capacity.get(n.name);
+          const { capacity, allocatable } = resources.get(n.name) ?? {};
           return {
             ...n,
-            cpuCapacityMilli: alloc?.cpu ? cpuToMilli(alloc.cpu) : undefined,
-            memCapacityBytes: alloc?.memory ? memToBytes(alloc.memory) : undefined,
+            cpuCapacityMilli: allocatable?.cpu ? cpuToMilli(allocatable.cpu) : undefined,
+            memCapacityBytes: allocatable?.memory ? memToBytes(allocatable.memory) : undefined,
+            cpuNodeCapacityMilli: capacity?.cpu ? cpuToMilli(capacity.cpu) : undefined,
+            memNodeCapacityBytes: capacity?.memory ? memToBytes(capacity.memory) : undefined,
           };
         }),
       };

--- a/server/src/routes/metrics.ts
+++ b/server/src/routes/metrics.ts
@@ -26,29 +26,40 @@ export function registerMetricsRoutes(app: FastifyInstance, ctx: AppContext): vo
       const handle = ctx.clusters.get(req.params.ctx);
       const poller = handle.metricsPoller;
       const items = poller.nodeSnapshot();
-      // Join both total capacity and allocatable resources from the nodes watcher.
-      // Per-node utilization remains based on allocatable resources; the overview
-      // can separately report the cluster's full capacity.
+      // Join allocatable resources per sampled node, while summing full capacity
+      // independently so nodes without a metrics-server sample still count.
       const nodesWatcher = handle.watchers.peek('', 'v1', 'nodes');
-      const resources = new Map<string, { capacity?: { cpu?: string; memory?: string }; allocatable?: { cpu?: string; memory?: string } }>();
+      const allocatableByNode = new Map<string, { cpu?: string; memory?: string }>();
+      let totalCpuCapacityMilli = 0;
+      let totalMemCapacityBytes = 0;
+      let hasCpuCapacity = false;
+      let hasMemCapacity = false;
       for (const node of nodesWatcher?.items() ?? []) {
         const status = node.status as {
           capacity?: { cpu?: string; memory?: string };
           allocatable?: { cpu?: string; memory?: string };
         };
-        resources.set(node.metadata.name, status);
+        if (status.allocatable) allocatableByNode.set(node.metadata.name, status.allocatable);
+        if (status.capacity?.cpu) {
+          totalCpuCapacityMilli += cpuToMilli(status.capacity.cpu);
+          hasCpuCapacity = true;
+        }
+        if (status.capacity?.memory) {
+          totalMemCapacityBytes += memToBytes(status.capacity.memory);
+          hasMemCapacity = true;
+        }
       }
       const snapshot: MetricsSnapshot = {
         available: poller.available,
         probed: poller.probed,
+        totalCpuCapacityMilli: hasCpuCapacity ? totalCpuCapacityMilli : undefined,
+        totalMemCapacityBytes: hasMemCapacity ? totalMemCapacityBytes : undefined,
         items: items.map((n) => {
-          const { capacity, allocatable } = resources.get(n.name) ?? {};
+          const allocatable = allocatableByNode.get(n.name);
           return {
             ...n,
             cpuCapacityMilli: allocatable?.cpu ? cpuToMilli(allocatable.cpu) : undefined,
             memCapacityBytes: allocatable?.memory ? memToBytes(allocatable.memory) : undefined,
-            cpuNodeCapacityMilli: capacity?.cpu ? cpuToMilli(capacity.cpu) : undefined,
-            memNodeCapacityBytes: capacity?.memory ? memToBytes(capacity.memory) : undefined,
           };
         }),
       };

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -526,9 +526,6 @@ export interface MetricsSnapshotEntry {
   /** Node only: allocatable totals for utilization %. */
   cpuCapacityMilli?: number;
   memCapacityBytes?: number;
-  /** Node only: total capacity reported by Kubernetes, before reservations. */
-  cpuNodeCapacityMilli?: number;
-  memNodeCapacityBytes?: number;
   /** Pod only: per-container usage breakdown. */
   containers?: ContainerUsage[];
 }
@@ -537,6 +534,9 @@ export interface MetricsSnapshot {
   available: boolean;
   /** At least one metrics probe has completed — until then `available` is provisional. */
   probed: boolean;
+  /** Node snapshot only: full capacity across every watched node, including nodes without a usage sample. */
+  totalCpuCapacityMilli?: number;
+  totalMemCapacityBytes?: number;
   items: MetricsSnapshotEntry[];
 }
 

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -526,6 +526,9 @@ export interface MetricsSnapshotEntry {
   /** Node only: allocatable totals for utilization %. */
   cpuCapacityMilli?: number;
   memCapacityBytes?: number;
+  /** Node only: total capacity reported by Kubernetes, before reservations. */
+  cpuNodeCapacityMilli?: number;
+  memNodeCapacityBytes?: number;
   /** Pod only: per-container usage breakdown. */
   containers?: ContainerUsage[];
 }

--- a/tests/unit/server/metrics-routes.test.ts
+++ b/tests/unit/server/metrics-routes.test.ts
@@ -5,7 +5,7 @@ import type { ClusterHandle } from '../../../server/src/kube/cluster-manager';
 import { registerMetricsRoutes } from '../../../server/src/routes/metrics';
 
 describe('metrics routes', () => {
-  it('returns full node capacity separately from allocatable resources', async () => {
+  it('aggregates full capacity from every watched node, including unsampled nodes', async () => {
     const handle = {
       metricsPoller: {
         available: true,
@@ -22,6 +22,13 @@ describe('metrics routes', () => {
                 allocatable: { cpu: '3500m', memory: '7Gi' },
               },
             },
+            {
+              metadata: { name: 'node-b' },
+              status: {
+                capacity: { cpu: '2', memory: '4Gi' },
+                allocatable: { cpu: '1500m', memory: '3Gi' },
+              },
+            },
           ],
         }),
       },
@@ -36,6 +43,8 @@ describe('metrics routes', () => {
       expect(response.json()).toEqual({
         available: true,
         probed: true,
+        totalCpuCapacityMilli: 6000,
+        totalMemCapacityBytes: 12 * 2 ** 30,
         items: [
           {
             name: 'node-a',
@@ -43,8 +52,6 @@ describe('metrics routes', () => {
             memBytes: 2 ** 30,
             cpuCapacityMilli: 3500,
             memCapacityBytes: 7 * 2 ** 30,
-            cpuNodeCapacityMilli: 4000,
-            memNodeCapacityBytes: 8 * 2 ** 30,
           },
         ],
       });

--- a/tests/unit/server/metrics-routes.test.ts
+++ b/tests/unit/server/metrics-routes.test.ts
@@ -1,0 +1,55 @@
+import Fastify from 'fastify';
+import { describe, expect, it } from 'vitest';
+import type { AppContext } from '../../../server/src/app';
+import type { ClusterHandle } from '../../../server/src/kube/cluster-manager';
+import { registerMetricsRoutes } from '../../../server/src/routes/metrics';
+
+describe('metrics routes', () => {
+  it('returns full node capacity separately from allocatable resources', async () => {
+    const handle = {
+      metricsPoller: {
+        available: true,
+        probed: true,
+        nodeSnapshot: () => [{ name: 'node-a', cpuMilli: 250, memBytes: 2 ** 30 }],
+      },
+      watchers: {
+        peek: () => ({
+          items: () => [
+            {
+              metadata: { name: 'node-a' },
+              status: {
+                capacity: { cpu: '4', memory: '8Gi' },
+                allocatable: { cpu: '3500m', memory: '7Gi' },
+              },
+            },
+          ],
+        }),
+      },
+    } as unknown as ClusterHandle;
+    const app = Fastify();
+    registerMetricsRoutes(app, { clusters: { get: () => handle } } as unknown as AppContext);
+
+    try {
+      const response = await app.inject({ method: 'GET', url: '/api/contexts/dev/metrics/nodes' });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({
+        available: true,
+        probed: true,
+        items: [
+          {
+            name: 'node-a',
+            cpuMilli: 250,
+            memBytes: 2 ** 30,
+            cpuCapacityMilli: 3500,
+            memCapacityBytes: 7 * 2 ** 30,
+            cpuNodeCapacityMilli: 4000,
+            memNodeCapacityBytes: 8 * 2 ** 30,
+          },
+        ],
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- expose cluster-wide Kubernetes capacity independently from metrics-server usage samples
- show aggregate CPU and memory as usage / capacity with the existing percentage
- keep per-node utilization based on allocatable resources
- include watched nodes that do not yet have a metrics-server sample in the cluster capacity
- widen usage labels so the added capacity values remain readable
- add regression coverage for sampled and unsampled nodes

## Why

The cluster overview showed current CPU and memory usage and a percentage, but not the total resources available in the cluster. Displaying the maximum values makes the cluster's overall size and remaining headroom immediately visible.

## Validation

- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- `pnpm lint`
- `pnpm test` — 69 test files, 902 tests passed
- isolated browser verification with one sampled node and a larger two-node capacity total