### PR TITLE
Add embedded terminal clipboard settings

### DIFF
--- a/client/src/components/TerminalPaneImpl.tsx
+++ b/client/src/components/TerminalPaneImpl.tsx
@@ -1,6 +1,14 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
+import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import { useTheme } from '@mui/material/styles';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import ContentPasteIcon from '@mui/icons-material/ContentPaste';
+import SelectAllIcon from '@mui/icons-material/SelectAll';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
@@ -11,29 +19,22 @@ import type { NodeShellTab, TerminalTab } from '../state/dock.js';
 import { useDockStore } from '../state/dock.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { showToast } from '../state/toast.js';
+import { selectedTerminalText } from '../terminal-selection.js';
+import { terminalRightClickIntent, xtermRightClickSelectsWord } from '../terminal-right-click.js';
 
 export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: TerminalTab | NodeShellTab; active: boolean; focusRequest: number }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const termRef = useRef<Terminal | null>(null);
+  const rightClickSelectsWordDefaultRef = useRef(false);
+  const [contextMenu, setContextMenu] = useState<{ top: number; left: number; selection: string } | null>(null);
   const activeRef = useRef(active);
   activeRef.current = active;
   const theme = useTheme();
 
-  // Right-click copies the selection when there is one, otherwise pastes —
-  // the common terminal-emulator convention. Paste goes through term.paste()
-  // so bracketed-paste mode reaches the remote shell intact.
-  const onContextMenu = (e: React.MouseEvent) => {
-    e.preventDefault();
+  const pasteFromClipboard = () => {
     const term = termRef.current;
     if (!term) return;
-    const selection = term.getSelection();
-    if (selection) {
-      void copyToClipboard(selection).then((ok) => {
-        if (ok) term.clearSelection();
-      });
-      return;
-    }
     void readFromClipboard().then((text) => {
       if (text === null) {
         showToast('warning', 'Clipboard read unavailable or denied — allow clipboard access, or paste with the keyboard.');
@@ -41,6 +42,39 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
       }
       if (text) term.paste(text);
     });
+  };
+
+  const prepareRightClick = () => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.rightClickSelectsWord = xtermRightClickSelectsWord(
+      rightClickSelectsWordDefaultRef.current,
+      useUiPrefsStore.getState().rightClickAction,
+      term.hasSelection(),
+    );
+  };
+
+  const onContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const term = termRef.current;
+    if (!term) return;
+    const intent = terminalRightClickIntent(useUiPrefsStore.getState().rightClickAction, term.getSelection());
+    if (intent.kind === 'menu') {
+      setContextMenu({ top: e.clientY, left: e.clientX, selection: intent.selection });
+      return;
+    }
+    if (intent.kind === 'copy') {
+      void copyToClipboard(intent.selection).then((ok) => {
+        if (ok) term.clearSelection();
+      });
+      return;
+    }
+    pasteFromClipboard();
+  };
+
+  const closeContextMenu = () => {
+    setContextMenu(null);
+    termRef.current?.focus();
   };
 
   useEffect(() => {
@@ -54,6 +88,7 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
       cursorBlink: true,
       theme: { background: '#16161e' },
     });
+    rightClickSelectsWordDefaultRef.current = term.options.rightClickSelectsWord ?? false;
     const fit = new FitAddon();
     fitRef.current = fit;
     termRef.current = term;
@@ -102,6 +137,10 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
     const onResize = term.onResize(({ cols, rows }) => {
       if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ op: 'resize', cols, rows }));
     });
+    const onSelection = term.onSelectionChange(() => {
+      const selection = selectedTerminalText(term, useUiPrefsStore.getState().copyOnSelect);
+      if (selection !== null) void copyToClipboard(selection);
+    });
 
     // Inactive tabs and a collapsed dock have zero height. Ignore those
     // resize notifications so the remote PTY keeps its last usable size.
@@ -114,6 +153,7 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
       observer.disconnect();
       onData.dispose();
       onResize.dispose();
+      onSelection.dispose();
       ws.close();
       term.dispose();
       termRef.current = null;
@@ -142,6 +182,10 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
     <Box sx={{ height: '100%', p: 1, pt: 0.75 }}>
       <Box
         ref={containerRef}
+        onMouseDownCapture={(event) => {
+          if (event.button === 2) prepareRightClick();
+        }}
+        onContextMenuCapture={prepareRightClick}
         onContextMenu={onContextMenu}
         sx={{
           height: '100%',
@@ -156,6 +200,54 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
           '& .xterm .xterm-viewport': { backgroundColor: 'transparent' },
         }}
       />
+      <Menu
+        open={contextMenu !== null}
+        onClose={closeContextMenu}
+        anchorReference="anchorPosition"
+        anchorPosition={contextMenu ?? undefined}
+      >
+        <MenuItem
+          disabled={!contextMenu?.selection}
+          onClick={() => {
+            const selection = contextMenu?.selection;
+            const term = termRef.current;
+            if (selection && term) {
+              void copyToClipboard(selection).then((ok) => {
+                if (ok) term.clearSelection();
+              });
+            }
+            closeContextMenu();
+          }}
+        >
+          <ListItemIcon>
+            <ContentCopyIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            closeContextMenu();
+            pasteFromClipboard();
+          }}
+        >
+          <ListItemIcon>
+            <ContentPasteIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Paste</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem
+          onClick={() => {
+            termRef.current?.selectAll();
+            closeContextMenu();
+          }}
+        >
+          <ListItemIcon>
+            <SelectAllIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Select all</ListItemText>
+        </MenuItem>
+      </Menu>
     </Box>
   );
 }

--- a/client/src/components/settings/SettingsDialog.tsx
+++ b/client/src/components/settings/SettingsDialog.tsx
@@ -43,7 +43,7 @@ import { AddClusterDialog } from './AddClusterDialog.js';
 import { EditClusterDialog } from './EditClusterDialog.js';
 import { useClustersStore } from '../../state/clusters.js';
 import { useLogPrefsStore, type TsMode } from '../../state/log-prefs.js';
-import { TAIL_LINE_OPTIONS, useUiPrefsStore, type RefreshRate, type TableDensity } from '../../state/prefs.js';
+import { TAIL_LINE_OPTIONS, useUiPrefsStore, type RefreshRate, type RightClickAction, type TableDensity } from '../../state/prefs.js';
 import { KubeconfigSection } from './KubeconfigSection.js';
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -320,7 +320,7 @@ function RefreshSection() {
 const SHELL_PRESETS = ['auto', 'sh', 'bash'] as const;
 
 function LogsTerminalSection() {
-  const { defaultTailLines, defaultShell } = useUiPrefsStore();
+  const { defaultTailLines, defaultShell, copyOnSelect, rightClickAction } = useUiPrefsStore();
   const setPrefs = useUiPrefsStore((s) => s.set);
   const { wrap, tsMode, highlight, setWrap, setTsMode, setHighlight } = useLogPrefsStore();
   const shellPreset = (SHELL_PRESETS as readonly string[]).includes(defaultShell) ? defaultShell : 'custom';
@@ -390,6 +390,30 @@ function LogsTerminalSection() {
           <Typography variant="caption" color="text.secondary">
             Applies to newly opened exec terminals
           </Typography>
+          <FormControlLabel
+            control={<Switch checked={copyOnSelect} onChange={(e) => setPrefs({ copyOnSelect: e.target.checked })} />}
+            label={
+              <Box>
+                <Typography variant="body2">Copy on select</Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Copy selected terminal text to the clipboard automatically
+                </Typography>
+              </Box>
+            }
+          />
+          <FormControl size="small" sx={{ maxWidth: 420 }}>
+            <InputLabel id="settings-terminal-right-click">Right-click</InputLabel>
+            <Select
+              labelId="settings-terminal-right-click"
+              label="Right-click"
+              value={rightClickAction}
+              onChange={(e) => setPrefs({ rightClickAction: e.target.value as RightClickAction })}
+            >
+              <MenuItem value="copy-paste">Copy selection, otherwise paste (terminal convention)</MenuItem>
+              <MenuItem value="paste">Always paste</MenuItem>
+              <MenuItem value="menu">Show context menu</MenuItem>
+            </Select>
+          </FormControl>
         </Stack>
       </Section>
     </Stack>

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -6,6 +6,7 @@ import { kubusStateStorage } from './persist-storage.js';
 
 export type TableDensity = 'compact' | 'comfortable';
 export type RefreshRate = 'fast' | 'normal' | 'slow' | 'off';
+export type RightClickAction = 'copy-paste' | 'paste' | 'menu';
 export const TAIL_LINE_OPTIONS = [100, 500, 1000, 5000] as const;
 
 const REFRESH_FACTOR: Record<Exclude<RefreshRate, 'off'>, number> = { fast: 0.5, normal: 1, slow: 2 };
@@ -20,6 +21,10 @@ interface UiPrefsState {
   defaultTailLines: number;
   /** Exec shell: 'auto' lets the server pick bash-or-sh; anything else is sent verbatim. */
   defaultShell: string;
+  /** Copy terminal text to the clipboard as soon as it is selected. */
+  copyOnSelect: boolean;
+  /** Right-click behavior in embedded terminals. */
+  rightClickAction: RightClickAction;
   /** Treat contexts without an explicit protected flag as protected. */
   protectByDefault: boolean;
   /** Nav rail collapsed to reclaim width (wide viewports only). */
@@ -64,6 +69,8 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       refreshRate: 'normal',
       defaultTailLines: 500,
       defaultShell: 'auto',
+      copyOnSelect: false,
+      rightClickAction: 'copy-paste',
       protectByDefault: false,
       navCollapsed: false,
       cronHumanSchedule: false,

--- a/client/src/terminal-right-click.ts
+++ b/client/src/terminal-right-click.ts
@@ -1,0 +1,17 @@
+import type { RightClickAction } from './state/prefs.js';
+
+export function xtermRightClickSelectsWord(platformDefault: boolean, action: RightClickAction, hasSelection: boolean): boolean {
+  return platformDefault && action === 'menu' && !hasSelection;
+}
+
+export type TerminalRightClickIntent =
+  | { kind: 'copy'; selection: string }
+  | { kind: 'paste' }
+  | { kind: 'menu'; selection: string };
+
+/** Resolve a right click from the selection that existed when it occurred. */
+export function terminalRightClickIntent(action: RightClickAction, selection: string): TerminalRightClickIntent {
+  if (action === 'menu') return { kind: 'menu', selection };
+  if (action === 'copy-paste' && selection) return { kind: 'copy', selection };
+  return { kind: 'paste' };
+}

--- a/client/src/terminal-selection.ts
+++ b/client/src/terminal-selection.ts
@@ -1,0 +1,10 @@
+interface TerminalSelection {
+  hasSelection: () => boolean;
+  getSelection: () => string;
+}
+
+/** Return the terminal selection when automatic clipboard copying is enabled. */
+export function selectedTerminalText(terminal: TerminalSelection, copyOnSelect: boolean): string | null {
+  if (!copyOnSelect || !terminal.hasSelection()) return null;
+  return terminal.getSelection();
+}

--- a/tests/unit/client/terminal-right-click.test.ts
+++ b/tests/unit/client/terminal-right-click.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { terminalRightClickIntent, xtermRightClickSelectsWord } from '../../../client/src/terminal-right-click';
+
+describe('terminal right click', () => {
+  it('preserves platform word selection only for an empty context menu', () => {
+    expect(xtermRightClickSelectsWord(true, 'menu', false)).toBe(true);
+    expect(xtermRightClickSelectsWord(true, 'menu', true)).toBe(false);
+    expect(xtermRightClickSelectsWord(true, 'copy-paste', false)).toBe(false);
+    expect(xtermRightClickSelectsWord(true, 'paste', false)).toBe(false);
+    expect(xtermRightClickSelectsWord(false, 'menu', false)).toBe(false);
+  });
+
+  it('copies an existing selection in copy-paste mode', () => {
+    expect(terminalRightClickIntent('copy-paste', 'selected output')).toEqual({ kind: 'copy', selection: 'selected output' });
+  });
+
+  it('pastes without a selection or when always-paste mode is enabled', () => {
+    expect(terminalRightClickIntent('copy-paste', '')).toEqual({ kind: 'paste' });
+    expect(terminalRightClickIntent('paste', 'leave selected')).toEqual({ kind: 'paste' });
+  });
+
+  it('snapshots the selection for the context menu', () => {
+    expect(terminalRightClickIntent('menu', 'selected output')).toEqual({ kind: 'menu', selection: 'selected output' });
+    expect(terminalRightClickIntent('menu', '')).toEqual({ kind: 'menu', selection: '' });
+  });
+});

--- a/tests/unit/client/terminal-selection.test.ts
+++ b/tests/unit/client/terminal-selection.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { selectedTerminalText } from '../../../client/src/terminal-selection';
+
+describe('selectedTerminalText', () => {
+  it('returns selected terminal text only when copy on select is enabled', () => {
+    const terminal = {
+      hasSelection: vi.fn(() => true),
+      getSelection: vi.fn(() => 'selected output'),
+    };
+
+    expect(selectedTerminalText(terminal, false)).toBeNull();
+    expect(terminal.hasSelection).not.toHaveBeenCalled();
+
+    expect(selectedTerminalText(terminal, true)).toBe('selected output');
+    expect(terminal.hasSelection).toHaveBeenCalledOnce();
+    expect(terminal.getSelection).toHaveBeenCalledOnce();
+  });
+
+  it('ignores an empty terminal selection', () => {
+    const terminal = {
+      hasSelection: vi.fn(() => false),
+      getSelection: vi.fn(() => ''),
+    };
+
+    expect(selectedTerminalText(terminal, true)).toBeNull();
+    expect(terminal.getSelection).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- add a persisted copy-on-select preference for embedded terminals
- make right-click behavior configurable between copy/paste, always paste, and a context menu
- add Copy, Paste, and Select all actions to the terminal context menu
- cover selection and right-click intent behavior with focused unit tests

## Validation

- `pnpm --filter @kubus/tests exec vitest run --project client` (437 tests)
- `pnpm --filter @kubus/client typecheck`
- `pnpm exec oxlint ... --deny-warnings`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- Playwright verification against a live pod terminal

Fixes #113