### PR TITLE
Refresh bulk delete selection count

### DIFF
--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -7,7 +7,7 @@ import Chip from '@mui/material/Chip';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { DataGrid, type GridColDef, type GridColumnVisibilityModel, type GridRowParams, type GridSortModel } from '@mui/x-data-grid';
+import { DataGrid, type GridColDef, type GridColumnVisibilityModel, type GridRowParams, type GridRowSelectionModel, type GridSortModel } from '@mui/x-data-grid';
 import type { ClusterRow } from '../api/queries.js';
 import { matchesPlainText, matchesSmartFilter, parseSmartFilter } from '../smart-filter.js';
 import { joinLabelSelector, splitLabelSelector } from '../label-selector.js';
@@ -42,6 +42,8 @@ interface Props {
   toolbar?: ReactNode;
   /** Enable checkbox selection; returns selected rows. */
   onSelectionChange?: (rows: ClusterRow[]) => void;
+  /** Controlled checkbox selection, kept in sync with external bulk actions. */
+  selectedRows?: ClusterRow[];
   checkboxSelection?: boolean;
   /** Column fields hidden by default (user can re-enable via the column menu). */
   hiddenFields?: string[];
@@ -87,6 +89,7 @@ export function ResourceTable({
   toolbar,
   checkboxSelection,
   onSelectionChange,
+  selectedRows,
   hiddenFields,
   tableId,
   activeRowId,
@@ -196,6 +199,10 @@ export function ResourceTable({
   }, [rows, parsedFilter, kind, metricsForFilter]);
 
   const rowsById = useMemo(() => new Map(filtered.map((row) => [row.obj.metadata.uid, row])), [filtered]);
+  const rowSelectionModel = useMemo<GridRowSelectionModel | undefined>(
+    () => selectedRows && { type: 'include', ids: new Set(selectedRows.map((row) => row.obj.metadata.uid)) },
+    [selectedRows],
+  );
   // Scanning and sorting every row's labels is only worth doing while the
   // dropdown is open — not on every watch flush of a large list.
   const [labelsOpen, setLabelsOpen] = useState(false);
@@ -336,6 +343,7 @@ export function ResourceTable({
         // reserve a real gutter instead.
         scrollbarSize={layout.scrollbarSize}
         checkboxSelection={checkboxSelection}
+        rowSelectionModel={rowSelectionModel}
         slots={{ noRowsOverlay: NoRowsOverlay }}
         onRowSelectionModelChange={
           onSelectionChange

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -684,6 +684,7 @@ export function ResourceListPage() {
           setContextMenuOpen(true);
         }}
         checkboxSelection
+        selectedRows={selectedRows}
         onSelectionChange={setSelectedRows}
         hiddenFields={hiddenFields}
         activeRowId={activeRowId}

--- a/client/src/pages/ResourceListPage.tsx
+++ b/client/src/pages/ResourceListPage.tsx
@@ -393,12 +393,22 @@ export function ResourceListPage() {
 
   const bulkRestartable = kind === 'Deployment' || kind === 'StatefulSet' || kind === 'DaemonSet';
   const bulkProtected = selectedRows.some((r) => contextSettings[r.ctx]?.protected ?? protectByDefault);
-  const runBulk = async (verb: string, run: (row: ClusterRow) => Promise<unknown>) => {
+  const runBulk = async (
+    verb: string,
+    run: (row: ClusterRow) => Promise<unknown>,
+    options: { clearSucceeded?: boolean } = {},
+  ) => {
     const rows = selectedRows;
     setBulkBusy(true);
     const results = await Promise.allSettled(rows.map((row) => run(row)));
     setBulkBusy(false);
     setBulkDialog(null);
+    if (options.clearSucceeded) {
+      const succeeded = new Set(
+        rows.flatMap((row, i) => (results[i]?.status === 'fulfilled' ? [row.obj.metadata.uid] : [])),
+      );
+      setSelectedRows((current) => current.filter((row) => !succeeded.has(row.obj.metadata.uid)));
+    }
     const failures = results
       .map((result, i) => ({ result, row: rows[i]! }))
       .filter((f): f is { result: PromiseRejectedResult; row: ClusterRow } => f.result.status === 'rejected');
@@ -743,8 +753,11 @@ export function ResourceListPage() {
         confirmText={bulkProtected ? `delete ${selectedRows.length}` : undefined}
         onClose={() => setBulkDialog(null)}
         onConfirm={() =>
-          void runBulk('Deleted', (row) =>
-            del.mutateAsync({ ctx: row.ctx, group, version, plural, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace }),
+          void runBulk(
+            'Deleted',
+            (row) =>
+              del.mutateAsync({ ctx: row.ctx, group, version, plural, name: row.obj.metadata.name, namespace: row.obj.metadata.namespace }),
+            { clearSucceeded: true },
           )
         }
       />

--- a/tests/unit/client/resource-list-page.test.tsx
+++ b/tests/unit/client/resource-list-page.test.tsx
@@ -66,6 +66,7 @@ vi.mock('../../../client/src/components/ResourceTable.js', () => ({
     columns: Array<{ field: string; valueGetter?: (...args: unknown[]) => unknown; renderCell?: (params: { row: Row; value?: unknown }) => ReactNode }>;
     toolbar?: ReactNode;
     onSelectionChange?: (rows: Row[]) => void;
+    selectedRows?: Row[];
     onFilterChange?: (value: string) => void;
     onLabelSelectorChange?: (value: string) => void;
     onRowClick?: (row: Row) => void;
@@ -77,7 +78,9 @@ vi.mock('../../../client/src/components/ResourceTable.js', () => ({
   }) => (
     <section data-testid="resource-table">
       <div>{props.toolbar}</div>
-      <output data-testid="table-state">{JSON.stringify({ hidden: props.hiddenFields, active: props.activeRowId, loading: props.loading })}</output>
+      <output data-testid="table-state">
+        {JSON.stringify({ hidden: props.hiddenFields, active: props.activeRowId, loading: props.loading, selected: props.selectedRows?.map((row) => row.obj.metadata.name) })}
+      </output>
       <button onClick={() => props.onSelectionChange?.(props.rows)}>Mock select all</button>
       <button onClick={() => props.onSelectionChange?.([])}>Mock clear selection</button>
       <button onClick={() => props.onFilterChange?.('failed pods')}>Mock text filter</button>
@@ -287,6 +290,7 @@ describe('ResourceListPage', () => {
     await waitFor(() => expect(effects.toast).toHaveBeenCalledWith('success', 'Deleted 2 Pods'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     expect(screen.queryByRole('button', { name: 'Delete (2)' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('table-state')).toHaveTextContent('"selected":[]');
 
     fireEvent.keyDown(window, { key: 'c' });
     expect(screen.getByText(/Create resource on dev/)).toBeInTheDocument();
@@ -319,6 +323,7 @@ describe('ResourceListPage', () => {
     await waitFor(() => expect(effects.toast).toHaveBeenCalledWith('error', expect.stringContaining('cannot delete web-b')));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     expect(screen.getByRole('button', { name: 'Delete (1)' })).toBeInTheDocument();
+    expect(screen.getByTestId('table-state')).toHaveTextContent('"selected":["web-b"]');
   });
 
   it('builds custom printer columns and links the API drawer to its CRD', () => {

--- a/tests/unit/client/resource-list-page.test.tsx
+++ b/tests/unit/client/resource-list-page.test.tsx
@@ -285,6 +285,8 @@ describe('ResourceListPage', () => {
     fireEvent.change(screen.getByPlaceholderText('delete 2'), { target: { value: 'delete 2' } });
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
     await waitFor(() => expect(effects.toast).toHaveBeenCalledWith('success', 'Deleted 2 Pods'));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Delete (2)' })).not.toBeInTheDocument();
 
     fireEvent.keyDown(window, { key: 'c' });
     expect(screen.getByText(/Create resource on dev/)).toBeInTheDocument();
@@ -315,6 +317,8 @@ describe('ResourceListPage', () => {
     fireEvent.change(screen.getByPlaceholderText('delete 2'), { target: { value: 'delete 2' } });
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
     await waitFor(() => expect(effects.toast).toHaveBeenCalledWith('error', expect.stringContaining('cannot delete web-b')));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Delete (1)' })).toBeInTheDocument();
   });
 
   it('builds custom printer columns and links the API drawer to its CRD', () => {

--- a/tests/unit/client/resource-table.test.tsx
+++ b/tests/unit/client/resource-table.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClusterRow } from '../../../client/src/api/queries';
+import { ResourceTable } from '../../../client/src/components/ResourceTable';
+
+vi.mock('../../../client/src/components/SmartFilterInput.js', () => ({ SmartFilterInput: () => null }));
+vi.mock('../../../client/src/components/CellCopy.js', () => ({
+  copyCellGridSx: {},
+  handleCopyCellKeyDown: vi.fn(),
+  withCellCopy: (column: unknown) => column,
+}));
+vi.mock('../../../client/src/components/quick-search.js', () => ({ useQuickSearchShortcut: vi.fn() }));
+
+function row(name: string): ClusterRow {
+  return {
+    ctx: 'dev',
+    obj: {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name, namespace: 'default', uid: `uid-${name}` },
+    },
+  };
+}
+
+describe('ResourceTable selection', () => {
+  it('synchronizes the grid model when an external bulk action clears selected rows', () => {
+    const first = row('first');
+    const second = row('second');
+    const columns = [{ field: 'name', valueGetter: (_value: unknown, current: ClusterRow) => current.obj.metadata.name }];
+    const { rerender } = render(
+      <ResourceTable rows={[first, second]} columns={columns} checkboxSelection selectedRows={[first, second]} onSelectionChange={vi.fn()} />,
+    );
+
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+    expect(screen.getAllByRole('checkbox').every((checkbox) => (checkbox as HTMLInputElement).checked)).toBe(true);
+
+    rerender(<ResourceTable rows={[first, second]} columns={columns} checkboxSelection selectedRows={[]} onSelectionChange={vi.fn()} />);
+    return waitFor(() => expect(screen.getAllByRole('checkbox').every((checkbox) => !(checkbox as HTMLInputElement).checked)).toBe(true));
+  });
+});


### PR DESCRIPTION
## Summary

- remove successfully deleted resources from the bulk selection
- keep failed deletions selected so they can be retried
- cover full-success and partial-failure counter updates with regression tests

## Root cause

The bulk delete flow closed its confirmation dialog after completion but left `selectedRows` unchanged. That kept the toolbar counter stale even after the selected resources disappeared from the watched list.

## Validation

- `pnpm lint`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- `pnpm --filter @kubus/tests exec vitest run tests/unit/client/resource-list-page.test.tsx --project client`
- built-client UI verification against an isolated server and throwaway ConfigMaps