### PR TITLE
Show CPU and memory capacity for each node

### DIFF
--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -362,8 +362,14 @@ function NodeUsageCard({ ctx, nodeMetrics }: { ctx: string; nodeMetrics: ReturnT
                 <Typography variant="body2" sx={{ width: 220 }} noWrap>
                   {n.name}
                 </Typography>
-                <UsageBar label={`CPU ${formatCpu(n.cpuMilli)}`} pct={n.cpuCapacityMilli ? (n.cpuMilli / n.cpuCapacityMilli) * 100 : undefined} />
-                <UsageBar label={`Mem ${formatBytes(n.memBytes)}`} pct={n.memCapacityBytes ? (n.memBytes / n.memCapacityBytes) * 100 : undefined} />
+                <UsageBar
+                  label={`CPU ${formatCpu(n.cpuMilli)}${n.cpuCapacityMilli ? ` / ${formatCpu(n.cpuCapacityMilli)}` : ''}`}
+                  pct={n.cpuCapacityMilli ? (n.cpuMilli / n.cpuCapacityMilli) * 100 : undefined}
+                />
+                <UsageBar
+                  label={`Mem ${formatBytes(n.memBytes)}${n.memCapacityBytes ? ` / ${formatBytes(n.memCapacityBytes)}` : ''}`}
+                  pct={n.memCapacityBytes ? (n.memBytes / n.memCapacityBytes) * 100 : undefined}
+                />
               </Box>
             ))}
           </Stack>

--- a/tests/unit/client/overview-page.test.tsx
+++ b/tests/unit/client/overview-page.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClusterOverview, MetricsSnapshot } from '@kubus/shared';
+import { OverviewPage } from '../../../client/src/pages/OverviewPage';
+import { useClustersStore } from '../../../client/src/state/clusters';
+
+const fixtures = vi.hoisted(() => ({
+  overview: undefined as ClusterOverview | undefined,
+  nodeMetrics: undefined as MetricsSnapshot | undefined,
+}));
+
+vi.mock('../../../client/src/api/queries.js', () => ({
+  useApiResources: () => ({ data: [] }),
+  useContexts: () => ({ data: [] }),
+  useKubeconfigSettings: () => ({ data: undefined }),
+  useNodeMetrics: () => ({ data: fixtures.nodeMetrics }),
+  useOverview: () => ({ data: fixtures.overview, isLoading: false, error: null }),
+  useOverviewCertificates: () => ({ data: undefined }),
+  useOverviewOperators: () => ({ data: undefined }),
+}));
+
+vi.mock('../../../client/src/components/ClusterSectionHeader.js', () => ({
+  ClusterSectionHeader: ({ ctx }: { ctx: string }) => <h2>{ctx}</h2>,
+}));
+vi.mock('../../../client/src/components/overview/CertExpiryCard.js', () => ({ CertExpiryCard: () => null }));
+vi.mock('../../../client/src/components/overview/NamespaceOverviewSection.js', () => ({ NamespaceOverviewSection: () => null }));
+vi.mock('../../../client/src/components/overview/OperatorSection.js', () => ({ OperatorSection: () => null }));
+vi.mock('../../../client/src/components/overview/PodUsagePanels.js', () => ({ PodUsagePanels: () => null }));
+vi.mock('../../../client/src/components/overview/WorkloadHealthSection.js', () => ({ WorkloadHealthSection: () => null }));
+
+beforeEach(() => {
+  useClustersStore.setState({ selected: ['dev'], namespaces: [] });
+  fixtures.overview = {
+    counts: {
+      nodes: 1,
+      namespaces: 1,
+      pods: 0,
+      podsRunning: 0,
+      deployments: 0,
+      persistentVolumes: 0,
+      persistentVolumesBound: 0,
+      persistentVolumesUnavailable: false,
+      crds: 0,
+      crdsEstablished: 0,
+      crdsUnavailable: false,
+      customResources: 0,
+      customResourcesIndexed: true,
+    },
+    failingPods: [],
+    unavailableWorkloads: [],
+    recentRestarts: [],
+    warningEvents: [],
+    workloadHealth: [],
+  };
+  fixtures.nodeMetrics = {
+    available: true,
+    probed: true,
+    totalCpuCapacityMilli: 6_000,
+    totalMemCapacityBytes: 16 * 2 ** 30,
+    items: [
+      {
+        name: 'node-a',
+        cpuMilli: 500,
+        memBytes: 2 * 2 ** 30,
+        cpuCapacityMilli: 2_000,
+        memCapacityBytes: 8 * 2 ** 30,
+      },
+    ],
+  };
+});
+
+describe('OverviewPage node usage', () => {
+  it('shows CPU and memory capacity for each node', () => {
+    render(
+      <MemoryRouter>
+        <OverviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('node-a')).toBeInTheDocument();
+    expect(screen.getByText('CPU 500m / 2.00 cores (25%)')).toBeInTheDocument();
+    expect(screen.getByText('Mem 2.0Gi / 8.0Gi (25%)')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- show CPU usage alongside allocatable CPU capacity for every node
- show memory usage alongside allocatable memory capacity for every node
- retain the usage-only fallback when capacity is unavailable
- add regression coverage for the per-node labels

## Why

The overview already received per-node capacity values and used them to calculate percentages, but only displayed the capacity in the total row. This made it harder to compare available resources across individual nodes.

Closes #125.

## Validation

- `pnpm lint`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- `pnpm --filter @kubus/tests typecheck`
- `pnpm --filter @kubus/tests test` (914 tests)
- built-client browser verification