### PR TITLE
Add kubectl get command to resource context menus

### DIFF
--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -59,6 +59,7 @@ import {
   useDeleteResource,
   useDrain,
   useRerunJob,
+  useKubeconfigSettings,
   useResourceList,
   useRolloutPause,
   useRolloutRestart,
@@ -80,6 +81,7 @@ import { splitImageRef } from '../image-ref.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detailPathForRef, favoriteForRef, kindListPath, shareLinkForPath } from '../resource-links.js';
 import { kubectlGetCommand } from '../kubectl-command.js';
+import { IS_WINDOWS } from '../platform.js';
 
 export interface RowActionTarget {
   ctx: string;
@@ -396,6 +398,7 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
   const rerun = useRerunJob();
   const rolloutPause = useRolloutPause();
   const suspendCj = useSuspendCronJob();
+  const kubeconfig = useKubeconfigSettings(open);
   const addTab = useDockStore((s) => s.addTab);
 
   const { kind, obj, ctx } = target;
@@ -719,10 +722,17 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
           <ListItemText>Copy link</ListItemText>
         </MenuItem>
         <MenuItem
+          disabled={kubeconfig.isLoading}
           onClick={() => {
-            void copyToClipboard(kubectlGetCommand({ ctx, group: target.group, plural: target.plural, name, namespace })).then((copied) =>
-              copied ? ok('kubectl get command copied') : showToast('error', 'Copy to clipboard failed'),
-            );
+            void copyToClipboard(
+              kubectlGetCommand(
+                { ctx, group: target.group, plural: target.plural, name, namespace },
+                {
+                  kubeconfigPaths: kubeconfig.data?.source === 'default' ? undefined : kubeconfig.data?.paths,
+                  shell: IS_WINDOWS ? 'windows' : 'posix',
+                },
+              ),
+            ).then((copied) => (copied ? ok('kubectl get command copied') : showToast('error', 'Copy to clipboard failed')));
             close();
           }}
         >

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -50,6 +50,7 @@ import SpeedIcon from '@mui/icons-material/Speed';
 import StarIcon from '@mui/icons-material/Star';
 import StarBorderIcon from '@mui/icons-material/StarBorder';
 import LinkIcon from '@mui/icons-material/Link';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { gvkForResource, type DebugProfile, type KubeObject, type LogTargetKind } from '@kubus/shared';
 import {
   resolveLogTargetPods,
@@ -78,6 +79,7 @@ import { execTargetContainer, podContainerNames } from '../kube-display.js';
 import { splitImageRef } from '../image-ref.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detailPathForRef, favoriteForRef, kindListPath, shareLinkForPath } from '../resource-links.js';
+import { kubectlGetCommand } from '../kubectl-command.js';
 
 export interface RowActionTarget {
   ctx: string;
@@ -715,6 +717,19 @@ export function RowActionMenu({ target, anchorEl, anchorPosition, open, onClose 
             <LinkIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>Copy link</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            void copyToClipboard(kubectlGetCommand({ ctx, group: target.group, plural: target.plural, name, namespace })).then((copied) =>
+              copied ? ok('kubectl get command copied') : showToast('error', 'Copy to clipboard failed'),
+            );
+            close();
+          }}
+        >
+          <ListItemIcon>
+            <ContentCopyIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Copy kubectl get command</ListItemText>
         </MenuItem>
         <Divider />
         <MenuItem

--- a/client/src/kubectl-command.ts
+++ b/client/src/kubectl-command.ts
@@ -1,0 +1,22 @@
+const SAFE_SHELL_ARGUMENT = /^[A-Za-z0-9_@%+=:,./-]+$/;
+
+function shellArgument(value: string): string {
+  if (SAFE_SHELL_ARGUMENT.test(value)) return value;
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+export interface KubectlGetTarget {
+  ctx: string;
+  group: string;
+  plural: string;
+  name: string;
+  namespace?: string;
+}
+
+/** Build a paste-ready command that preserves Kubus' exact cluster and resource scope. */
+export function kubectlGetCommand(target: KubectlGetTarget): string {
+  const resourceType = target.group ? `${target.plural}.${target.group}` : target.plural;
+  const resource = shellArgument(`${resourceType}/${target.name}`);
+  const namespace = target.namespace ? ` --namespace ${shellArgument(target.namespace)}` : '';
+  return `kubectl get ${resource}${namespace} --context ${shellArgument(target.ctx)}`;
+}

--- a/client/src/kubectl-command.ts
+++ b/client/src/kubectl-command.ts
@@ -1,8 +1,13 @@
 const SAFE_SHELL_ARGUMENT = /^[A-Za-z0-9_@%+=:,./-]+$/;
 
-function shellArgument(value: string): string {
+function posixShellArgument(value: string): string {
   if (SAFE_SHELL_ARGUMENT.test(value)) return value;
   return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function windowsShellArgument(value: string): string {
+  if (SAFE_SHELL_ARGUMENT.test(value)) return value;
+  return `"${value.replaceAll('"', '\\"')}"`;
 }
 
 export interface KubectlGetTarget {
@@ -13,10 +18,25 @@ export interface KubectlGetTarget {
   namespace?: string;
 }
 
+export interface KubectlCommandOptions {
+  /** Effective non-default kubeconfig files, in kubectl merge order. */
+  kubeconfigPaths?: string[];
+  shell?: 'posix' | 'windows';
+}
+
 /** Build a paste-ready command that preserves Kubus' exact cluster and resource scope. */
-export function kubectlGetCommand(target: KubectlGetTarget): string {
+export function kubectlGetCommand(target: KubectlGetTarget, options: KubectlCommandOptions = {}): string {
+  const shellArgument = options.shell === 'windows' ? windowsShellArgument : posixShellArgument;
   const resourceType = target.group ? `${target.plural}.${target.group}` : target.plural;
   const resource = shellArgument(`${resourceType}/${target.name}`);
   const namespace = target.namespace ? ` --namespace ${shellArgument(target.namespace)}` : '';
-  return `kubectl get ${resource}${namespace} --context ${shellArgument(target.ctx)}`;
+  const paths = options.kubeconfigPaths ?? [];
+  const kubeconfig = paths.length === 1 ? ` --kubeconfig ${shellArgument(paths[0]!)}` : '';
+  const prefix =
+    paths.length > 1
+      ? options.shell === 'windows'
+        ? `set "KUBECONFIG=${paths.join(';')}" && `
+        : `KUBECONFIG=${posixShellArgument(paths.join(':'))} `
+      : '';
+  return `${prefix}kubectl get ${resource}${namespace} --context ${shellArgument(target.ctx)}${kubeconfig}`;
 }

--- a/client/src/platform.ts
+++ b/client/src/platform.ts
@@ -1,6 +1,9 @@
 /** True on macOS — the desktop app reports the real platform; browsers are sniffed. */
 export const IS_MAC = window.kubusDesktop ? window.kubusDesktop.platform === 'darwin' : /Mac|iP(hone|ad|od)/.test(navigator.platform);
 
+/** True on Windows — used where copied commands must follow the host shell's quoting rules. */
+export const IS_WINDOWS = window.kubusDesktop ? window.kubusDesktop.platform === 'win32' : navigator.platform.startsWith('Win');
+
 /** Prefix for rendering a mod-key shortcut inline, e.g. "⌘1" / "Ctrl+1". */
 export const HOTKEY_MOD_LABEL = IS_MAC ? '⌘' : 'Ctrl+';
 

--- a/tests/unit/client/kubectl-command.test.ts
+++ b/tests/unit/client/kubectl-command.test.ts
@@ -25,4 +25,38 @@ describe('kubectlGetCommand', () => {
       `kubectl get widgets.example.io/sample --context 'team'"'"'s dev'`,
     );
   });
+
+  it('preserves a non-default kubeconfig path', () => {
+    expect(
+      kubectlGetCommand(
+        { ctx: 'dev', group: '', plural: 'pods', name: 'web', namespace: 'team-a' },
+        { kubeconfigPaths: ['/work/kubeconfigs/team dev.yaml'] },
+      ),
+    ).toBe("kubectl get pods/web --namespace team-a --context dev --kubeconfig '/work/kubeconfigs/team dev.yaml'");
+  });
+
+  it('uses Windows-compatible double quotes on Windows', () => {
+    expect(
+      kubectlGetCommand(
+        { ctx: "team's dev", group: '', plural: 'nodes', name: 'worker-1' },
+        { kubeconfigPaths: [String.raw`C:\Users\Me\team dev.yaml`], shell: 'windows' },
+      ),
+    ).toBe(String.raw`kubectl get nodes/worker-1 --context "team's dev" --kubeconfig "C:\Users\Me\team dev.yaml"`);
+  });
+
+  it('preserves merged kubeconfig files with the platform path delimiter', () => {
+    expect(
+      kubectlGetCommand(
+        { ctx: 'dev', group: '', plural: 'pods', name: 'web' },
+        { kubeconfigPaths: ['/work/base.yaml', '/work/team config.yaml'] },
+      ),
+    ).toBe("KUBECONFIG='/work/base.yaml:/work/team config.yaml' kubectl get pods/web --context dev");
+
+    expect(
+      kubectlGetCommand(
+        { ctx: 'dev', group: '', plural: 'pods', name: 'web' },
+        { kubeconfigPaths: [String.raw`C:\Kube\base.yaml`, String.raw`D:\Team Config\team.yaml`], shell: 'windows' },
+      ),
+    ).toBe(String.raw`set "KUBECONFIG=C:\Kube\base.yaml;D:\Team Config\team.yaml" && kubectl get pods/web --context dev`);
+  });
 });

--- a/tests/unit/client/kubectl-command.test.ts
+++ b/tests/unit/client/kubectl-command.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { kubectlGetCommand } from '../../../client/src/kubectl-command';
+
+describe('kubectlGetCommand', () => {
+  it('includes resource group, namespace, and context for a namespaced resource', () => {
+    expect(
+      kubectlGetCommand({
+        ctx: 'kind-dev',
+        group: 'apps',
+        plural: 'deployments',
+        name: 'web',
+        namespace: 'team-a',
+      }),
+    ).toBe('kubectl get deployments.apps/web --namespace team-a --context kind-dev');
+  });
+
+  it('omits the namespace and group for a cluster-scoped core resource', () => {
+    expect(kubectlGetCommand({ ctx: 'prod', group: '', plural: 'nodes', name: 'worker-1' })).toBe(
+      'kubectl get nodes/worker-1 --context prod',
+    );
+  });
+
+  it('quotes shell-sensitive context names', () => {
+    expect(kubectlGetCommand({ ctx: "team's dev", group: 'example.io', plural: 'widgets', name: 'sample' })).toBe(
+      `kubectl get widgets.example.io/sample --context 'team'"'"'s dev'`,
+    );
+  });
+});

--- a/tests/unit/client/row-actions.test.tsx
+++ b/tests/unit/client/row-actions.test.tsx
@@ -329,6 +329,13 @@ describe('pod actions', () => {
     await waitFor(() => expect(sideEffects.copy).toHaveBeenCalled());
     view.unmount();
 
+    view = clickMenuAction(pod, 'Copy kubectl get command');
+    await waitFor(() =>
+      expect(sideEffects.copy).toHaveBeenCalledWith('kubectl get pods/pod-a --namespace team-a --context dev'),
+    );
+    expect(sideEffects.showToast).toHaveBeenCalledWith('success', 'kubectl get command copied');
+    view.unmount();
+
     view = clickMenuAction(pod, 'Delete…');
     const confirm = screen.getByPlaceholderText('pod-a');
     expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled();

--- a/tests/unit/client/row-actions.test.tsx
+++ b/tests/unit/client/row-actions.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { KubeObject } from '@kubus/shared';
+import type { KubeconfigSettings, KubeObject } from '@kubus/shared';
 import {
   DetailQuickActions,
   isLogTargetKind,
@@ -48,6 +48,13 @@ const queryMocks = vi.hoisted(() => {
     services: [] as KubeObject[],
     preflight: { allowed: true } as { allowed: boolean; reason?: string },
     localPort: vi.fn(async () => ({ available: true })),
+    kubeconfig: {
+      paths: ['/home/test/.kube/config'],
+      primaryPath: '/home/test/.kube/config',
+      override: null,
+      source: 'default',
+      kubeconfigEnv: null,
+    } as KubeconfigSettings,
   };
 });
 
@@ -75,6 +82,7 @@ vi.mock('../../../client/src/api/queries.js', () => ({
   checkLocalPort: queryMocks.localPort,
   useCreateResource: () => queryMocks.create,
   useDryRunResource: () => queryMocks.dryRun,
+  useKubeconfigSettings: () => ({ data: queryMocks.kubeconfig, isLoading: false }),
   useResourceSchema: () => ({ data: undefined }),
   useResourceList: (selection: { plural?: string } | undefined) => ({
     data: selection?.plural === 'horizontalpodautoscalers'
@@ -161,6 +169,13 @@ beforeEach(() => {
   queryMocks.hpas = [];
   queryMocks.services = [];
   queryMocks.preflight = { allowed: true };
+  queryMocks.kubeconfig = {
+    paths: ['/home/test/.kube/config'],
+    primaryPath: '/home/test/.kube/config',
+    override: null,
+    source: 'default',
+    kubeconfigEnv: null,
+  };
   queryMocks.localPort.mockClear();
   sideEffects.copy.mockClear();
   sideEffects.showToast.mockClear();
@@ -334,6 +349,21 @@ describe('pod actions', () => {
       expect(sideEffects.copy).toHaveBeenCalledWith('kubectl get pods/pod-a --namespace team-a --context dev'),
     );
     expect(sideEffects.showToast).toHaveBeenCalledWith('success', 'kubectl get command copied');
+    view.unmount();
+
+    queryMocks.kubeconfig = {
+      paths: ['/work/kubeconfigs/team dev.yaml'],
+      primaryPath: '/work/kubeconfigs/team dev.yaml',
+      override: '/work/kubeconfigs/team dev.yaml',
+      source: 'settings-file',
+      kubeconfigEnv: null,
+    };
+    view = clickMenuAction(pod, 'Copy kubectl get command');
+    await waitFor(() =>
+      expect(sideEffects.copy).toHaveBeenCalledWith(
+        "kubectl get pods/pod-a --namespace team-a --context dev --kubeconfig '/work/kubeconfigs/team dev.yaml'",
+      ),
+    );
     view.unmount();
 
     view = clickMenuAction(pod, 'Delete…');


### PR DESCRIPTION
## Summary

- add a **Copy kubectl get command** action to resource context menus
- preserve the exact cluster, namespace, and API group in the generated command
- safely quote shell-sensitive values before copying
- show success or failure feedback after the clipboard operation

This gives users a quick path from a resource in Kubus to the equivalent CLI command for further exploration or sharing.

Closes #127

## Validation

- `pnpm --filter @kubus/tests test` — 930 tests passed
- `pnpm --filter @kubus/client typecheck`
- `pnpm lint`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- live Playwright check against the built app, including the right-click menu, clipboard contents, and success toast