### PR TITLE
Keep favorite navigation from selecting panel entries

### DIFF
--- a/client/src/layout/NavDrawer.tsx
+++ b/client/src/layout/NavDrawer.tsx
@@ -57,6 +57,11 @@ const KIND_INDENT = '66px';
 const FAVORITE_DRAG_TYPE = 'application/x-kubus-favorite';
 const CUSTOM_GROUP_PREFIX = 'custom:';
 const CRD_LIST_PATH = '/r/apiextensions.k8s.io/v1/customresourcedefinitions';
+const FAVORITE_NAVIGATION_STATE = { fromFavorite: true } as const;
+
+function isFavoriteNavigation(state: unknown): boolean {
+  return !!state && typeof state === 'object' && 'fromFavorite' in state && state.fromFavorite === true;
+}
 
 
 /**
@@ -73,14 +78,14 @@ function hotkeyFavorites(favorites: FavoriteItem[]): FavoriteItem[] {
  * page tab (+Shift focuses it), middle-click opens a background tab.
  * Plain clicks keep navigating the active tab via NavLink.
  */
-function useOpenInNewTab(to: string, pendingSavedView?: SavedView['grid']) {
+function useOpenInNewTab(to: string, pendingSavedView?: SavedView['grid'], fromFavorite = false) {
   const openTab = useTabsStore((s) => s.openTab);
   const navigate = useNavigate();
   const open = (e: React.MouseEvent, foreground: boolean) => {
     e.preventDefault();
     if (foreground && pendingSavedView) applySavedViewGridState(to, pendingSavedView);
     openTab(to, { activate: foreground, afterActive: true, pendingSavedView: foreground ? undefined : pendingSavedView });
-    if (foreground) void navigate(to);
+    if (foreground) void navigate(to, { state: fromFavorite ? FAVORITE_NAVIGATION_STATE : undefined });
   };
   return {
     onClick: (e: React.MouseEvent) => {
@@ -223,6 +228,7 @@ function NavEntry({
   hotkey,
   onIntent,
   indent,
+  inFavorites = false,
 }: {
   to: string;
   label: string;
@@ -238,17 +244,21 @@ function NavEntry({
   onIntent?: () => void;
   /** Left padding override for entries nested below the default group level. */
   indent?: string;
+  /** This copy lives in Favorites; navigating it must not reveal its canonical panel entry. */
+  inFavorites?: boolean;
 }) {
   const location = useLocation();
-  const active = location.pathname === to;
+  const fromFavorite = isFavoriteNavigation(location.state);
+  const active = location.pathname === to && (!fromFavorite || inFavorites);
   const isFav = useNavigationStore((s) => (favorite ? s.favorites.some((x) => x.id === favorite.id) : false));
   const addFavorite = useNavigationStore((s) => s.addFavorite);
   const removeFavorite = useNavigationStore((s) => s.removeFavorite);
-  const newTabHandlers = useOpenInNewTab(to);
+  const newTabHandlers = useOpenInNewTab(to, undefined, inFavorites);
   const button = (
     <ListItemButton
       component={NavLink}
       to={to}
+      state={inFavorites ? FAVORITE_NAVIGATION_STATE : undefined}
       dense
       selected={active}
       onMouseEnter={onIntent}
@@ -810,7 +820,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
       const fav = hotkeyFavorites(visibleFavsRef.current)[Number(digit) - 1];
       if (!fav?.path) return;
       e.preventDefault();
-      void navigate(fav.path);
+      void navigate(fav.path, { state: FAVORITE_NAVIGATION_STATE });
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
@@ -908,6 +918,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
   // arrives, so those retry once groupChainByPath fills in.
   const revealedPathRef = useRef<string | null>(null);
   useEffect(() => {
+    if (isFavoriteNavigation(location.state)) return;
     if (revealedPathRef.current === location.pathname) return;
     const chain = groupChainByPath.get(location.pathname);
     if (!chain && location.pathname.startsWith('/r/')) return;
@@ -925,7 +936,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
       });
     }
     return scrollActiveEntryIntoView();
-  }, [location.pathname, groupChainByPath, scrollActiveEntryIntoView]);
+  }, [location.pathname, location.state, groupChainByPath, scrollActiveEntryIntoView]);
 
   // Clearing the filter re-collapses groups; keep the active entry in view
   // instead of letting the selection vanish with them.
@@ -1114,7 +1125,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                       )}
                       <Collapse in={isOpen(key)}>
                         {kinds.map((k) => (
-                          <NavEntry key={`${k.group}/${k.version}/${k.plural}`} to={kindPath(k.group, k.version, k.plural)} label={k.label} />
+                          <NavEntry key={`${k.group}/${k.version}/${k.plural}`} to={kindPath(k.group, k.version, k.plural)} label={k.label} inFavorites />
                         ))}
                       </Collapse>
                     </Box>
@@ -1138,6 +1149,7 @@ export const NavDrawer = memo(function NavDrawer({ overlay, hidden, open, onClos
                         favoriteAction={favoriteDragHandle(fav)}
                         onManageFavorite={manageFavorite}
                         hotkey={hotkeyByFavorite.get(fav.id)}
+                        inFavorites
                       />,
                     )}
                   </Box>

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -17,7 +17,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import SubjectIcon from '@mui/icons-material/Subject';
 import BookmarkAddOutlinedIcon from '@mui/icons-material/BookmarkAddOutlined';
-import { useParams, useSearchParams } from 'react-router';
+import { useLocation, useParams, useSearchParams, type SetURLSearchParams } from 'react-router';
 import { columnsForKind, groupFromPath, groupToPath, gvkForResource, gvkLabel, pluralLabel, type ResourceKindInfo } from '@kubus/shared';
 import { useApiResourcesForContexts, useCrdColumns, useCreateResource, useDeleteResource, useDryRunResource, useFilteredList, useResourceMetrics, useRolloutRestart, useWatchedList, type ClusterRow } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
@@ -45,6 +45,17 @@ import { podContainerNames } from '../kube-display.js';
 // their place there.
 const BUILTIN_HIDDEN_FIELDS: Record<string, string[]> = { Node: ['nodeProviderID'], CustomResourceDefinition: ['labels'] };
 
+/** Keep navigation provenance while this page only rewrites its query string. */
+function usePreservedSearchParams(): [URLSearchParams, SetURLSearchParams] {
+  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setPreservedSearchParams = useCallback<SetURLSearchParams>(
+    (nextInit, navigateOpts) => setSearchParams(nextInit, { state: location.state, ...navigateOpts }),
+    [location.state, setSearchParams],
+  );
+  return [searchParams, setPreservedSearchParams];
+}
+
 /**
  * Renderless bridge between this page's URL params and the shared detail
  * selection. Pages stay mounted (and live) in hidden tab panes, so everything
@@ -54,7 +65,7 @@ const BUILTIN_HIDDEN_FIELDS: Record<string, string[]> = { Node: ['nodeProviderID
  */
 function DetailUrlSync({ sel }: { sel: ResourceSelection | undefined }) {
   const paneActive = usePaneActive();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = usePreservedSearchParams();
   const openDetail = useDetailStore((s) => s.open);
   const closeDetail = useDetailStore((s) => s.close);
 
@@ -126,7 +137,7 @@ function EmbeddedResourceDetail() {
   const width = useDetailStore((s) => s.width);
   const setWidth = useDetailStore((s) => s.setWidth);
   const focusSeq = useDetailStore((s) => s.focusSeq);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = usePreservedSearchParams();
   const asideRef = useRef<HTMLElement>(null);
   const collapseHandleDraggedRef = useRef(false);
 
@@ -343,7 +354,7 @@ export function ResourceListPage() {
     [kindInfo, group, version, plural, kind, builtinKind],
   );
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = usePreservedSearchParams();
   const textFilter = searchParams.get('q') ?? '';
   const labelSelector = searchParams.get('label') ?? '';
 

--- a/tests/unit/client/nav-drawer.test.tsx
+++ b/tests/unit/client/nav-drawer.test.tsx
@@ -128,6 +128,20 @@ describe('NavDrawer', () => {
     expect(useNavigationStore.getState().favorites.map((favorite) => favorite.id)).toContain('kind:/v1/pods');
   }, 15_000);
 
+  it('keeps the canonical panel entry collapsed when navigating from a favorite', async () => {
+    renderDrawer('/');
+    const workloadHeaders = screen.getAllByRole('button', { name: 'Workloads' });
+    fireEvent.click(workloadHeaders[1]!);
+
+    await waitFor(() => expect(screen.getAllByRole('link', { name: /Pods/ })).toHaveLength(1));
+    const favorite = screen.getByRole('link', { name: /Pods/ });
+    fireEvent.click(favorite);
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/r/core/v1/pods');
+    expect(favorite).toHaveClass('Mui-selected');
+    await waitFor(() => expect(screen.getAllByRole('link', { name: /Pods/ })).toHaveLength(1));
+  });
+
   it('scopes a favorite to a cluster from its menu and hides it elsewhere', async () => {
     const legacy = () => useNavigationStore.getState().favorites.find((favorite) => favorite.id === 'legacy');
     const { unmount } = renderDrawer('/');

--- a/tests/unit/client/resource-list-page.test.tsx
+++ b/tests/unit/client/resource-list-page.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation, type InitialEntry } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { KubeObject, PrinterColumn, ResourceKindInfo } from '@kubus/shared';
 import { ResourceListPage } from '../../../client/src/pages/ResourceListPage';
@@ -150,10 +150,15 @@ function row(name: string, ctx = 'dev', namespace = 'team-a', kind = 'Pod'): Row
 
 function LocationProbe() {
   const location = useLocation();
-  return <output data-testid="location">{location.pathname + location.search}</output>;
+  return (
+    <>
+      <output data-testid="location">{location.pathname + location.search}</output>
+      <output data-testid="location-state">{JSON.stringify(location.state)}</output>
+    </>
+  );
 }
 
-function renderPage(path: string) {
+function renderPage(path: InitialEntry) {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
@@ -215,6 +220,21 @@ describe('ResourceListPage', () => {
     renderPage('/r/core/v1/pods');
     expect(screen.getByText('No cluster selected')).toBeInTheDocument();
     expect(screen.getByText(/Pick one or more clusters/)).toBeInTheDocument();
+  });
+
+  it('preserves navigation state across same-page URL updates', async () => {
+    renderPage({ pathname: '/r/core/v1/pods', search: '?field=legacy', state: { fromFavorite: true } });
+
+    await waitFor(() => expect(screen.getByTestId('location')).not.toHaveTextContent('field='));
+    expect(screen.getByTestId('location-state')).toHaveTextContent('{"fromFavorite":true}');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mock text filter' }));
+    expect(screen.getByTestId('location-state')).toHaveTextContent('{"fromFavorite":true}');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mock open row' }));
+    expect(screen.getByTestId('location-state')).toHaveTextContent('{"fromFavorite":true}');
+    fireEvent.click(screen.getByRole('button', { name: 'Close detail mock' }));
+    expect(screen.getByTestId('location-state')).toHaveTextContent('{"fromFavorite":true}');
   });
 
   it('surfaces per-context health, filters, saves views, opens rows, and groups pod logs', async () => {


### PR DESCRIPTION
## Summary

- mark navigation originating from favourites in router state
- keep the favourite row selected without expanding or selecting its canonical panel entry
- apply the behavior to direct favourites, category favourites, hotkeys, and foreground tab navigation
- add regression coverage for a collapsed canonical resource group

## Root cause

Favourite links and canonical resource entries share the same route. The drawer treated every route change as canonical navigation, so it expanded the matching resource group, selected both copies, and scrolled to the canonical entry.

## Testing

- `pnpm exec vitest run unit/client/nav-drawer.test.tsx --reporter=verbose`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- built-client Playwright verification

Closes #115