### PR TITLE
Reposition cluster connectivity errors

### DIFF
--- a/client/src/api/ws/watch-client.ts
+++ b/client/src/api/ws/watch-client.ts
@@ -7,6 +7,13 @@ export interface WatchHandlers {
   onStatus(state: WatchStatusState, message?: string): void;
 }
 
+export interface ContextWatchIssue {
+  state: Extract<WatchStatusState, 'reconnecting' | 'error'>;
+  message?: string;
+}
+
+export type ContextWatchIssues = Record<string, ContextWatchIssue>;
+
 export type BroadcastHandler = (
   msg: Extract<WatchServerMessage, { op: 'drain-progress' | 'helm-operation' | 'pf-update' | 'contexts-changed' | 'discovery-update' }>,
 ) => void;
@@ -49,10 +56,22 @@ class WatchClient {
   private subs = new Map<string, WireSub>(); // by wire id
   private byKey = new Map<string, WireSub>();
   private broadcastHandlers = new Set<BroadcastHandler>();
+  private contextStatusHandlers = new Set<(issues: ContextWatchIssues) => void>();
   private counter = 0;
   private reconnectDelay = 1000;
   private connecting = false;
   private closedByUser = false;
+
+  /**
+   * Report context-level watch failures to global UI such as the cluster
+   * switcher. Resource subscriptions remain the source of truth; this only
+   * folds their current statuses into one issue per context.
+   */
+  onContextIssues(handler: (issues: ContextWatchIssues) => void): () => void {
+    this.contextStatusHandlers.add(handler);
+    handler(this.contextIssues());
+    return () => this.contextStatusHandlers.delete(handler);
+  }
 
   constructor() {
     // Don't sit out a long backoff when we can tell connectivity is back.
@@ -99,6 +118,7 @@ class WatchClient {
     if (sub.flushTimer !== undefined) window.clearTimeout(sub.flushTimer);
     this.byKey.delete(sub.key);
     this.subs.delete(sub.id);
+    this.emitContextIssues();
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify({ op: 'unsub', id: sub.id }));
     }
@@ -157,6 +177,7 @@ class WatchClient {
           if (!sub) break;
           sub.lastStatus = { state: msg.state, message: msg.message };
           for (const handlers of sub.handlers) handlers.onStatus(msg.state, msg.message);
+          this.emitContextIssues();
           break;
         }
         case 'drain-progress':
@@ -192,6 +213,7 @@ class WatchClient {
         sub.lastStatus = { state: 'reconnecting', message: 'connection lost' };
         for (const handlers of sub.handlers) handlers.onStatus('reconnecting', 'connection lost');
       }
+      this.emitContextIssues();
       if (this.subs.size > 0 || this.broadcastHandlers.size > 0) {
         window.setTimeout(() => this.ensureConnected(), this.reconnectDelay);
         this.reconnectDelay = Math.min(this.reconnectDelay * 2, 15_000);
@@ -201,6 +223,27 @@ class WatchClient {
     ws.onerror = () => {
       ws.close();
     };
+  }
+
+  private contextIssues(): ContextWatchIssues {
+    const issues: ContextWatchIssues = {};
+    for (const sub of this.subs.values()) {
+      const status = sub.lastStatus;
+      if (status?.state !== 'reconnecting' && status?.state !== 'error') continue;
+      const current = issues[sub.params.ctx];
+      // A terminal watch error is more useful than a transient reconnecting
+      // message when different resource subscriptions disagree.
+      if (!current || (current.state === 'reconnecting' && status.state === 'error')) {
+        issues[sub.params.ctx] = { state: status.state, message: status.message };
+      }
+    }
+    return issues;
+  }
+
+  private emitContextIssues(): void {
+    if (this.contextStatusHandlers.size === 0) return;
+    const issues = this.contextIssues();
+    for (const handler of this.contextStatusHandlers) handler(issues);
   }
 
   private queueEvents(id: string, events: Array<{ type: WatchEventType; object: KubeObject }>): void {

--- a/client/src/api/ws/watch-client.ts
+++ b/client/src/api/ws/watch-client.ts
@@ -12,7 +12,7 @@ export interface ContextWatchIssue {
   message?: string;
 }
 
-export type ContextWatchIssues = Record<string, ContextWatchIssue>;
+export type ContextWatchIssues = ReadonlyMap<string, ContextWatchIssue>;
 
 export type BroadcastHandler = (
   msg: Extract<WatchServerMessage, { op: 'drain-progress' | 'helm-operation' | 'pf-update' | 'contexts-changed' | 'discovery-update' }>,
@@ -226,15 +226,15 @@ class WatchClient {
   }
 
   private contextIssues(): ContextWatchIssues {
-    const issues: ContextWatchIssues = {};
+    const issues = new Map<string, ContextWatchIssue>();
     for (const sub of this.subs.values()) {
       const status = sub.lastStatus;
       if (status?.state !== 'reconnecting' && status?.state !== 'error') continue;
-      const current = issues[sub.params.ctx];
+      const current = issues.get(sub.params.ctx);
       // A terminal watch error is more useful than a transient reconnecting
       // message when different resource subscriptions disagree.
       if (!current || (current.state === 'reconnecting' && status.state === 'error')) {
-        issues[sub.params.ctx] = { state: status.state, message: status.message };
+        issues.set(sub.params.ctx, { state: status.state, message: status.message });
       }
     }
     return issues;

--- a/client/src/layout/ClusterSwitcher.tsx
+++ b/client/src/layout/ClusterSwitcher.tsx
@@ -232,7 +232,7 @@ export function ClusterSwitcher() {
   const [customize, setCustomize] = useState<{ ctx: string; anchor: HTMLElement } | null>(null);
   const [dragName, setDragName] = useState<string | null>(null);
   const [dropHint, setDropHint] = useState<{ name: string; before: boolean } | null>(null);
-  const [watchIssues, setWatchIssues] = useState<ContextWatchIssues>({});
+  const [watchIssues, setWatchIssues] = useState<ContextWatchIssues>(() => new Map());
   const [showConnectivityDetails, setShowConnectivityDetails] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -477,7 +477,7 @@ export function ClusterSwitcher() {
     const byName = new Map((contexts ?? []).map((context) => [context.name, context]));
     return selected.flatMap((name) => {
       const context = byName.get(name);
-      const watchIssue = watchIssues[name];
+      const watchIssue = watchIssues.get(name);
       const details = new Set<string>();
       if (context?.health === 'error') details.add(context.healthMessage ?? 'Connection failed');
       if (watchIssue) details.add(watchIssue.message ?? (watchIssue.state === 'reconnecting' ? 'Connection lost' : 'Watch failed'));
@@ -491,7 +491,7 @@ export function ClusterSwitcher() {
     const icon = contextSettings[c.name]?.icon;
     const isReconnecting = reconnect.isPending && reconnect.variables === c.name;
     const busy = (connect.isPending && connect.variables?.ctx === c.name) || isReconnecting;
-    const watchIssue = selected.includes(c.name) ? watchIssues[c.name] : undefined;
+    const watchIssue = selected.includes(c.name) ? watchIssues.get(c.name) : undefined;
     const isDropTarget = !!dropHint && dropHint.name === c.name && dragName !== c.name;
     return (
       <ListItemButton
@@ -620,7 +620,7 @@ export function ClusterSwitcher() {
     const icon = contextSettings[c.name]?.icon;
     const isReconnecting = reconnect.isPending && reconnect.variables === c.name;
     const busy = (connect.isPending && connect.variables?.ctx === c.name) || isReconnecting;
-    const watchIssue = selected.includes(c.name) ? watchIssues[c.name] : undefined;
+    const watchIssue = selected.includes(c.name) ? watchIssues.get(c.name) : undefined;
     const protectButton = (
       <Tooltip title={isProtected ? 'Protected: destructive actions require typed confirmation' : 'Mark as protected (e.g. production)'}>
         <IconButton

--- a/client/src/layout/ClusterSwitcher.tsx
+++ b/client/src/layout/ClusterSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Autocomplete from '@mui/material/Autocomplete';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -28,6 +29,7 @@ import TuneIcon from '@mui/icons-material/Tune';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import type { ContextHealth, ContextInfo } from '@kubus/shared';
 import { useConnectContext, useContexts, useReconnectContext } from '../api/queries.js';
+import { watchClient, type ContextWatchIssue, type ContextWatchIssues } from '../api/ws/watch-client.js';
 import { HEALTH_COLOR, healthTitle } from '../components/ContextHealthDot.js';
 import { fuzzyMatch } from '../fuzzy.js';
 import { HOTKEY_MOD_LABEL } from '../platform.js';
@@ -45,6 +47,11 @@ function selectedHealth(contexts: ContextInfo[] | undefined, selected: string[])
   if (healths.includes('connecting')) return 'connecting';
   if (healths.includes('unknown')) return 'unknown';
   return 'connected';
+}
+
+function watchIssueTitle(issue: ContextWatchIssue): string {
+  const fallback = issue.state === 'reconnecting' ? 'Connection lost' : 'Watch failed';
+  return `${issue.state === 'reconnecting' ? 'Reconnecting' : 'Watch error'}: ${issue.message ?? fallback}`;
 }
 
 function groupOf(settings: Record<string, ContextSettings>, name: string): string | undefined {
@@ -225,8 +232,12 @@ export function ClusterSwitcher() {
   const [customize, setCustomize] = useState<{ ctx: string; anchor: HTMLElement } | null>(null);
   const [dragName, setDragName] = useState<string | null>(null);
   const [dropHint, setDropHint] = useState<{ name: string; before: boolean } | null>(null);
+  const [watchIssues, setWatchIssues] = useState<ContextWatchIssues>({});
+  const [showConnectivityDetails, setShowConnectivityDetails] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => watchClient.onContextIssues(setWatchIssues), []);
 
   // On startup pick the persisted (or kubeconfig-current) selection; afterwards
   // keep the selection healthy on every context update: drop contexts gone from
@@ -285,6 +296,7 @@ export function ClusterSwitcher() {
     if (anchor) {
       setQuery('');
       setActiveIndex(0);
+      setShowConnectivityDetails(false);
     }
   }, [anchor]);
   useEffect(() => {
@@ -461,12 +473,25 @@ export function ClusterSwitcher() {
   const onlyProtected = only ? !!contextSettings[only]?.protected : false;
   const onlyIcon = only ? contextSettings[only]?.icon : undefined;
   const selectedConnectivity = selectedHealth(contexts, selected);
+  const connectivityIssues = useMemo(() => {
+    const byName = new Map((contexts ?? []).map((context) => [context.name, context]));
+    return selected.flatMap((name) => {
+      const context = byName.get(name);
+      const watchIssue = watchIssues[name];
+      const details = new Set<string>();
+      if (context?.health === 'error') details.add(context.healthMessage ?? 'Connection failed');
+      if (watchIssue) details.add(watchIssue.message ?? (watchIssue.state === 'reconnecting' ? 'Connection lost' : 'Watch failed'));
+      return details.size ? [{ name, details: [...details] }] : [];
+    });
+  }, [contexts, selected, watchIssues]);
+  const selectedHasConnectivityIssue = connectivityIssues.length > 0;
 
   const renderRow = (c: ContextInfo, idx: number) => {
     const isProtected = !!contextSettings[c.name]?.protected;
     const icon = contextSettings[c.name]?.icon;
     const isReconnecting = reconnect.isPending && reconnect.variables === c.name;
     const busy = (connect.isPending && connect.variables?.ctx === c.name) || isReconnecting;
+    const watchIssue = selected.includes(c.name) ? watchIssues[c.name] : undefined;
     const isDropTarget = !!dropHint && dropHint.name === c.name && dragName !== c.name;
     return (
       <ListItemButton
@@ -525,8 +550,8 @@ export function ClusterSwitcher() {
           {busy ? (
             <CircularProgress size={12} />
           ) : (
-            <Tooltip title={healthTitle(c)}>
-              <CircleIcon color={HEALTH_COLOR[c.health]} sx={{ fontSize: 12 }} />
+            <Tooltip title={watchIssue ? watchIssueTitle(watchIssue) : healthTitle(c)}>
+              <CircleIcon color={watchIssue ? 'warning' : HEALTH_COLOR[c.health]} sx={{ fontSize: 12 }} />
             </Tooltip>
           )}
         </ListItemIcon>
@@ -595,6 +620,7 @@ export function ClusterSwitcher() {
     const icon = contextSettings[c.name]?.icon;
     const isReconnecting = reconnect.isPending && reconnect.variables === c.name;
     const busy = (connect.isPending && connect.variables?.ctx === c.name) || isReconnecting;
+    const watchIssue = selected.includes(c.name) ? watchIssues[c.name] : undefined;
     const protectButton = (
       <Tooltip title={isProtected ? 'Protected: destructive actions require typed confirmation' : 'Mark as protected (e.g. production)'}>
         <IconButton
@@ -631,8 +657,8 @@ export function ClusterSwitcher() {
           {busy ? (
             <CircularProgress size={10} />
           ) : (
-            <Tooltip title={healthTitle(c)}>
-              <CircleIcon color={HEALTH_COLOR[c.health]} sx={{ fontSize: 10 }} />
+            <Tooltip title={watchIssue ? watchIssueTitle(watchIssue) : healthTitle(c)}>
+              <CircleIcon color={watchIssue ? 'warning' : HEALTH_COLOR[c.health]} sx={{ fontSize: 10 }} />
             </Tooltip>
           )}
           {icon && <Box component="span">{icon}</Box>}
@@ -722,8 +748,8 @@ export function ClusterSwitcher() {
     <>
       <Button variant="outlined" color="inherit" endIcon={<KeyboardArrowDownIcon />} onClick={(e) => setAnchor(e.currentTarget)}>
         {selectedConnectivity && (
-          <Tooltip title={selected.length === 1 ? `Connectivity: ${selectedConnectivity}` : `Selected clusters: ${selectedConnectivity}`}>
-            <CircleIcon color={HEALTH_COLOR[selectedConnectivity]} sx={{ fontSize: 10, mr: 1 }} />
+          <Tooltip title={selectedHasConnectivityIssue ? 'Connectivity issue' : selected.length === 1 ? `Connectivity: ${selectedConnectivity}` : `Selected clusters: ${selectedConnectivity}`}>
+            <CircleIcon color={selectedHasConnectivityIssue ? 'warning' : HEALTH_COLOR[selectedConnectivity]} sx={{ fontSize: 10, mr: 1 }} />
           </Tooltip>
         )}
         {onlyIcon && (
@@ -787,6 +813,36 @@ export function ClusterSwitcher() {
               </IconButton>
             </Tooltip>
           </Box>
+          {connectivityIssues.length > 0 && (
+            <Alert severity="warning" sx={{ mx: 1.5, mb: 1, py: 0, '& .MuiAlert-message': { minWidth: 0, width: '100%' } }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="caption" sx={{ flexGrow: 1, fontWeight: 700 }}>
+                  {connectivityIssues.length} selected cluster{connectivityIssues.length === 1 ? '' : 's'} {connectivityIssues.length === 1 ? 'has' : 'have'} connectivity issues
+                </Typography>
+                <Button
+                  size="small"
+                  color="inherit"
+                  aria-expanded={showConnectivityDetails}
+                  onClick={() => setShowConnectivityDetails((show) => !show)}
+                  sx={{ flexShrink: 0, minWidth: 0, px: 0.5 }}
+                >
+                  {showConnectivityDetails ? 'Hide details' : 'Show details'}
+                </Button>
+              </Box>
+              {showConnectivityDetails && (
+                <Box sx={{ maxHeight: 144, overflowY: 'auto', pr: 0.5 }}>
+                  {connectivityIssues.map((issue) => (
+                    <Typography key={issue.name} variant="caption" component="div" sx={{ mt: 0.5, overflowWrap: 'anywhere' }}>
+                      <Box component="span" sx={{ fontWeight: 700 }}>
+                        {issue.name}:
+                      </Box>{' '}
+                      {issue.details.join(' · ')}
+                    </Typography>
+                  ))}
+                </Box>
+              )}
+            </Alert>
+          )}
           <Divider />
           <Box ref={listRef} sx={{ maxHeight: 440, overflowY: 'auto', p: 0.5 }}>
             {sections.map((section, si) => (

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import FormControl from '@mui/material/FormControl';
@@ -239,25 +238,12 @@ export function EventsPage() {
     return <NoClustersState icon={<NotificationsNoneOutlinedIcon />} />;
   }
 
-  const errors = Object.entries(list.status).filter(([, s]) => s.state === 'error');
-  const reconnecting = Object.entries(list.status).filter(([, s]) => s.state === 'reconnecting');
-
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Box sx={{ px: 1.5, pt: 1.5 }}>
         <PageHeader title="Events" icon={<NotificationsNoneOutlinedIcon />}>
           <Chip label={countLabel(rows.length, 'event')} variant="outlined" />
         </PageHeader>
-        {errors.map(([ctx, s]) => (
-          <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>
-            {ctx}: {s.message ?? 'watch error'}
-          </Alert>
-        ))}
-        {reconnecting.map(([ctx]) => (
-          <Alert key={ctx} severity="warning" sx={{ mt: 0.5 }}>
-            {ctx}: connection lost — reconnecting, events may be stale.
-          </Alert>
-        ))}
       </Box>
       <Stack direction="row" spacing={1} sx={{ px: 1.5, py: 1, flexShrink: 0, alignItems: 'center' }}>
         <SmartFilterInput value={text} onChange={setText} kind="Event" rows={list.rows} inputRef={searchInputRef} />

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -562,8 +562,6 @@ export function ResourceListPage() {
   const unavailable = Object.entries(list.status).filter(([, s]) => s.state === 'unavailable');
   const unavailableContexts = new Set(unavailable.map(([ctx]) => ctx));
   const discoveryOnlyMissing = discoveryMissing.filter((ctx) => !unavailableContexts.has(ctx));
-  const errors = Object.entries(list.status).filter(([, s]) => s.state === 'error');
-  const reconnecting = Object.entries(list.status).filter(([, s]) => s.state === 'reconnecting');
   const activeRowId = useMemo(() => {
     if (!sel) return undefined;
     return list.rows.find(
@@ -637,16 +635,6 @@ export function ResourceListPage() {
             {resourceGvk}
           </Typography>
         </Box>
-        {errors.map(([ctx, s]) => (
-          <Alert key={ctx} severity="error" sx={{ mt: 0.5 }}>
-            {ctx}: {s.message ?? 'watch error'}
-          </Alert>
-        ))}
-        {reconnecting.map(([ctx]) => (
-          <Alert key={ctx} severity="warning" sx={{ mt: 0.5 }}>
-            {ctx}: connection lost — reconnecting, the list may be stale.
-          </Alert>
-        ))}
         {unavailable.map(([ctx, s]) => (
           <Alert key={ctx} severity="info" sx={{ mt: 0.5 }}>
             {ctx}: {s.message ?? `${kind} is not installed on this cluster.`}

--- a/tests/unit/client/cluster-switcher.test.tsx
+++ b/tests/unit/client/cluster-switcher.test.tsx
@@ -10,7 +10,7 @@ const queryMocks = vi.hoisted(() => ({
 }));
 
 const watchMocks = vi.hoisted(() => ({
-  issues: {} as Record<string, { state: 'reconnecting' | 'error'; message?: string }>,
+  issues: new Map<string, { state: 'reconnecting' | 'error'; message?: string }>(),
 }));
 
 vi.mock('../../../client/src/api/queries.js', () => ({
@@ -43,7 +43,7 @@ beforeEach(() => {
   queryMocks.reconnect.mutate.mockClear();
   queryMocks.reconnect.isPending = false;
   queryMocks.reconnect.variables = undefined;
-  watchMocks.issues = {};
+  watchMocks.issues = new Map();
   useClustersStore.setState({
     selected: ['dev-eu', 'removed'],
     namespaces: [],
@@ -134,11 +134,11 @@ describe('ClusterSwitcher', () => {
 
   it('marks affected clusters orange and collapses connectivity details behind a count', async () => {
     useClustersStore.setState({ selected: ['dev-eu', 'prod-eu', 'stage-us'] });
-    watchMocks.issues = {
-      'dev-eu': { state: 'reconnecting', message: 'connection lost' },
-      'prod-eu': { state: 'error', message: 'watch denied' },
-      'stage-us': { state: 'reconnecting', message: 'connection reset' },
-    };
+    watchMocks.issues = new Map([
+      ['dev-eu', { state: 'reconnecting', message: 'connection lost' }],
+      ['prod-eu', { state: 'error', message: 'watch denied' }],
+      ['stage-us', { state: 'reconnecting', message: 'connection reset' }],
+    ]);
 
     render(<ClusterSwitcher />);
     const button = await screen.findByRole('button', { name: /3 clusters/i });

--- a/tests/unit/client/cluster-switcher.test.tsx
+++ b/tests/unit/client/cluster-switcher.test.tsx
@@ -9,10 +9,23 @@ const queryMocks = vi.hoisted(() => ({
   reconnect: { mutate: vi.fn(), isPending: false, variables: undefined as unknown },
 }));
 
+const watchMocks = vi.hoisted(() => ({
+  issues: {} as Record<string, { state: 'reconnecting' | 'error'; message?: string }>,
+}));
+
 vi.mock('../../../client/src/api/queries.js', () => ({
   useContexts: () => ({ data: queryMocks.contexts }),
   useConnectContext: () => queryMocks.connect,
   useReconnectContext: () => queryMocks.reconnect,
+}));
+
+vi.mock('../../../client/src/api/ws/watch-client.js', () => ({
+  watchClient: {
+    onContextIssues: (handler: (issues: typeof watchMocks.issues) => void) => {
+      handler(watchMocks.issues);
+      return vi.fn();
+    },
+  },
 }));
 
 const contexts = [
@@ -30,6 +43,7 @@ beforeEach(() => {
   queryMocks.reconnect.mutate.mockClear();
   queryMocks.reconnect.isPending = false;
   queryMocks.reconnect.variables = undefined;
+  watchMocks.issues = {};
   useClustersStore.setState({
     selected: ['dev-eu', 'removed'],
     namespaces: [],
@@ -116,5 +130,30 @@ describe('ClusterSwitcher', () => {
     queryMocks.contexts = [];
     act(() => view.rerender(<ClusterSwitcher />));
     expect(screen.getByText(/No contexts found in kubeconfig/)).toBeInTheDocument();
+  });
+
+  it('marks affected clusters orange and collapses connectivity details behind a count', async () => {
+    useClustersStore.setState({ selected: ['dev-eu', 'prod-eu', 'stage-us'] });
+    watchMocks.issues = {
+      'dev-eu': { state: 'reconnecting', message: 'connection lost' },
+      'prod-eu': { state: 'error', message: 'watch denied' },
+      'stage-us': { state: 'reconnecting', message: 'connection reset' },
+    };
+
+    render(<ClusterSwitcher />);
+    const button = await screen.findByRole('button', { name: /3 clusters/i });
+    expect(button.querySelector('svg.MuiSvgIcon-colorWarning')).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(await screen.findByText('3 selected clusters have connectivity issues')).toBeInTheDocument();
+    expect(screen.queryByText(/connection lost/)).not.toBeInTheDocument();
+
+    const devRow = screen.getByText('dev-eu').closest('.MuiListItemButton-root');
+    expect(devRow?.querySelector('svg.MuiSvgIcon-colorWarning')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show details' }));
+    expect(screen.getByText(/connection lost/)).toBeInTheDocument();
+    expect(screen.getByText(/watch denied/)).toBeInTheDocument();
+    expect(screen.getByText(/connection reset/)).toBeInTheDocument();
   });
 });

--- a/tests/unit/client/resource-list-page.test.tsx
+++ b/tests/unit/client/resource-list-page.test.tsx
@@ -255,8 +255,8 @@ describe('ResourceListPage', () => {
     useClustersStore.setState({ selected: ['dev', 'prod', 'stage', 'lab', 'loading', 'ignored'] });
     renderPage('/r/core/v1/pods?field=legacy&q=old&label=tier%3Dfrontend&sel=dev%7Cteam-a%7Cpod-a');
 
-    expect(screen.getByText(/watch denied/)).toBeInTheDocument();
-    expect(screen.getByText(/connection lost/)).toBeInTheDocument();
+    expect(screen.queryByText(/watch denied/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/connection lost/)).not.toBeInTheDocument();
     expect(screen.getByText(/not installed on this cluster/)).toBeInTheDocument();
     expect(screen.getByText(/metrics-server is not reachable/)).toBeInTheDocument();
     expect(screen.getByTestId('table-state')).toHaveTextContent('loading');

--- a/tests/unit/client/watch-client.test.ts
+++ b/tests/unit/client/watch-client.test.ts
@@ -52,7 +52,7 @@ describe('watch context issues', () => {
     const snapshots: ContextWatchIssues[] = [];
     const stopIssues = watchClient.onContextIssues((issues) => snapshots.push(issues));
     const stopWatch = watchClient.subscribe(
-      { ctx: 'dev', group: 'core', version: 'v1', plural: 'pods' },
+      { ctx: 'constructor', group: 'core', version: 'v1', plural: 'pods' },
       { onSnapshot: vi.fn(), onEvents: vi.fn(), onStatus: vi.fn() },
     );
     const socket = MockWebSocket.instances[0]!;
@@ -60,10 +60,10 @@ describe('watch context issues', () => {
     const subscription = JSON.parse(socket.sent[0]!) as { id: string };
 
     socket.receive({ op: 'status', id: subscription.id, state: 'reconnecting', message: 'connection lost' });
-    expect(snapshots.at(-1)).toEqual({ dev: { state: 'reconnecting', message: 'connection lost' } });
+    expect(snapshots.at(-1)).toEqual(new Map([['constructor', { state: 'reconnecting', message: 'connection lost' }]]));
 
     socket.receive({ op: 'status', id: subscription.id, state: 'live' });
-    expect(snapshots.at(-1)).toEqual({});
+    expect(snapshots.at(-1)).toEqual(new Map());
 
     stopIssues();
     stopWatch();

--- a/tests/unit/client/watch-client.test.ts
+++ b/tests/unit/client/watch-client.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { watchClient, type ContextWatchIssues } from '../../../client/src/api/ws/watch-client';
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen?: () => void;
+  onmessage?: (event: { data: string }) => void;
+  onclose?: () => void;
+  onerror?: () => void;
+  sent: string[] = [];
+
+  constructor(_url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  send(message: string) {
+    this.sent.push(message);
+  }
+
+  close() {
+    this.readyState = 3;
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(message: unknown) {
+    this.onmessage?.({ data: JSON.stringify(message) });
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  MockWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', MockWebSocket);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('watch context issues', () => {
+  it('aggregates subscription failures by context and clears them when live', () => {
+    const snapshots: ContextWatchIssues[] = [];
+    const stopIssues = watchClient.onContextIssues((issues) => snapshots.push(issues));
+    const stopWatch = watchClient.subscribe(
+      { ctx: 'dev', group: 'core', version: 'v1', plural: 'pods' },
+      { onSnapshot: vi.fn(), onEvents: vi.fn(), onStatus: vi.fn() },
+    );
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+    const subscription = JSON.parse(socket.sent[0]!) as { id: string };
+
+    socket.receive({ op: 'status', id: subscription.id, state: 'reconnecting', message: 'connection lost' });
+    expect(snapshots.at(-1)).toEqual({ dev: { state: 'reconnecting', message: 'connection lost' } });
+
+    socket.receive({ op: 'status', id: subscription.id, state: 'live' });
+    expect(snapshots.at(-1)).toEqual({});
+
+    stopIssues();
+    stopWatch();
+    vi.advanceTimersByTime(30_000);
+  });
+});


### PR DESCRIPTION
## Summary

- aggregate live watch connectivity failures per selected cluster
- turn affected cluster indicators orange in both the top bar and cluster picker
- replace page-level watch alerts with a compact affected-cluster count and optional scrollable details
- keep healthy and deselected cluster indicators unchanged
- add coverage for watch-status aggregation, multi-cluster summaries, and page layout stability

## Why

Intermittent cluster connectivity caused resource and event pages to repeatedly resize as watch alerts appeared and disappeared. Keeping this state in the cluster picker makes connectivity visible without shifting the active page, while the collapsed summary scales to multiple affected clusters.

## Validation

- `pnpm test` — 72 test files, 912 tests passed
- `pnpm --filter @kubus/tests typecheck`
- `pnpm lint`
- shared, client, and server production builds
- isolated Playwright verification with an unreachable cluster

Closes #116