### PR TITLE
Add diagnostic logging controls

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { buildTheme } from './theme.js';
@@ -11,11 +11,18 @@ import { ToastHost } from './components/ToastHost.js';
 import { BackendStatusBanner } from './components/BackendStatusBanner.js';
 import { UpdateNotification } from './components/UpdateNotification.js';
 import { TitleBarAwareBackdrop } from './components/TitleBarAwareBackdrop.js';
+import { setDebugLogging } from './api/logs.js';
+import { useUiPrefsStore } from './state/prefs.js';
+import { useUiStore } from './state/ui.js';
+
+const LogViewerDialog = lazy(() => import('./components/LogViewerDialog.js').then((module) => ({ default: module.LogViewerDialog })));
 
 export default function App() {
   // One app-wide subscription keeps context/discovery queries fresh.
   useContextsInvalidation();
   const themeMode = useClustersStore((s) => s.themeMode);
+  const debugMode = useUiPrefsStore((state) => state.debugMode);
+  const logViewerOpen = useUiStore((state) => state.logViewerOpen);
   const [osTheme, setOsTheme] = useState<'light' | 'dark'>(() =>
     //Check the operating system’s current color scheme and return true if it is dark, false otherwise
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
@@ -26,6 +33,10 @@ export default function App() {
     // Keep the desktop app's native window controls in sync with the theme.
     setTitleBarMode(effectiveMode);
   }, [effectiveMode]);
+  useEffect(() => {
+    // The debug preference is client-side; keep the server's live level in sync.
+    void setDebugLogging(debugMode).catch(() => undefined);
+  }, [debugMode]);
   useEffect(() => {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = (e: MediaQueryListEvent) => setOsTheme(e.matches ? 'dark' : 'light');
@@ -41,6 +52,7 @@ export default function App() {
       <ToastHost />
       <BackendStatusBanner />
       <UpdateNotification />
+      <Suspense fallback={null}>{logViewerOpen ? <LogViewerDialog /> : null}</Suspense>
     </ThemeProvider>
   );
 }

--- a/client/src/api/logs.ts
+++ b/client/src/api/logs.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import type { AppLogEntry, AppLogsResponse } from '@kubus/shared';
+import { apiFetch } from './http.js';
+
+export function fetchAppLogs(): Promise<AppLogsResponse> {
+  return apiFetch<AppLogsResponse>('/api/logs');
+}
+
+/** Diagnostic log buffer, polled only while the viewer is open. */
+export function useAppLogs(enabled: boolean) {
+  return useQuery({
+    queryKey: ['app-logs'],
+    queryFn: fetchAppLogs,
+    enabled,
+    refetchInterval: 2_000,
+  });
+}
+
+/** Raise (or restore) the server's log level; idempotent per window. */
+export function setDebugLogging(debugEnabled: boolean): Promise<{ debugEnabled: boolean }> {
+  return apiFetch<{ debugEnabled: boolean }>('/api/logs/settings', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ debugEnabled }),
+  });
+}
+
+export function clearAppLogs(): Promise<{ cleared: boolean }> {
+  return apiFetch<{ cleared: boolean }>('/api/logs', { method: 'DELETE' });
+}
+
+/** One text line per entry, shared by the viewer, copy, and export. */
+export function formatLogEntry(entry: AppLogEntry): string {
+  const context = entry.context ? ` ${JSON.stringify(entry.context)}` : '';
+  return `${new Date(entry.ts).toISOString()} ${entry.level.toUpperCase().padEnd(5)} ${entry.source.padEnd(6)} ${entry.msg}${context}`;
+}

--- a/client/src/components/LogViewerDialog.tsx
+++ b/client/src/components/LogViewerDialog.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import ContentCopyOutlinedIcon from '@mui/icons-material/ContentCopyOutlined';
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import type { AppLogEntry, AppLogLevel } from '@kubus/shared';
+import { clearAppLogs, formatLogEntry, useAppLogs } from '../api/logs.js';
+import { copyToClipboard } from '../clipboard.js';
+import { exportFilename, saveTextFile } from '../save-file.js';
+import { showErrorToast, showToast } from '../state/toast.js';
+import { useUiStore } from '../state/ui.js';
+
+type LevelFilter = 'all' | 'debug' | 'info' | 'warn' | 'error';
+
+/** Minimum severity per filter choice; 'all' shows trace upward. */
+const LEVEL_RANK: Record<AppLogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+  fatal: 5,
+};
+
+const FILTER_RANK: Record<LevelFilter, number> = {
+  all: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+function levelColor(level: AppLogLevel): string {
+  if (level === 'error' || level === 'fatal') return 'error.main';
+  if (level === 'warn') return 'warning.main';
+  if (level === 'debug' || level === 'trace') return 'text.secondary';
+  return 'text.primary';
+}
+
+function matches(entry: AppLogEntry, filter: LevelFilter, query: string): boolean {
+  if (LEVEL_RANK[entry.level] < FILTER_RANK[filter]) return false;
+  if (!query) return true;
+  return formatLogEntry(entry).toLowerCase().includes(query);
+}
+
+/** Diagnostic log viewer over the server's bounded in-memory buffer. */
+export function LogViewerDialog() {
+  const open = useUiStore((state) => state.logViewerOpen);
+  const setOpen = useUiStore((state) => state.setLogViewerOpen);
+  const { data, refetch } = useAppLogs(open);
+  const [filter, setFilter] = useState<LevelFilter>('all');
+  const [query, setQuery] = useState('');
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const pinnedToEnd = useRef(true);
+
+  const entries = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    return (data?.entries ?? []).filter((entry) => matches(entry, filter, needle));
+  }, [data?.entries, filter, query]);
+
+  // Follow new output like a terminal until the user scrolls back up.
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element && pinnedToEnd.current) element.scrollTop = element.scrollHeight;
+  }, [entries]);
+
+  const exportText = () =>
+    [
+      `# Kubus diagnostic log — exported ${new Date().toISOString()}`,
+      `# ${entries.length} entries, debug logging ${data?.debugEnabled ? 'on' : 'off'}`,
+      ...entries.map(formatLogEntry),
+    ].join('\n');
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => setOpen(false)}
+      maxWidth="lg"
+      fullWidth
+      slotProps={{ paper: { sx: { height: '80vh' } } }}
+      aria-labelledby="app-log-viewer-title"
+    >
+      <DialogTitle id="app-log-viewer-title" sx={{ pb: 1 }}>
+        Diagnostic logs
+      </DialogTitle>
+      <DialogContent dividers sx={{ display: 'flex', flexDirection: 'column', gap: 1.5, p: 2 }}>
+        <Stack direction="row" spacing={1.5} sx={{ alignItems: 'center' }}>
+          <TextField
+            select
+            size="small"
+            label="Level"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value as LevelFilter)}
+            sx={{ width: 130 }}
+          >
+            <MenuItem value="all">All</MenuItem>
+            <MenuItem value="debug">Debug +</MenuItem>
+            <MenuItem value="info">Info +</MenuItem>
+            <MenuItem value="warn">Warning +</MenuItem>
+            <MenuItem value="error">Error</MenuItem>
+          </TextField>
+          <TextField
+            size="small"
+            label="Filter"
+            placeholder="cluster, namespace, message, error …"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            sx={{ flex: 1, maxWidth: 360 }}
+          />
+          <Box sx={{ flex: 1 }} />
+          <Typography variant="caption" color="text.secondary">
+            {entries.length} of {data?.entries.length ?? 0} entries
+          </Typography>
+        </Stack>
+        {data && !data.debugEnabled ? (
+          <Alert severity="info" sx={{ py: 0 }}>
+            Debug logging is off — only informational messages, warnings and errors are captured. Turn on debug mode in the settings for detailed diagnostics.
+          </Alert>
+        ) : null}
+        <Box
+          ref={scrollRef}
+          onScroll={(event) => {
+            const element = event.currentTarget;
+            pinnedToEnd.current = element.scrollHeight - element.scrollTop - element.clientHeight < 24;
+          }}
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            overflow: 'auto',
+            borderRadius: 1,
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.default',
+            p: 1.5,
+            fontFamily: 'monospace',
+            fontSize: 12,
+            lineHeight: 1.6,
+          }}
+        >
+          {entries.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              Nothing captured yet. Cluster operations, warnings and errors show up here as they happen.
+            </Typography>
+          ) : (
+            entries.map((entry, index) => (
+              <Box
+                key={`${entry.ts}-${index}`}
+                sx={{
+                  whiteSpace: 'pre-wrap',
+                  overflowWrap: 'anywhere',
+                  color: levelColor(entry.level),
+                  contentVisibility: 'auto',
+                }}
+              >
+                {formatLogEntry(entry)}
+              </Box>
+            ))
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          size="small"
+          startIcon={<DeleteOutlineOutlinedIcon />}
+          onClick={() => {
+            clearAppLogs()
+              .then(() => refetch())
+              .catch(showErrorToast);
+          }}
+        >
+          Clear
+        </Button>
+        <Button
+          size="small"
+          startIcon={<ContentCopyOutlinedIcon />}
+          disabled={entries.length === 0}
+          onClick={() => {
+            void copyToClipboard(exportText()).then((copied) => {
+              if (copied) showToast('success', 'Log copied to the clipboard.');
+            });
+          }}
+        >
+          Copy
+        </Button>
+        <Button
+          size="small"
+          startIcon={<DownloadOutlinedIcon />}
+          disabled={entries.length === 0}
+          onClick={() => saveTextFile(exportFilename('debug log', 'log'), exportText())}
+        >
+          Export
+        </Button>
+        <Box sx={{ flex: 1 }} />
+        <Button variant="contained" onClick={() => setOpen(false)}>
+          Close
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/client/src/components/settings/SettingsDialog.tsx
+++ b/client/src/components/settings/SettingsDialog.tsx
@@ -29,6 +29,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import ShieldIcon from '@mui/icons-material/Shield';
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
@@ -45,6 +46,10 @@ import { useClustersStore } from '../../state/clusters.js';
 import { useLogPrefsStore, type TsMode } from '../../state/log-prefs.js';
 import { TAIL_LINE_OPTIONS, useUiPrefsStore, type RefreshRate, type RightClickAction, type TableDensity } from '../../state/prefs.js';
 import { KubeconfigSection } from './KubeconfigSection.js';
+import { fetchAppLogs, formatLogEntry } from '../../api/logs.js';
+import { exportFilename, saveTextFile } from '../../save-file.js';
+import { showErrorToast } from '../../state/toast.js';
+import { useUiStore } from '../../state/ui.js';
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -420,6 +425,59 @@ function LogsTerminalSection() {
   );
 }
 
+/** Diagnostic logging: verbose capture plus viewer and export controls. */
+function DebugSection() {
+  const debugMode = useUiPrefsStore((state) => state.debugMode);
+  const setPrefs = useUiPrefsStore((state) => state.set);
+  const setLogViewerOpen = useUiStore((state) => state.setLogViewerOpen);
+
+  const exportLogs = () => {
+    fetchAppLogs()
+      .then((logs) => {
+        saveTextFile(
+          exportFilename('debug log', 'log'),
+          [
+            `# Kubus diagnostic log — exported ${new Date().toISOString()}`,
+            `# ${logs.entries.length} entries, debug logging ${logs.debugEnabled ? 'on' : 'off'}`,
+            ...logs.entries.map(formatLogEntry),
+          ].join('\n'),
+        );
+      })
+      .catch(showErrorToast);
+  };
+
+  return (
+    <Stack spacing={3}>
+      <Section title="Debug mode">
+        <FormControlLabel
+          control={<Switch checked={debugMode} onChange={(event) => setPrefs({ debugMode: event.target.checked })} />}
+          label={
+            <Box>
+              <Typography variant="body2">Capture verbose diagnostic logs</Typography>
+              <Typography variant="caption" color="text.secondary">
+                Records cluster discovery, API access, watches, port forwards and Helm operations in greater detail. Warnings and errors are always captured, even while this is off.
+              </Typography>
+            </Box>
+          }
+        />
+      </Section>
+      <Section title="Logs">
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" size="small" startIcon={<ArticleOutlinedIcon />} onClick={() => setLogViewerOpen(true)}>
+            View logs
+          </Button>
+          <Button variant="outlined" size="small" startIcon={<DownloadOutlinedIcon />} onClick={exportLogs}>
+            Export logs
+          </Button>
+        </Stack>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+          Covers app startup and operations since launch. Logs are held in memory on this machine only and never leave it unless you export them. If the desktop app fails to launch entirely, its shell also writes logs/main.log in the app data directory.
+        </Typography>
+      </Section>
+    </Stack>
+  );
+}
+
 function updateReasonLabel(reason?: string): string {
   switch (reason) {
     case 'timeout':
@@ -529,7 +587,7 @@ function AboutSection() {
   );
 }
 
-const TABS = ['Kubeconfig', 'Clusters', 'Appearance', 'Data & refresh', 'Logs & terminal', 'About'];
+const TABS = ['Kubeconfig', 'Clusters', 'Appearance', 'Data & refresh', 'Logs & terminal', 'Debug', 'About'];
 
 export function SettingsDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [tab, setTab] = useState(0);
@@ -553,7 +611,8 @@ export function SettingsDialog({ open, onClose }: { open: boolean; onClose: () =
           {tab === 2 && <AppearanceSection />}
           {tab === 3 && <RefreshSection />}
           {tab === 4 && <LogsTerminalSection />}
-          {tab === 5 && <AboutSection />}
+          {tab === 5 && <DebugSection />}
+          {tab === 6 && <AboutSection />}
         </Box>
       </DialogContent>
       <DialogActions>

--- a/client/src/save-file.ts
+++ b/client/src/save-file.ts
@@ -1,0 +1,18 @@
+/** Save text as a downloaded file (browser download / desktop save-as). */
+export function saveTextFile(filename: string, text: string, mime = 'text/plain'): void {
+  const url = URL.createObjectURL(new Blob([text], { type: `${mime};charset=utf-8` }));
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+/** "kubus-<slug>-YYYYMMDD-HHMMSS.<ext>" for user exports. */
+export function exportFilename(title: string, ext: string): string {
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'export';
+  const now = new Date();
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `kubus-${slug}-${stamp}.${ext}`;
+}

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -35,6 +35,8 @@ interface UiPrefsState {
   highUsagePct: number;
   /** Overview "under-requested" pod panel: usage ≥ this multiple of the request. */
   underRequestedFactor: number;
+  /** Verbose diagnostic logging plus access to the app log viewer and export. */
+  debugMode: boolean;
   /** User-resized column widths, keyed by table id then column field. */
   columnWidths: Record<string, Record<string, number>>;
   /** User-toggled column visibility models, keyed by table id then column field. */
@@ -76,6 +78,7 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       cronHumanSchedule: false,
       highUsagePct: 80,
       underRequestedFactor: 2,
+      debugMode: false,
       columnWidths: {},
       columnVisibility: {},
       sortModels: {},

--- a/client/src/state/ui.ts
+++ b/client/src/state/ui.ts
@@ -9,11 +9,13 @@ interface UiState {
   searchOpen: boolean;
   settingsOpen: boolean;
   shortcutsOpen: boolean;
+  logViewerOpen: boolean;
   /** When a `g` go-to sequence is pending: its Date.now() start; 0 = none. Drives the which-key panel. */
   goPendingSince: number;
   setSearchOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
   setShortcutsOpen: (open: boolean) => void;
+  setLogViewerOpen: (open: boolean) => void;
   startGoPending: () => void;
   clearGoPending: () => void;
 }
@@ -22,10 +24,12 @@ export const useUiStore = create<UiState>((set) => ({
   searchOpen: false,
   settingsOpen: false,
   shortcutsOpen: false,
+  logViewerOpen: false,
   goPendingSince: 0,
   setSearchOpen: (searchOpen) => set({ searchOpen }),
   setSettingsOpen: (settingsOpen) => set({ settingsOpen }),
   setShortcutsOpen: (shortcutsOpen) => set({ shortcutsOpen }),
+  setLogViewerOpen: (logViewerOpen) => set({ logViewerOpen }),
   startGoPending: () => set({ goPendingSince: Date.now() }),
   clearGoPending: () => set((s) => (s.goPendingSince ? { goPendingSince: 0 } : s)),
 }));

--- a/electron/src/main-log.ts
+++ b/electron/src/main-log.ts
@@ -1,0 +1,66 @@
+import { appendFileSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { appendAppLog } from '@kubus/server';
+
+/**
+ * Main-process diagnostics. Every entry goes to the in-process viewer buffer
+ * and to a plain-text file that survives failures before a window can open.
+ */
+const MAX_LOG_BYTES = 1024 * 1024;
+
+let logFile: string | undefined;
+
+export function initMainLog(userDataDir: string): void {
+  try {
+    const dir = path.join(userDataDir, 'logs');
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'main.log');
+    try {
+      if (statSync(file).size > MAX_LOG_BYTES) renameSync(file, path.join(dir, 'main.old.log'));
+    } catch {
+      // First run: no file yet.
+    }
+    logFile = file;
+  } catch {
+    // Diagnostics never block startup; the in-memory mirror still works.
+  }
+}
+
+export function mainLogPath(): string | undefined {
+  return logFile;
+}
+
+function describeError(err: unknown): string | undefined {
+  if (err === undefined) return undefined;
+  if (err instanceof Error) return err.stack ?? `${err.name}: ${err.message}`;
+  if (typeof err === 'string') return err;
+  if (typeof err === 'number' || typeof err === 'boolean' || typeof err === 'bigint') return String(err);
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return Object.prototype.toString.call(err);
+  }
+}
+
+export function mainLog(level: 'info' | 'warn' | 'error', msg: string, err?: unknown): void {
+  const detail = describeError(err);
+  appendAppLog(level, msg, detail ? { err: detail } : undefined);
+  if (!logFile) return;
+  const line = `${new Date().toISOString()} ${level.toUpperCase()} ${msg}${detail ? `\n  ${detail.replaceAll('\n', '\n  ')}` : ''}\n`;
+  try {
+    appendFileSync(logFile, line);
+  } catch {
+    // Never let logging take the app down.
+  }
+}
+
+/** Last-resort capture: observe fatal main-process errors without handling them. */
+export function installCrashCapture(): void {
+  process.on('uncaughtExceptionMonitor', (err, origin) => {
+    mainLog(
+      'error',
+      origin === 'unhandledRejection' ? 'unhandled promise rejection in the main process' : 'uncaught exception in the main process',
+      err,
+    );
+  });
+}

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import {
   app,
   BrowserWindow,
+  dialog,
   type IpcMainEvent,
   type IpcMainInvokeEvent,
   ipcMain,
@@ -14,6 +15,7 @@ import {
 } from 'electron';
 import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@kubus/server';
+import { initMainLog, installCrashCapture, mainLog, mainLogPath } from './main-log.js';
 
 // GUI apps on macOS/Linux don't inherit the shell PATH; kubeconfig exec
 // plugins (aws, gke-gcloud-auth-plugin, kubelogin, ...) need it.
@@ -23,6 +25,9 @@ fixPath();
 // ("@kubus/electron") and never matches the .desktop StartupWMClass,
 // leaving the window without taskbar/dock icon.
 app.setName('Kubus');
+initMainLog(app.getPath('userData'));
+installCrashCapture();
+mainLog('info', `Kubus ${app.getVersion()} starting on ${process.platform}/${process.arch} (Electron ${process.versions.electron})`);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isMac = process.platform === 'darwin';
@@ -333,6 +338,9 @@ function createWindow(url: string): void {
   mainWindow.webContents.on('did-start-loading', () => {
     rendererRouteReady = false;
   });
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    mainLog('error', `window renderer gone (${details.reason}, exit code ${details.exitCode})`);
+  });
   mainWindow.webContents.setWindowOpenHandler(({ url: external }) => {
     void shell.openExternal(external);
     return { action: 'deny' };
@@ -500,10 +508,16 @@ if (!app.requestSingleInstanceLock()) {
           : path.resolve(__dirname, '../../client/dist'),
       });
     } catch (err) {
-      console.error('failed to start kubus server', err);
+      mainLog('error', 'the embedded server failed to start', err);
+      const logPath = mainLogPath();
+      dialog.showErrorBox(
+        'Kubus failed to start',
+        `${err instanceof Error ? err.message : String(err)}${logPath ? `\n\nDetails were written to:\n${logPath}` : ''}`,
+      );
       app.quit();
       return;
     }
+    mainLog('info', `server listening at ${server.url}`);
     buildMenu();
     createWindow(server.url);
   });

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -517,7 +517,9 @@ if (!app.requestSingleInstanceLock()) {
       app.quit();
       return;
     }
-    mainLog('info', `server listening at ${server.url}`);
+    // server.url carries the renderer's bearer token. Keep credentials out of
+    // the persistent main-process log and the exportable diagnostic buffer.
+    mainLog('info', `server listening at ${new URL(server.url).origin}`);
     buildMenu();
     createWindow(server.url);
   });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,7 +1,8 @@
 import path from 'node:path';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyBaseLogger, type FastifyInstance } from 'fastify';
+import pino from 'pino';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyStatic from '@fastify/static';
 import type { ServerConfig } from './config.js';
@@ -25,11 +26,13 @@ import { registerGraphRoutes } from './routes/graph.js';
 import { registerAuditRoutes } from './routes/audit.js';
 import { registerSearchRoutes } from './routes/search.js';
 import { registerFileRoutes } from './routes/files.js';
+import { registerLogRoutes } from './routes/logs.js';
 import { broadcastWatchMessage, registerWatchSocket } from './ws/watch-socket.js';
 import { registerLogsSocket } from './ws/logs-socket.js';
 import { registerExecSocket } from './ws/exec-socket.js';
 import { registerNodeShellSocket } from './ws/node-shell-socket.js';
 import { HelmOperationManager } from './helm/operations.js';
+import { appLogPinoSink } from './logging/log-buffer.js';
 
 export interface AppContext {
   config: ServerConfig;
@@ -44,12 +47,28 @@ export interface AppContext {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/** The level the server returns to when debug logging is switched off. */
+export function baseLogLevel(): string {
+  return process.env.LOG_LEVEL ?? 'info';
+}
+
+/** Mirror every accepted pino record to the console and in-memory log viewer. */
+function buildLogger(config: ServerConfig): FastifyBaseLogger {
+  const console = config.prettyLogs
+    ? (pino.transport({ target: 'pino-pretty', options: { translateTime: 'HH:MM:ss' } }) as pino.DestinationStream)
+    : process.stdout;
+  return pino(
+    { level: baseLogLevel() },
+    pino.multistream([
+      { level: 'trace', stream: console },
+      { level: 'trace', stream: appLogPinoSink() },
+    ]),
+  ) as FastifyBaseLogger;
+}
+
 export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInstance; ctx: AppContext }> {
   const app = Fastify({
-    logger: {
-      level: process.env.LOG_LEVEL ?? 'info',
-      transport: config.prettyLogs ? { target: 'pino-pretty', options: { translateTime: 'HH:MM:ss' } } : undefined,
-    },
+    loggerInstance: buildLogger(config),
     // Resource lists can be large; YAML applies too.
     bodyLimit: 32 * 1024 * 1024,
   });
@@ -110,6 +129,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   registerAuditRoutes(app, ctx);
   registerSearchRoutes(app, ctx);
   registerFileRoutes(app, ctx);
+  registerLogRoutes(app);
   registerWatchSocket(app, ctx);
   registerLogsSocket(app, ctx);
   registerExecSocket(app, ctx);

--- a/server/src/logging/log-buffer.ts
+++ b/server/src/logging/log-buffer.ts
@@ -1,0 +1,108 @@
+import type { AppLogEntry, AppLogLevel } from '@kubus/shared';
+
+export const APP_LOG_CAPACITY = 5000;
+
+/** pino numeric levels → names; unknown values round down to 'info'. */
+const PINO_LEVELS: Array<[number, AppLogLevel]> = [
+  [60, 'fatal'],
+  [50, 'error'],
+  [40, 'warn'],
+  [30, 'info'],
+  [20, 'debug'],
+  [10, 'trace'],
+];
+
+function levelName(value: unknown): AppLogLevel {
+  if (typeof value !== 'number') return 'info';
+  for (const [threshold, name] of PINO_LEVELS) {
+    if (value >= threshold) return name;
+  }
+  return 'trace';
+}
+
+/** Record fields that describe the process, not the event. */
+const NOISE_KEYS = new Set(['level', 'time', 'msg', 'pid', 'hostname']);
+
+class AppLogBuffer {
+  private readonly slots: Array<AppLogEntry | undefined> = Array.from({ length: APP_LOG_CAPACITY });
+  private next = 0;
+  private size = 0;
+
+  append(entry: AppLogEntry): void {
+    this.slots[this.next] = entry;
+    this.next = (this.next + 1) % APP_LOG_CAPACITY;
+    if (this.size < APP_LOG_CAPACITY) this.size++;
+  }
+
+  list(): AppLogEntry[] {
+    const start = (this.next - this.size + APP_LOG_CAPACITY) % APP_LOG_CAPACITY;
+    const out: AppLogEntry[] = [];
+    for (let i = 0; i < this.size; i++) {
+      const entry = this.slots[(start + i) % APP_LOG_CAPACITY];
+      if (entry) out.push(entry);
+    }
+    return out;
+  }
+
+  clear(): void {
+    this.slots.fill(undefined);
+    this.next = 0;
+    this.size = 0;
+  }
+}
+
+/**
+ * One buffer per process. The Electron shell bundles the server into its main
+ * process, so shell milestones and backend logs share the viewer timeline.
+ */
+const buffer = new AppLogBuffer();
+
+export function appLogEntries(): AppLogEntry[] {
+  return buffer.list();
+}
+
+export function clearAppLog(): void {
+  buffer.clear();
+}
+
+/** Direct entry point for the desktop shell (and anything else without pino). */
+export function appendAppLog(level: AppLogLevel, msg: string, context?: Record<string, unknown>): void {
+  buffer.append({
+    ts: Date.now(),
+    level,
+    source: 'app',
+    msg,
+    ...(context ? { context } : {}),
+  });
+}
+
+/** A pino destination that mirrors every serialized record into the buffer. */
+export function appLogPinoSink(): { write(line: string): void } {
+  return {
+    write(line: string): void {
+      let record: Record<string, unknown>;
+      try {
+        record = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      // Fastify's routine request lines would flush real diagnostics out of
+      // the ring quickly. Request errors are retained.
+      if (record.msg === 'incoming request' || record.msg === 'request completed') return;
+      const context: Record<string, unknown> = {};
+      let hasContext = false;
+      for (const [key, value] of Object.entries(record)) {
+        if (NOISE_KEYS.has(key)) continue;
+        context[key] = value;
+        hasContext = true;
+      }
+      buffer.append({
+        ts: typeof record.time === 'number' ? record.time : Date.now(),
+        level: levelName(record.level),
+        source: 'server',
+        msg: typeof record.msg === 'string' ? record.msg : '',
+        ...(hasContext ? { context } : {}),
+      });
+    },
+  };
+}

--- a/server/src/routes/logs.ts
+++ b/server/src/routes/logs.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { AppLogsResponse } from '@kubus/shared';
+import { baseLogLevel } from '../app.js';
+import { APP_LOG_CAPACITY, appLogEntries, clearAppLog } from '../logging/log-buffer.js';
+import { HttpProblem, sendError } from '../util/errors.js';
+
+const settingsSchema = z.object({ debugEnabled: z.boolean() });
+
+function debugEnabled(app: FastifyInstance): boolean {
+  return app.log.level === 'debug' || app.log.level === 'trace';
+}
+
+export function registerLogRoutes(app: FastifyInstance): void {
+  app.get('/api/logs', (): AppLogsResponse => ({
+    entries: appLogEntries(),
+    debugEnabled: debugEnabled(app),
+    capacity: APP_LOG_CAPACITY,
+  }));
+
+  app.put('/api/logs/settings', async (req, reply) => {
+    const parsed = settingsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return sendError(reply, new HttpProblem(400, 'debugEnabled must be a boolean'));
+    }
+    const base = baseLogLevel();
+    const wasEnabled = debugEnabled(app);
+    // An explicit LOG_LEVEL=trace stays trace; the toggle never lowers it.
+    app.log.level = parsed.data.debugEnabled ? (base === 'trace' ? 'trace' : 'debug') : base;
+    if (parsed.data.debugEnabled !== wasEnabled) {
+      app.log.info(parsed.data.debugEnabled ? 'debug logging enabled' : 'debug logging disabled');
+    }
+    return { debugEnabled: debugEnabled(app) };
+  });
+
+  app.delete('/api/logs', () => {
+    clearAppLog();
+    return { cleared: true };
+  });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -3,6 +3,10 @@ import type { FastifyInstance } from 'fastify';
 import { resolveConfig, type ServerConfig } from './config.js';
 import { buildApp } from './app.js';
 
+// The Electron shell logs boot and crash milestones into the same in-process
+// buffer that backs the diagnostic log viewer.
+export { appendAppLog } from './logging/log-buffer.js';
+
 export interface RunningServer {
   app: FastifyInstance;
   port: number;

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -7,6 +7,32 @@ export interface AppInfo {
   helmEngine: boolean;
 }
 
+export type AppLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+/** One diagnostic log record from the in-memory app log buffer. */
+export interface AppLogEntry {
+  /** Unix epoch milliseconds. */
+  ts: number;
+  level: AppLogLevel;
+  /** 'server' — the embedded backend; 'app' — the desktop shell's main process. */
+  source: 'server' | 'app';
+  msg: string;
+  /** Structured fields attached to the record (context, namespace, err, …). */
+  context?: Record<string, unknown>;
+}
+
+export interface AppLogsResponse {
+  entries: AppLogEntry[];
+  /** True while the server logs at debug level or below. */
+  debugEnabled: boolean;
+  /** Ring-buffer size; older entries beyond it are dropped. */
+  capacity: number;
+}
+
+export interface AppLogSettingsInput {
+  debugEnabled: boolean;
+}
+
 export type UpdateCheckResult =
   | {
       available: true;

--- a/tests/unit/client/app-log-viewer.test.tsx
+++ b/tests/unit/client/app-log-viewer.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppLogsResponse } from '@kubus/shared';
+import { LogViewerDialog } from '../../../client/src/components/LogViewerDialog';
+import { formatLogEntry } from '../../../client/src/api/logs';
+import { useUiStore } from '../../../client/src/state/ui';
+
+const harness = vi.hoisted(() => ({
+  clear: vi.fn(async () => ({ cleared: true })),
+  copy: vi.fn(async () => true),
+  refetch: vi.fn(async () => undefined),
+  save: vi.fn(),
+  data: {
+    debugEnabled: false,
+    capacity: 5000,
+    entries: [
+      { ts: 1_753_862_400_000, level: 'info', source: 'app', msg: 'Kubus started' },
+      { ts: 1_753_862_401_000, level: 'error', source: 'server', msg: 'cluster probe failed', context: { ctx: 'cluster-a' } },
+    ],
+  } as AppLogsResponse,
+}));
+
+vi.mock('../../../client/src/api/logs.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../client/src/api/logs')>();
+  return {
+    ...actual,
+    clearAppLogs: harness.clear,
+    useAppLogs: () => ({ data: harness.data, refetch: harness.refetch }),
+  };
+});
+vi.mock('../../../client/src/clipboard.js', () => ({ copyToClipboard: harness.copy }));
+vi.mock('../../../client/src/save-file.js', () => ({ exportFilename: () => 'kubus-debug.log', saveTextFile: harness.save }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useUiStore.setState({ logViewerOpen: true });
+});
+
+describe('diagnostic log viewer', () => {
+  it('formats structured entries consistently', () => {
+    expect(formatLogEntry(harness.data.entries[1]!)).toBe(
+      '2025-07-30T08:00:01.000Z ERROR server cluster probe failed {"ctx":"cluster-a"}',
+    );
+  });
+
+  it('filters, copies, exports, clears, and closes the in-memory log', async () => {
+    render(<LogViewerDialog />);
+
+    expect(screen.getByRole('heading', { name: 'Diagnostic logs' })).toBeInTheDocument();
+    expect(screen.getByText(/Kubus started/)).toBeInTheDocument();
+    expect(screen.getByText(/cluster probe failed/)).toBeInTheDocument();
+    expect(screen.getByText(/Debug logging is off/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Filter'), { target: { value: 'cluster-a' } });
+    expect(screen.queryByText(/Kubus started/)).not.toBeInTheDocument();
+    expect(screen.getByText(/cluster probe failed/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    await waitFor(() => expect(harness.copy).toHaveBeenCalledWith(expect.stringContaining('cluster probe failed')));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    expect(harness.save).toHaveBeenCalledWith('kubus-debug.log', expect.stringContaining('cluster probe failed'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    await waitFor(() => expect(harness.clear).toHaveBeenCalledOnce());
+    expect(harness.refetch).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(useUiStore.getState().logViewerOpen).toBe(false);
+  });
+});

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -83,6 +83,7 @@ const electron = vi.hoisted(() => {
   const state = { userDataPath: '' };
   const serverClose = vi.fn(async () => undefined);
   const startServer = vi.fn(async () => ({ url: 'http://127.0.0.1:41234', close: serverClose }));
+  const appendAppLog = vi.fn();
   const fixPath = vi.fn();
   const menu = {
     buildFromTemplate: vi.fn(() => ({ id: 'application-menu' })),
@@ -95,6 +96,8 @@ const electron = vi.hoisted(() => {
     appHandlers,
     BrowserWindow: MockBrowserWindow,
     fixPath,
+    appendAppLog,
+    dialog: { showErrorBox: vi.fn() },
     ipcMain: {
       on: vi.fn((name: string, handler: Handler) => ipcListeners.set(name, handler)),
       handle: vi.fn((name: string, handler: Handler) => ipcHandlers.set(name, handler)),
@@ -113,13 +116,14 @@ const electron = vi.hoisted(() => {
 vi.mock('electron', () => ({
   app: electron.app,
   BrowserWindow: electron.BrowserWindow,
+  dialog: electron.dialog,
   ipcMain: electron.ipcMain,
   Menu: electron.menu,
   nativeTheme: electron.nativeTheme,
   shell: electron.shell,
 }));
 vi.mock('fix-path', () => ({ default: electron.fixPath }));
-vi.mock('@kubus/server', () => ({ startServer: electron.startServer }));
+vi.mock('@kubus/server', () => ({ appendAppLog: electron.appendAppLog, startServer: electron.startServer }));
 
 let userDataPath: string;
 let previousHelmEngine: string | undefined;
@@ -181,6 +185,8 @@ describe('Electron main process', () => {
       expect.objectContaining({ port: 0, openBrowser: false, prettyLogs: false }),
     );
     expect(win.loadURL).toHaveBeenCalledWith('http://127.0.0.1:41234');
+    expect(readFileSync(path.join(userDataPath, 'logs', 'main.log'), 'utf8')).toMatch(/Kubus 0\.6\.1 starting/);
+    expect(electron.appendAppLog).toHaveBeenCalledWith('info', expect.stringContaining('Kubus 0.6.1 starting'), undefined);
     expect(win.options).toMatchObject({
       minWidth: 800,
       minHeight: 500,
@@ -196,6 +202,9 @@ describe('Electron main process', () => {
 
     win.handlers.get('ready-to-show')?.();
     expect(win.show).toHaveBeenCalledOnce();
+
+    win.webContents.handlers.get('render-process-gone')?.({}, { reason: 'crashed', exitCode: 9 });
+    expect(electron.appendAppLog).toHaveBeenCalledWith('error', 'window renderer gone (crashed, exit code 9)', undefined);
 
     const result = win.webContents.windowOpenHandler?.({ url: 'https://example.com/docs' });
     expect(result).toEqual({ action: 'deny' });
@@ -421,6 +430,26 @@ describe('Electron main process', () => {
     expect(electron.app.quit).toHaveBeenCalledOnce();
     expect(electron.app.whenReady).not.toHaveBeenCalled();
     expect(electron.startServer).not.toHaveBeenCalled();
+    expect(electron.BrowserWindow.instances).toHaveLength(0);
+  });
+
+  it('records and reports an embedded-server startup failure', async () => {
+    electron.startServer.mockRejectedValueOnce(new Error('address unavailable'));
+
+    await import('../../../electron/src/main.js');
+    await vi.waitFor(() => expect(electron.app.quit).toHaveBeenCalledOnce());
+
+    const logPath = path.join(userDataPath, 'logs', 'main.log');
+    expect(readFileSync(logPath, 'utf8')).toContain('ERROR the embedded server failed to start');
+    expect(electron.appendAppLog).toHaveBeenCalledWith(
+      'error',
+      'the embedded server failed to start',
+      expect.objectContaining({ err: expect.stringContaining('address unavailable') }),
+    );
+    expect(electron.dialog.showErrorBox).toHaveBeenCalledWith(
+      'Kubus failed to start',
+      expect.stringContaining(logPath),
+    );
     expect(electron.BrowserWindow.instances).toHaveLength(0);
   });
 });

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -82,7 +82,7 @@ const electron = vi.hoisted(() => {
   };
   const state = { userDataPath: '' };
   const serverClose = vi.fn(async () => undefined);
-  const startServer = vi.fn(async () => ({ url: 'http://127.0.0.1:41234', close: serverClose }));
+  const startServer = vi.fn(async () => ({ url: 'http://127.0.0.1:41234/?token=secret-test-token', close: serverClose }));
   const appendAppLog = vi.fn();
   const fixPath = vi.fn();
   const menu = {
@@ -158,7 +158,7 @@ beforeEach(() => {
   electron.app.requestSingleInstanceLock.mockReturnValue(true);
   electron.app.whenReady.mockResolvedValue(undefined);
   electron.serverClose.mockResolvedValue(undefined);
-  electron.startServer.mockResolvedValue({ url: 'http://127.0.0.1:41234', close: electron.serverClose });
+  electron.startServer.mockResolvedValue({ url: 'http://127.0.0.1:41234/?token=secret-test-token', close: electron.serverClose });
   electron.nativeTheme.shouldUseDarkColors = false;
 
   userDataPath = mkdtempSync(path.join(tmpdir(), 'kubus-electron-unit-'));
@@ -184,9 +184,13 @@ describe('Electron main process', () => {
     expect(electron.startServer).toHaveBeenCalledWith(
       expect.objectContaining({ port: 0, openBrowser: false, prettyLogs: false }),
     );
-    expect(win.loadURL).toHaveBeenCalledWith('http://127.0.0.1:41234');
-    expect(readFileSync(path.join(userDataPath, 'logs', 'main.log'), 'utf8')).toMatch(/Kubus 0\.6\.1 starting/);
+    expect(win.loadURL).toHaveBeenCalledWith('http://127.0.0.1:41234/?token=secret-test-token');
+    const mainLogText = readFileSync(path.join(userDataPath, 'logs', 'main.log'), 'utf8');
+    expect(mainLogText).toMatch(/Kubus 0\.6\.1 starting/);
+    expect(mainLogText).toContain('server listening at http://127.0.0.1:41234');
+    expect(mainLogText).not.toContain('secret-test-token');
     expect(electron.appendAppLog).toHaveBeenCalledWith('info', expect.stringContaining('Kubus 0.6.1 starting'), undefined);
+    expect(electron.appendAppLog).toHaveBeenCalledWith('info', 'server listening at http://127.0.0.1:41234', undefined);
     expect(win.options).toMatchObject({
       minWidth: 800,
       minHeight: 500,

--- a/tests/unit/server/log-buffer.test.ts
+++ b/tests/unit/server/log-buffer.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  APP_LOG_CAPACITY,
+  appLogEntries,
+  appLogPinoSink,
+  appendAppLog,
+  clearAppLog,
+} from '../../../server/src/logging/log-buffer.js';
+
+beforeEach(() => {
+  clearAppLog();
+});
+
+describe('app log buffer', () => {
+  it('stores shell entries with level, source and context', () => {
+    appendAppLog('error', 'the embedded server failed to start', { err: 'EADDRINUSE' });
+
+    const entries = appLogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      level: 'error',
+      source: 'app',
+      msg: 'the embedded server failed to start',
+      context: { err: 'EADDRINUSE' },
+    });
+    expect(entries[0]!.ts).toBeGreaterThan(0);
+  });
+
+  it('drops the oldest entries beyond the capacity', () => {
+    for (let i = 0; i < APP_LOG_CAPACITY + 10; i++) appendAppLog('info', `entry ${i}`);
+
+    const entries = appLogEntries();
+    expect(entries).toHaveLength(APP_LOG_CAPACITY);
+    expect(entries[0]!.msg).toBe('entry 10');
+    expect(entries.at(-1)!.msg).toBe(`entry ${APP_LOG_CAPACITY + 9}`);
+  });
+
+  it('clears on demand', () => {
+    appendAppLog('info', 'before');
+    clearAppLog();
+    expect(appLogEntries()).toEqual([]);
+  });
+
+  it('parses serialized pino records into server entries', () => {
+    const sink = appLogPinoSink();
+    sink.write(
+      JSON.stringify({
+        level: 40,
+        time: 1753862400000,
+        pid: 4242,
+        hostname: 'box',
+        ctx: 'kind-dev',
+        err: { type: 'Error', message: 'API server did not respond' },
+        msg: 'cluster probe failed',
+      }),
+    );
+
+    expect(appLogEntries()).toEqual([
+      {
+        ts: 1753862400000,
+        level: 'warn',
+        source: 'server',
+        msg: 'cluster probe failed',
+        context: {
+          ctx: 'kind-dev',
+          err: { type: 'Error', message: 'API server did not respond' },
+        },
+      },
+    ]);
+  });
+
+  it('skips routine Fastify request noise and unparseable lines', () => {
+    const sink = appLogPinoSink();
+    sink.write(JSON.stringify({ level: 30, time: 1, msg: 'incoming request', reqId: 'req-1' }));
+    sink.write(JSON.stringify({ level: 30, time: 2, msg: 'request completed', reqId: 'req-1' }));
+    sink.write('not json\n');
+    sink.write(JSON.stringify({ level: 50, time: 3, msg: 'request errored', reqId: 'req-1' }));
+
+    expect(appLogEntries()).toHaveLength(1);
+    expect(appLogEntries()[0]).toMatchObject({ level: 'error', msg: 'request errored' });
+  });
+
+  it('maps unknown pino levels to sane names', () => {
+    const sink = appLogPinoSink();
+    sink.write(JSON.stringify({ level: 60, time: 1, msg: 'fatal thing' }));
+    sink.write(JSON.stringify({ level: 5, time: 2, msg: 'below trace' }));
+    sink.write(JSON.stringify({ level: 'nope', time: 3, msg: 'no level' }));
+
+    expect(appLogEntries().map((entry) => entry.level)).toEqual(['fatal', 'trace', 'info']);
+  });
+});

--- a/tests/unit/server/logs-routes.test.ts
+++ b/tests/unit/server/logs-routes.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buildApp } from '../../../server/src/app.js';
+import { resolveConfig } from '../../../server/src/config.js';
+import { clearAppLog } from '../../../server/src/logging/log-buffer.js';
+
+const TOKEN = 'logs-route-test-token';
+let app: Awaited<ReturnType<typeof buildApp>>['app'];
+
+beforeEach(async () => {
+  clearAppLog();
+  ({ app } = await buildApp(
+    resolveConfig({
+      token: TOKEN,
+      openBrowser: false,
+      prettyLogs: false,
+      staticRoot: '/path/that/does/not/exist',
+    }),
+  ));
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+const auth = { authorization: `Bearer ${TOKEN}` };
+
+describe('log routes', () => {
+  it('serves buffered server log entries', async () => {
+    app.log.warn({ ctx: 'kind-dev' }, 'cluster probe failed');
+
+    const response = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body.debugEnabled).toBe(false);
+    expect(body.capacity).toBeGreaterThan(0);
+    expect(body.entries).toContainEqual(
+      expect.objectContaining({
+        level: 'warn',
+        source: 'server',
+        msg: 'cluster probe failed',
+        context: { ctx: 'kind-dev' },
+      }),
+    );
+  });
+
+  it('captures debug records only after debug mode is enabled', async () => {
+    app.log.debug('hidden detail');
+    const before = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(before.json().entries).not.toContainEqual(expect.objectContaining({ msg: 'hidden detail' }));
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: true },
+    });
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toEqual({ debugEnabled: true });
+
+    app.log.debug('visible detail');
+    const after = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(after.json().debugEnabled).toBe(true);
+    expect(after.json().entries).toContainEqual(expect.objectContaining({ level: 'debug', msg: 'visible detail' }));
+  });
+
+  it('restores the base level and leaves an audit trail when disabled', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: true },
+    });
+    const off = await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: false },
+    });
+    expect(off.json()).toEqual({ debugEnabled: false });
+    expect(app.log.level).toBe('info');
+
+    const logs = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    const messages = logs.json().entries.map((entry: { msg: string }) => entry.msg);
+    expect(messages).toContain('debug logging enabled');
+    expect(messages).toContain('debug logging disabled');
+  });
+
+  it('rejects malformed settings, clears the buffer, and requires authentication', async () => {
+    const malformed = await app.inject({
+      method: 'PUT',
+      url: '/api/logs/settings',
+      headers: auth,
+      payload: { debugEnabled: 'yes' },
+    });
+    expect(malformed.statusCode).toBe(400);
+
+    app.log.warn('to be cleared');
+    const cleared = await app.inject({ method: 'DELETE', url: '/api/logs', headers: auth });
+    expect(cleared.json()).toEqual({ cleared: true });
+    const logs = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(logs.json().entries).not.toContainEqual(expect.objectContaining({ msg: 'to be cleared' }));
+
+    const unauthorized = await app.inject({ method: 'GET', url: '/api/logs' });
+    expect(unauthorized.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

- add a persisted Debug setting that switches the server between its normal and verbose log levels
- add a bounded in-memory application log with authenticated APIs and an in-app viewer for filtering, copying, clearing, and exporting entries
- capture Electron startup, renderer crashes, and startup failures in both the viewer timeline and a rotated `logs/main.log` file
- add client, server, and Electron coverage for the new behavior

## Why

Kubus needs the same practical diagnostic workflow as Muxus so users can enable detailed logging temporarily, inspect it without leaving the app, and retain startup failures that occur before the UI opens.

## Impact

Warnings and errors remain available with Debug mode disabled. Enabling Debug mode adds detailed operational records while the app is running. In-memory logs stay local and bounded to 5,000 entries; desktop shell logs are also written locally for launch-failure diagnosis.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- shared, client, server, and Electron builds
- `pnpm test` — 77 files and 927 tests passed
- isolated built-app Playwright verification of the Debug toggle, viewer, filter, clear, export, and disable flow