### PR TITLE
Keep search input position stable

### DIFF
--- a/client/src/layout/SearchDialog.tsx
+++ b/client/src/layout/SearchDialog.tsx
@@ -290,7 +290,16 @@ export function SearchDialog({ open, onClose }: { open: boolean; onClose: () => 
 
   return (
     <>
-      <Dialog open={open} onClose={closeAll} maxWidth="sm" fullWidth slotProps={{ transition: { onEntered: focusInput } }}>
+      <Dialog
+        open={open}
+        onClose={closeAll}
+        maxWidth="sm"
+        fullWidth
+        slotProps={{
+          container: { sx: { alignItems: 'flex-start' } },
+          transition: { onEntered: focusInput },
+        }}
+      >
         <DialogContent sx={{ p: 1.25 }}>
           <TextField
             autoFocus

--- a/tests/e2e/specs/shortcuts.spec.ts
+++ b/tests/e2e/specs/shortcuts.spec.ts
@@ -2,13 +2,19 @@ import { expect, test } from '@playwright/test';
 import { gotoApp } from '../helpers/app.js';
 import { contextName } from '../helpers/cluster.mjs';
 
-test('command palette opens with mod+k and closes with escape', async ({ page }) => {
+test('command palette stays top-aligned while results change and closes with escape', async ({ page }) => {
   await gotoApp(page);
   await expect(page.getByRole('button', { name: contextName })).toBeVisible();
 
   await page.keyboard.press('ControlOrMeta+k');
   const palette = page.getByPlaceholder(/Search resources, pages, kinds/);
   await expect(palette).toBeVisible();
+
+  const dialog = page.getByRole('dialog');
+  const topBeforeSearch = await dialog.evaluate((element) => element.getBoundingClientRect().top);
+  await palette.fill('po');
+  await expect(dialog.getByText(/\d+ results/)).toBeVisible();
+  await expect.poll(() => dialog.evaluate((element) => element.getBoundingClientRect().top)).toBe(topBeforeSearch);
 
   await page.keyboard.press('Escape');
   await expect(palette).toHaveCount(0);


### PR DESCRIPTION
## Summary

- keep the command palette top-aligned while its result count changes
- preserve the existing responsive maximum height and scrolling behavior
- add an end-to-end regression check for the dialog position

## Root cause

MUI vertically centered the dialog by default, so changes to the results list changed the dialog height and moved the search input.

## Validation

- filtered shared/client/server build
- test TypeScript check
- lint
- full end-to-end suite (23 tests)

Fixes #114