### PR TITLE
Add terminal tab reconnect action

### DIFF
--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -6,7 +6,7 @@ const TerminalPaneImpl = lazy(() => import('./TerminalPaneImpl.js'));
 
 const terminalLoading = <Box sx={{ height: '100%', bgcolor: '#16161e' }} />;
 
-export function TerminalPane(props: { tab: TerminalTab | NodeShellTab; active: boolean; focusRequest: number }) {
+export function TerminalPane(props: { tab: TerminalTab | NodeShellTab; active: boolean; focusRequest: number; reconnectRequest: number }) {
   return (
     <Suspense fallback={terminalLoading}>
       <TerminalPaneImpl {...props} />

--- a/client/src/components/TerminalPaneImpl.tsx
+++ b/client/src/components/TerminalPaneImpl.tsx
@@ -22,7 +22,17 @@ import { showToast } from '../state/toast.js';
 import { selectedTerminalText } from '../terminal-selection.js';
 import { terminalRightClickIntent, xtermRightClickSelectsWord } from '../terminal-right-click.js';
 
-export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: TerminalTab | NodeShellTab; active: boolean; focusRequest: number }) {
+export default function TerminalPaneImpl({
+  tab,
+  active,
+  focusRequest,
+  reconnectRequest,
+}: {
+  tab: TerminalTab | NodeShellTab;
+  active: boolean;
+  focusRequest: number;
+  reconnectRequest: number;
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -81,7 +91,7 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
     const el = containerRef.current;
     if (!el) return;
 
-    const { monoFontSize, defaultShell } = useUiPrefsStore.getState();
+    const { monoFontSize } = useUiPrefsStore.getState();
     const term = new Terminal({
       fontSize: monoFontSize + 1,
       fontFamily: '"JetBrains Mono", "Fira Code", monospace',
@@ -96,6 +106,33 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
     term.open(el);
     fit.fit();
 
+    const onSelection = term.onSelectionChange(() => {
+      const selection = selectedTerminalText(term, useUiPrefsStore.getState().copyOnSelect);
+      if (selection !== null) void copyToClipboard(selection);
+    });
+
+    // Inactive tabs and a collapsed dock have zero height. Ignore those
+    // resize notifications so the remote PTY keeps its last usable size.
+    const observer = new ResizeObserver(() => {
+      if (activeRef.current) fit.fit();
+    });
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      onSelection.dispose();
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [tab.id]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+
+    if (reconnectRequest > 0) term.write('\r\n\x1b[90m[reconnecting]\x1b[0m\r\n');
+    const { defaultShell } = useUiPrefsStore.getState();
     const ws = new WebSocket(
       tab.kind === 'node-shell'
         ? wsUrl('/ws/node-shell', { ctx: tab.ctx, node: tab.node, cols: term.cols, rows: term.rows })
@@ -137,29 +174,16 @@ export default function TerminalPaneImpl({ tab, active, focusRequest }: { tab: T
     const onResize = term.onResize(({ cols, rows }) => {
       if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ op: 'resize', cols, rows }));
     });
-    const onSelection = term.onSelectionChange(() => {
-      const selection = selectedTerminalText(term, useUiPrefsStore.getState().copyOnSelect);
-      if (selection !== null) void copyToClipboard(selection);
-    });
-
-    // Inactive tabs and a collapsed dock have zero height. Ignore those
-    // resize notifications so the remote PTY keeps its last usable size.
-    const observer = new ResizeObserver(() => {
-      if (activeRef.current) fit.fit();
-    });
-    observer.observe(el);
-
     return () => {
-      observer.disconnect();
       onData.dispose();
       onResize.dispose();
-      onSelection.dispose();
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onclose = null;
       ws.close();
-      term.dispose();
-      termRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab.id]);
+  }, [reconnectRequest, tab.id]);
 
   // Refit when this tab becomes visible (display:none panes have zero size).
   useEffect(() => {

--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -1,6 +1,10 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Tooltip from '@mui/material/Tooltip';
@@ -8,6 +12,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import SubjectIcon from '@mui/icons-material/Subject';
 import { clampDockHeight, useDockStore } from '../state/dock.js';
@@ -25,6 +30,9 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
   const maximized = useDockStore((s) => s.maximized);
   const setMaximized = useDockStore((s) => s.setMaximized);
   const terminalFocusRequest = useDockStore((s) => s.terminalFocusRequest);
+  const terminalReconnectRequests = useDockStore((s) => s.terminalReconnectRequests);
+  const requestTerminalReconnect = useDockStore((s) => s.requestTerminalReconnect);
+  const [tabMenu, setTabMenu] = useState<{ id: string; x: number; y: number } | null>(null);
 
   // Escape restores a maximized dock via the global dismiss chain in
   // GlobalShortcuts — guarded there so a focused terminal keeps its Escape.
@@ -108,6 +116,18 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
               onAuxClick={(e) => {
                 if (e.button === 1) closeTab(tab.id);
               }}
+              onContextMenu={(e) => {
+                if (tab.kind !== 'terminal' && tab.kind !== 'node-shell') return;
+                e.preventDefault();
+                setTabMenu({ id: tab.id, x: e.clientX, y: e.clientY });
+              }}
+              onKeyDown={(e) => {
+                if (tab.kind !== 'terminal' && tab.kind !== 'node-shell') return;
+                if (e.key !== 'ContextMenu' && !(e.shiftKey && e.key === 'F10')) return;
+                e.preventDefault();
+                const rect = e.currentTarget.getBoundingClientRect();
+                setTabMenu({ id: tab.id, x: rect.left + 8, y: rect.bottom - 4 });
+              }}
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   {tab.kind === 'terminal' || tab.kind === 'node-shell' ? <TerminalIcon sx={{ fontSize: 14 }} /> : <SubjectIcon sx={{ fontSize: 14 }} />}
@@ -148,6 +168,7 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
                 tab={tab}
                 active={open && tab.id === activeId}
                 focusRequest={terminalFocusRequest?.tabId === tab.id ? terminalFocusRequest.sequence : 0}
+                reconnectRequest={terminalReconnectRequests[tab.id] ?? 0}
               />
             ) : open ? (
               <LogViewer tab={tab} />
@@ -155,6 +176,24 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
           </Box>
         ))}
       </Box>
+      <Menu
+        open={tabMenu !== null}
+        onClose={() => setTabMenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={tabMenu ? { top: tabMenu.y, left: tabMenu.x } : undefined}
+      >
+        <MenuItem
+          onClick={() => {
+            if (tabMenu) requestTerminalReconnect(tabMenu.id);
+            setTabMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <RestartAltIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Reconnect</ListItemText>
+        </MenuItem>
+      </Menu>
     </Box>
   );
 });

--- a/client/src/state/dock.ts
+++ b/client/src/state/dock.ts
@@ -45,6 +45,7 @@ interface DockState {
   height: number;
   maximized: boolean;
   terminalFocusRequest?: { tabId: string; sequence: number };
+  terminalReconnectRequests: Record<string, number>;
   addTab: (tab: DockTab) => void;
   closeTab: (id: string) => void;
   setActive: (id: string) => void;
@@ -52,6 +53,7 @@ interface DockState {
   setHeight: (height: number) => void;
   setMaximized: (maximized: boolean) => void;
   requestTerminalFocus: (id: string) => void;
+  requestTerminalReconnect: (id: string) => void;
 }
 
 let counter = 0;
@@ -70,6 +72,7 @@ export const useDockStore = create<DockState>((set) => ({
   height: 320,
   maximized: false,
   terminalFocusRequest: undefined,
+  terminalReconnectRequests: {},
   addTab: (tab) => {
     // The detail drawer is modal and would cover the dock — close it so the
     // freshly opened terminal/log tab is actually visible.
@@ -79,12 +82,15 @@ export const useDockStore = create<DockState>((set) => ({
   closeTab: (id) =>
     set((s) => {
       const tabs = s.tabs.filter((t) => t.id !== id);
+      const terminalReconnectRequests = { ...s.terminalReconnectRequests };
+      delete terminalReconnectRequests[id];
       return {
         tabs,
         activeId: s.activeId === id ? tabs[tabs.length - 1]?.id : s.activeId,
         open: tabs.length > 0 ? s.open : false,
         maximized: tabs.length > 0 ? s.maximized : false,
         terminalFocusRequest: s.terminalFocusRequest?.tabId === id ? undefined : s.terminalFocusRequest,
+        terminalReconnectRequests,
       };
     }),
   setActive: (id) => set({ activeId: id, open: true }),
@@ -101,6 +107,17 @@ export const useDockStore = create<DockState>((set) => ({
         terminalFocusRequest: {
           tabId: id,
           sequence: (s.terminalFocusRequest?.sequence ?? 0) + 1,
+        },
+      };
+    }),
+  requestTerminalReconnect: (id) =>
+    set((s) => {
+      const tab = s.tabs.find((candidate) => candidate.id === id);
+      if (tab?.kind !== 'terminal' && tab?.kind !== 'node-shell') return s;
+      return {
+        terminalReconnectRequests: {
+          ...s.terminalReconnectRequests,
+          [id]: (s.terminalReconnectRequests[id] ?? 0) + 1,
         },
       };
     }),

--- a/tests/e2e/specs/terminal-reconnect.spec.ts
+++ b/tests/e2e/specs/terminal-reconnect.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+import { gotoApp } from '../helpers/app.js';
+import { namespace } from '../helpers/cluster.mjs';
+
+test('reconnects a terminal session from its tab menu', async ({ page }) => {
+  let execSocketCount = 0;
+  let closedExecSocketCount = 0;
+  page.on('websocket', (socket) => {
+    if (!socket.url().includes('/ws/exec?')) return;
+    execSocketCount += 1;
+    socket.on('close', () => {
+      closedExecSocketCount += 1;
+    });
+  });
+
+  await gotoApp(page, '/r/core/v1/pods');
+  const row = page.getByRole('row').filter({ hasText: 'logger' }).filter({ hasText: namespace }).first();
+  await expect(row).toBeVisible({ timeout: 20_000 });
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Shell' }).click();
+
+  const terminal = page.locator('.xterm');
+  await expect(terminal).toBeVisible({ timeout: 20_000 });
+  await expect.poll(() => execSocketCount).toBe(1);
+
+  await page.getByRole('tab', { name: /sh: logger/ }).click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Reconnect' }).click();
+
+  await expect.poll(() => execSocketCount).toBe(2);
+  await expect.poll(() => closedExecSocketCount).toBe(1);
+  await expect(terminal).toBeVisible();
+  await expect(terminal).toHaveCount(1);
+});

--- a/tests/unit/client/bottom-dock.test.tsx
+++ b/tests/unit/client/bottom-dock.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BottomDock } from '../../../client/src/layout/BottomDock';
+import { useDockStore, type DockTab, type NodeShellTab, type TerminalTab } from '../../../client/src/state/dock';
+
+vi.mock('../../../client/src/components/TerminalPane.js', () => ({
+  TerminalPane: ({ tab, reconnectRequest }: { tab: TerminalTab | NodeShellTab; reconnectRequest: number }) => (
+    <div data-testid={`terminal-${tab.id}`} data-reconnect-request={reconnectRequest} />
+  ),
+}));
+
+vi.mock('../../../client/src/components/LogViewer.js', () => ({
+  LogViewer: () => <div data-testid="log-viewer" />,
+}));
+
+const terminal: DockTab = {
+  kind: 'terminal',
+  id: 'terminal',
+  title: 'shell',
+  ctx: 'kind-a',
+  namespace: 'default',
+  pod: 'web',
+  container: 'web',
+};
+const logs: DockTab = {
+  kind: 'logs',
+  id: 'logs',
+  title: 'logs',
+  ctx: 'kind-a',
+  namespace: 'default',
+  pods: ['web'],
+};
+
+beforeEach(() => {
+  useDockStore.setState({
+    tabs: [terminal, logs],
+    activeId: terminal.id,
+    open: true,
+    maximized: false,
+    terminalFocusRequest: undefined,
+    terminalReconnectRequests: {},
+  });
+});
+
+describe('BottomDock terminal tab menu', () => {
+  it('requests a new terminal connection from the right-click menu', () => {
+    render(<BottomDock containerRef={{ current: document.createElement('div') }} />);
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /shell/ }), { clientX: 24, clientY: 36 });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reconnect' }));
+
+    expect(useDockStore.getState().terminalReconnectRequests).toEqual({ [terminal.id]: 1 });
+    expect(screen.getByTestId(`terminal-${terminal.id}`)).toHaveAttribute('data-reconnect-request', '1');
+  });
+
+  it('does not show reconnect for log tabs', () => {
+    render(<BottomDock containerRef={{ current: document.createElement('div') }} />);
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /logs/ }), { clientX: 24, clientY: 36 });
+
+    expect(screen.queryByRole('menuitem', { name: 'Reconnect' })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/client/state.test.ts
+++ b/tests/unit/client/state.test.ts
@@ -64,6 +64,7 @@ describe('useDockStore terminal focus requests', () => {
       open: false,
       maximized: false,
       terminalFocusRequest: undefined,
+      terminalReconnectRequests: {},
     });
   });
 
@@ -79,11 +80,32 @@ describe('useDockStore terminal focus requests', () => {
     expect(useDockStore.getState().terminalFocusRequest).toEqual({ tabId: terminal.id, sequence: 2 });
   });
 
-  it('ignores log tabs and unknown ids', () => {
+  it('ignores log tabs and unknown ids for focus requests', () => {
     const before = useDockStore.getState();
     before.requestTerminalFocus(logs.id);
     before.requestTerminalFocus('missing');
     expect(useDockStore.getState()).toBe(before);
+  });
+
+  it('issues reconnect requests without activating or opening the terminal', () => {
+    useDockStore.getState().requestTerminalReconnect(terminal.id);
+    useDockStore.getState().requestTerminalReconnect(terminal.id);
+
+    const state = useDockStore.getState();
+    expect(state.terminalReconnectRequests).toEqual({ [terminal.id]: 2 });
+    expect(state.activeId).toBe(logs.id);
+    expect(state.open).toBe(false);
+  });
+
+  it('ignores non-terminal reconnect requests and clears requests when a tab closes', () => {
+    const before = useDockStore.getState();
+    before.requestTerminalReconnect(logs.id);
+    before.requestTerminalReconnect('missing');
+    expect(useDockStore.getState()).toBe(before);
+
+    before.requestTerminalReconnect(terminal.id);
+    useDockStore.getState().closeTab(terminal.id);
+    expect(useDockStore.getState().terminalReconnectRequests).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary

- add a Reconnect action to terminal and node-shell tab context menus, including keyboard invocation
- replace the stale session WebSocket while keeping the terminal instance and scrollback mounted
- match the existing action-menu typography, spacing, and reconnect icon
- add focused store, component, and end-to-end regression coverage

## User impact

Stale terminal sessions can be reconnected directly from the tab header without closing and recreating the tab or losing its visible scrollback.

## Validation

- `pnpm --filter @kubus/tests test` — 937 tests passed
- `pnpm --dir tests exec playwright test e2e/specs/terminal-reconnect.spec.ts` — 1 test passed
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- `pnpm typecheck`
- `pnpm lint`

Closes #128