### PR TITLE
Add complete tab window controls and focused utility windows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@mui/x-data-grid": "^9.11.0",
     "@tanstack/react-query": "^5.101.4",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-serialize": "^0.14.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.2",
     "croner": "^10.0.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,15 +14,30 @@ import { TitleBarAwareBackdrop } from './components/TitleBarAwareBackdrop.js';
 import { setDebugLogging } from './api/logs.js';
 import { useUiPrefsStore } from './state/prefs.js';
 import { useUiStore } from './state/ui.js';
+import { DockWindowShell } from './layout/DockWindowShell.js';
+import type { AppWindowSurface } from './window-management.js';
 
 const LogViewerDialog = lazy(() => import('./components/LogViewerDialog.js').then((module) => ({ default: module.LogViewerDialog })));
 
-export default function App() {
+function FullApplication() {
   // One app-wide subscription keeps context/discovery queries fresh.
   useContextsInvalidation();
+  const logViewerOpen = useUiStore((state) => state.logViewerOpen);
+  return (
+    <>
+      <ErrorBoundary label="Kubus">
+        <AppRouter />
+      </ErrorBoundary>
+      <BackendStatusBanner />
+      <UpdateNotification />
+      <Suspense fallback={null}>{logViewerOpen ? <LogViewerDialog /> : null}</Suspense>
+    </>
+  );
+}
+
+export default function App({ surface = 'app' }: { surface?: AppWindowSurface }) {
   const themeMode = useClustersStore((s) => s.themeMode);
   const debugMode = useUiPrefsStore((state) => state.debugMode);
-  const logViewerOpen = useUiStore((state) => state.logViewerOpen);
   const [osTheme, setOsTheme] = useState<'light' | 'dark'>(() =>
     //Check the operating system’s current color scheme and return true if it is dark, false otherwise
     window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
@@ -46,13 +61,14 @@ export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <ErrorBoundary label="Kubus">
-        <AppRouter />
-      </ErrorBoundary>
+      {surface === 'dock' ? (
+        <ErrorBoundary label="The terminal or log window">
+          <DockWindowShell />
+        </ErrorBoundary>
+      ) : (
+        <FullApplication />
+      )}
       <ToastHost />
-      <BackendStatusBanner />
-      <UpdateNotification />
-      <Suspense fallback={null}>{logViewerOpen ? <LogViewerDialog /> : null}</Suspense>
     </ThemeProvider>
   );
 }

--- a/client/src/components/TabActionsMenu.tsx
+++ b/client/src/components/TabActionsMenu.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ButtonBase from '@mui/material/ButtonBase';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
+import CheckIcon from '@mui/icons-material/Check';
+import CloseIcon from '@mui/icons-material/Close';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DriveFileMoveOutlinedIcon from '@mui/icons-material/DriveFileMoveOutlined';
+import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutline';
+import OpenInNewOutlinedIcon from '@mui/icons-material/OpenInNewOutlined';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import { useDockStore } from '../state/dock.js';
+import type { DockTab } from '../state/dock.js';
+import { useTabsStore, type PageTab } from '../state/tabs.js';
+import { openTabInNewWindow, moveTabToNewWindow, type TabSurface } from '../tab-window-actions.js';
+import { showToast } from '../state/toast.js';
+
+export interface TabMenuState {
+  surface: TabSurface;
+  id: string;
+  title: string;
+  x: number;
+  y: number;
+}
+
+const TAB_FLAG_COLORS = ['#ef5350', '#ff9800', '#fdd835', '#66bb6a', '#42a5f5', '#7e57c2'] as const;
+
+export function TabActionsMenu({
+  menu,
+  onClose,
+  afterPageMutation,
+}: {
+  menu: TabMenuState | null;
+  onClose: () => void;
+  afterPageMutation?: () => void;
+}) {
+  const pageTabs = useTabsStore((state) => state.tabs);
+  const dockTabs = useDockStore((state) => state.tabs);
+  const [renaming, setRenaming] = useState<{ surface: TabSurface; id: string; title: string } | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const tabs: Array<PageTab | DockTab> = menu?.surface === 'dock' ? dockTabs : pageTabs;
+  const tab = tabs.find((candidate) => candidate.id === menu?.id);
+  const index = tab ? tabs.indexOf(tab) : -1;
+  const closeableOthers = tabs.some((candidate) => candidate.id !== menu?.id && !candidate.pinned);
+  const closeableRight = index >= 0 && tabs.slice(index + 1).some((candidate) => !candidate.pinned);
+  const terminal = tab && 'kind' in tab && (tab.kind === 'terminal' || tab.kind === 'node-shell');
+
+  useEffect(() => {
+    if (!renaming) return;
+    const frame = requestAnimationFrame(() => renameInputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [renaming]);
+
+  const run = (action: () => void, pageMutation = false) => {
+    action();
+    onClose();
+    if (pageMutation) afterPageMutation?.();
+  };
+
+  const openRename = () => {
+    if (!menu) return;
+    setRenaming({ surface: menu.surface, id: menu.id, title: menu.title });
+    setRenameValue(menu.title);
+    onClose();
+  };
+
+  const commitRename = () => {
+    if (!renaming || !renameValue.trim()) return;
+    if (renaming.surface === 'page') useTabsStore.getState().renameTab(renaming.id, renameValue);
+    else useDockStore.getState().renameTab(renaming.id, renameValue);
+    setRenaming(null);
+  };
+
+  return (
+    <>
+      <Menu
+        open={!!menu && !!tab}
+        onClose={onClose}
+        anchorReference="anchorPosition"
+        anchorPosition={menu ? { top: menu.y, left: menu.x } : undefined}
+      >
+        <MenuItem onClick={openRename}>
+          <ListItemIcon><DriveFileRenameOutlineIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Rename tab</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (!menu || !tab) return;
+            run(() => {
+              if (menu.surface === 'page') useTabsStore.getState().setPinned(menu.id, !tab.pinned);
+              else useDockStore.getState().setPinned(menu.id, !tab.pinned);
+            });
+          }}
+        >
+          <ListItemIcon>
+            <PushPinOutlinedIcon fontSize="small" sx={{ transform: tab?.pinned ? 'rotate(45deg)' : undefined }} />
+          </ListItemIcon>
+          <ListItemText>{tab?.pinned ? 'Unpin tab' : 'Pin tab'}</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (!menu) return;
+            run(() => {
+              if (menu.surface === 'page') useTabsStore.getState().duplicateTab(menu.id);
+              else useDockStore.getState().duplicateTab(menu.id);
+            }, menu.surface === 'page');
+          }}
+        >
+          <ListItemIcon><ContentCopyIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>{menu?.surface === 'dock' && terminal ? 'Duplicate (new session)' : 'Duplicate tab'}</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem
+          onClick={() => {
+            if (!menu) return;
+            if (!openTabInNewWindow(menu.surface, menu.id, menu.title)) {
+              showToast('warning', 'The browser blocked the new window. Allow pop-ups for Kubus and try again.');
+            }
+            onClose();
+          }}
+        >
+          <ListItemIcon><OpenInNewOutlinedIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Open in new window</ListItemText>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            if (!menu) return;
+            if (!moveTabToNewWindow(menu.surface, menu.id, menu.title)) {
+              showToast('warning', 'The browser blocked the new window. Allow pop-ups for Kubus and try again.');
+            }
+            onClose();
+          }}
+        >
+          <ListItemIcon><DriveFileMoveOutlinedIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Move to new window</ListItemText>
+        </MenuItem>
+        {terminal ? (
+          <>
+            <Divider />
+            <MenuItem onClick={() => run(() => useDockStore.getState().requestTerminalReconnect(menu!.id))}>
+              <ListItemIcon><RestartAltIcon fontSize="small" /></ListItemIcon>
+              <ListItemText>Reconnect</ListItemText>
+            </MenuItem>
+          </>
+        ) : null}
+        <Divider />
+        <Box sx={{ px: 2, py: 0.75 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>Flag</Typography>
+          <Stack direction="row" spacing={0.6}>
+            {TAB_FLAG_COLORS.map((color) => (
+              <ButtonBase
+                key={color}
+                aria-label={`Flag tab ${color}`}
+                onClick={() => {
+                  if (!menu) return;
+                  if (menu.surface === 'page') useTabsStore.getState().setColor(menu.id, tab?.color === color ? undefined : color);
+                  else useDockStore.getState().setColor(menu.id, tab?.color === color ? undefined : color);
+                  onClose();
+                }}
+                sx={{ width: 20, height: 20, borderRadius: '50%', bgcolor: color, '&:hover': { transform: 'scale(1.12)' } }}
+              >
+                {tab?.color === color ? <CheckIcon sx={{ fontSize: 14, color: 'rgba(0,0,0,0.72)' }} /> : null}
+              </ButtonBase>
+            ))}
+            <Tooltip title="No flag">
+              <ButtonBase
+                aria-label="Remove tab flag"
+                onClick={() => {
+                  if (!menu) return;
+                  if (menu.surface === 'page') useTabsStore.getState().setColor(menu.id);
+                  else useDockStore.getState().setColor(menu.id);
+                  onClose();
+                }}
+                sx={{ width: 20, height: 20, borderRadius: '50%', border: 1, borderColor: 'divider' }}
+              >
+                {!tab?.color ? <CheckIcon sx={{ fontSize: 14, color: 'text.disabled' }} /> : null}
+              </ButtonBase>
+            </Tooltip>
+          </Stack>
+        </Box>
+        <Divider />
+        <MenuItem
+          onClick={() => {
+            if (!menu) return;
+            run(() => {
+              if (menu.surface === 'page') useTabsStore.getState().closeTab(menu.id);
+              else useDockStore.getState().closeTab(menu.id);
+            }, menu.surface === 'page');
+          }}
+        >
+          <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Close tab</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!closeableOthers}
+          onClick={() => {
+            if (!menu) return;
+            run(() => {
+              if (menu.surface === 'page') useTabsStore.getState().closeOthers(menu.id);
+              else useDockStore.getState().closeOthers(menu.id);
+            }, menu.surface === 'page');
+          }}
+        >
+          <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Close other tabs</ListItemText>
+        </MenuItem>
+        <MenuItem
+          disabled={!closeableRight}
+          onClick={() => {
+            if (!menu) return;
+            run(() => {
+              if (menu.surface === 'page') useTabsStore.getState().closeRight(menu.id);
+              else useDockStore.getState().closeRight(menu.id);
+            }, menu.surface === 'page');
+          }}
+        >
+          <ListItemIcon><CloseIcon fontSize="small" /></ListItemIcon>
+          <ListItemText>Close tabs to the right</ListItemText>
+        </MenuItem>
+      </Menu>
+
+      <Dialog open={!!renaming} onClose={() => setRenaming(null)} maxWidth="xs" fullWidth>
+        <DialogTitle>Rename tab</DialogTitle>
+        <DialogContent>
+          <TextField
+            inputRef={renameInputRef}
+            fullWidth
+            label="Tab name"
+            value={renameValue}
+            onChange={(event) => setRenameValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') commitRename();
+            }}
+            slotProps={{ htmlInput: { maxLength: 200 } }}
+            sx={{ mt: 0.5 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRenaming(null)}>Cancel</Button>
+          <Button variant="contained" disabled={!renameValue.trim()} onClick={commitRename}>Rename</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/client/src/components/TerminalPaneImpl.tsx
+++ b/client/src/components/TerminalPaneImpl.tsx
@@ -11,8 +11,9 @@ import ContentPasteIcon from '@mui/icons-material/ContentPaste';
 import SelectAllIcon from '@mui/icons-material/SelectAll';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
+import { SerializeAddon } from '@xterm/addon-serialize';
 import '@xterm/xterm/css/xterm.css';
-import type { ExecServerControl } from '@kubus/shared';
+import { EXEC_SESSION_CLOSE_REASON, type ExecServerControl } from '@kubus/shared';
 import { wsUrl } from '../api/http.js';
 import { copyToClipboard, readFromClipboard } from '../clipboard.js';
 import type { NodeShellTab, TerminalTab } from '../state/dock.js';
@@ -21,6 +22,10 @@ import { useUiPrefsStore } from '../state/prefs.js';
 import { showToast } from '../state/toast.js';
 import { selectedTerminalText } from '../terminal-selection.js';
 import { terminalRightClickIntent, xtermRightClickSelectsWord } from '../terminal-right-click.js';
+import { registerTerminal } from '../terminal-registry.js';
+import { cancelTabTransfer, completeTabTransfer } from '../tab-transfer.js';
+
+const TRANSFER_PREPARE_TIMEOUT_MS = 5_000;
 
 export default function TerminalPaneImpl({
   tab,
@@ -36,6 +41,13 @@ export default function TerminalPaneImpl({
   const containerRef = useRef<HTMLDivElement>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const termRef = useRef<Terminal | null>(null);
+  const serializeRef = useRef<SerializeAddon | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const transferPreparationRef = useRef<{
+    resolve: (prepared: boolean) => void;
+    timer: ReturnType<typeof setTimeout>;
+  } | null>(null);
+  const initialSnapshotRef = useRef(tab.snapshot);
   const rightClickSelectsWordDefaultRef = useRef(false);
   const [contextMenu, setContextMenu] = useState<{ top: number; left: number; selection: string } | null>(null);
   const activeRef = useRef(active);
@@ -100,11 +112,45 @@ export default function TerminalPaneImpl({
     });
     rightClickSelectsWordDefaultRef.current = term.options.rightClickSelectsWord ?? false;
     const fit = new FitAddon();
+    const serialize = new SerializeAddon();
     fitRef.current = fit;
     termRef.current = term;
+    serializeRef.current = serialize;
     term.loadAddon(fit);
+    term.loadAddon(serialize);
     term.open(el);
     fit.fit();
+    if (initialSnapshotRef.current) term.write(initialSnapshotRef.current);
+
+    const settleTransfer = (prepared: boolean) => {
+      const pending = transferPreparationRef.current;
+      if (!pending) return;
+      transferPreparationRef.current = null;
+      clearTimeout(pending.timer);
+      pending.resolve(prepared);
+    };
+    const unregister = registerTerminal(tab.id, {
+      prepareTransfer: () => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN || transferPreparationRef.current) return Promise.resolve(false);
+        return new Promise<boolean>((resolve) => {
+          const timer = setTimeout(() => {
+            if (transferPreparationRef.current?.resolve !== resolve) return;
+            transferPreparationRef.current = null;
+            if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ op: 'cancel-transfer' }));
+            resolve(false);
+          }, TRANSFER_PREPARE_TIMEOUT_MS);
+          transferPreparationRef.current = { resolve, timer };
+          ws.send(JSON.stringify({ op: 'prepare-transfer' }));
+        });
+      },
+      cancelTransfer: () => {
+        settleTransfer(false);
+        const ws = wsRef.current;
+        if (ws?.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ op: 'cancel-transfer' }));
+      },
+      snapshot: () => serialize.serialize(),
+    });
 
     const onSelection = term.onSelectionChange(() => {
       const selection = selectedTerminalText(term, useUiPrefsStore.getState().copyOnSelect);
@@ -120,10 +166,13 @@ export default function TerminalPaneImpl({
 
     return () => {
       observer.disconnect();
+      unregister();
+      settleTransfer(false);
       onSelection.dispose();
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
+      serializeRef.current = null;
     };
   }, [tab.id]);
 
@@ -133,9 +182,18 @@ export default function TerminalPaneImpl({
 
     if (reconnectRequest > 0) term.write('\r\n\x1b[90m[reconnecting]\x1b[0m\r\n');
     const { defaultShell } = useUiPrefsStore.getState();
+    const currentTab = useDockStore.getState().tabs.find((candidate) => candidate.id === tab.id);
+    const terminalId =
+      reconnectRequest === 0 && (currentTab?.kind === 'terminal' || currentTab?.kind === 'node-shell')
+        ? currentTab.terminalId
+        : undefined;
+    // Reconnect is intentionally a fresh shell. Retaining the old id would race
+    // the old socket's explicit close and briefly attach to a session being torn
+    // down, producing a second close instead of a usable replacement.
+    if (reconnectRequest > 0) useDockStore.getState().setTerminalSession(tab.id, undefined);
     const ws = new WebSocket(
       tab.kind === 'node-shell'
-        ? wsUrl('/ws/node-shell', { ctx: tab.ctx, node: tab.node, cols: term.cols, rows: term.rows })
+        ? wsUrl('/ws/node-shell', { ctx: tab.ctx, node: tab.node, cols: term.cols, rows: term.rows, terminalId })
         : wsUrl('/ws/exec', {
             ctx: tab.ctx,
             namespace: tab.namespace,
@@ -144,8 +202,10 @@ export default function TerminalPaneImpl({
             shell: defaultShell !== 'auto' && defaultShell.trim() ? defaultShell.trim() : undefined,
             cols: term.cols,
             rows: term.rows,
+            terminalId,
           }),
     );
+    wsRef.current = ws;
     ws.binaryType = 'arraybuffer';
 
     ws.onopen = () => {
@@ -157,7 +217,24 @@ export default function TerminalPaneImpl({
       } else if (typeof ev.data === 'string') {
         try {
           const ctl = JSON.parse(ev.data) as ExecServerControl;
-          if (ctl.op === 'exit') {
+          if (ctl.op === 'session') {
+            useDockStore.getState().setTerminalSession(tab.id, ctl.terminalId);
+            const current = useDockStore.getState().tabs.find((candidate) => candidate.id === tab.id);
+            if (current && (current.kind === 'terminal' || current.kind === 'node-shell') && current.transferId) {
+              completeTabTransfer(current.transferId);
+              useDockStore.getState().clearTransfer(tab.id);
+            }
+          } else if (ctl.op === 'transfer-ready') {
+            const pending = transferPreparationRef.current;
+            if (pending) term.write('', () => {
+              if (transferPreparationRef.current === pending) {
+                transferPreparationRef.current = null;
+                clearTimeout(pending.timer);
+                pending.resolve(true);
+              }
+            });
+          } else if (ctl.op === 'exit') {
+            useDockStore.getState().setTerminalSession(tab.id, undefined);
             term.write(`\r\n\x1b[33m[session ended${ctl.message ? `: ${ctl.message}` : ''}]\x1b[0m\r\n`);
           }
         } catch {
@@ -165,7 +242,14 @@ export default function TerminalPaneImpl({
         }
       }
     };
-    ws.onclose = () => term.write('\r\n\x1b[90m[disconnected]\x1b[0m\r\n');
+    ws.onclose = () => {
+      const current = useDockStore.getState().tabs.find((candidate) => candidate.id === tab.id);
+      if (current && (current.kind === 'terminal' || current.kind === 'node-shell') && current.transferId) {
+        cancelTabTransfer(current.transferId);
+        useDockStore.getState().clearTransfer(tab.id);
+      }
+      term.write('\r\n\x1b[90m[disconnected]\x1b[0m\r\n');
+    };
 
     const encoder = new TextEncoder();
     const onData = term.onData((data) => {
@@ -180,7 +264,10 @@ export default function TerminalPaneImpl({
       ws.onopen = null;
       ws.onmessage = null;
       ws.onclose = null;
-      ws.close();
+      if (wsRef.current === ws) wsRef.current = null;
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close(1000, EXEC_SESSION_CLOSE_REASON);
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reconnectRequest, tab.id]);

--- a/client/src/cross-window-state.ts
+++ b/client/src/cross-window-state.ts
@@ -1,0 +1,39 @@
+import { useLogPrefsStore } from './state/log-prefs.js';
+
+const EXTERNAL_STATE_EVENT = 'kubus:state-changed';
+
+interface PersistApi {
+  persist: { rehydrate: () => Promise<void> | void };
+}
+
+const storeLoaders: Record<string, () => Promise<PersistApi>> = {
+  'kubus-audit': () => import('./state/audit.js').then((module) => module.useAuditPrefsStore),
+  'kubus-clusters': () => import('./state/clusters.js').then((module) => module.useClustersStore),
+  'kubus-log-prefs': () => Promise.resolve(useLogPrefsStore),
+  'kubus-navigation': () => import('./state/navigation.js').then((module) => module.useNavigationStore),
+  'kubus-portforward-prefs': () => import('./state/portforward-prefs.js').then((module) => module.usePortForwardPrefsStore),
+  'kubus-prefs': () => import('./state/prefs.js').then((module) => module.useUiPrefsStore),
+};
+
+let installed = false;
+
+function rehydrate(name: string | null): void {
+  if (!name) return;
+  const load = storeLoaders[name];
+  if (load) void load().then((store) => store.persist.rehydrate());
+}
+
+/**
+ * Keep durable app-wide preferences and saved definitions live. Cluster and
+ * UI stores deliberately partialize their persisted state, so rehydration
+ * cannot replace a window's selected contexts, namespaces, or nav layout.
+ */
+export function installCrossWindowStateSync(): void {
+  if (installed) return;
+  installed = true;
+  window.addEventListener('storage', (event) => rehydrate(event.key));
+  window.addEventListener(EXTERNAL_STATE_EVENT, (event) => {
+    const name = (event as CustomEvent<{ name?: unknown }>).detail?.name;
+    if (typeof name === 'string') rehydrate(name);
+  });
+}

--- a/client/src/desktop.d.ts
+++ b/client/src/desktop.d.ts
@@ -1,4 +1,4 @@
-import type { AppInfo, UpdateCheckResult } from '@kubus/shared';
+import type { AppInfo, AppWindowLaunch, UpdateCheckResult } from '@kubus/shared';
 
 declare global {
   /** Bridge exposed by the Electron preload (absent in regular browsers). */
@@ -6,6 +6,8 @@ declare global {
     kubusDesktop?: {
       /** Electron's process.platform ('linux', 'win32', 'darwin', …). */
       platform: string;
+      /** One-shot payload describing the content of a secondary app window. */
+      windowLaunch?: AppWindowLaunch;
       stateStorage: {
         getItem(name: string): string | null;
         setItem(name: string, value: string): void;
@@ -14,6 +16,10 @@ declare global {
       setTitleBarOverlay(options: { color: string; symbolColor: string }): void;
       getAppInfo(): Promise<AppInfo | undefined>;
       checkForUpdate(options?: { force?: boolean }): Promise<UpdateCheckResult>;
+      /** Open a secondary native application window. */
+      openWindow(launch: AppWindowLaunch): void;
+      /** Detach only if the native cursor is outside every Kubus window. */
+      detachTab(launch: Extract<AppWindowLaunch, { kind: 'tab-transfer' }>): Promise<boolean>;
       /** Subscribe to the OS close-window chord (Cmd/Ctrl+W); returns unsubscribe. */
       onCloseTab(callback: () => void): () => void;
       /** Subscribe to the tab-cycling chords (Ctrl+Tab & friends); backwards=true cycles left. */

--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -1,10 +1,6 @@
-import { memo, useState } from 'react';
+import { memo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Tooltip from '@mui/material/Tooltip';
@@ -12,14 +8,26 @@ import CloseIcon from '@mui/icons-material/Close';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
-import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import SubjectIcon from '@mui/icons-material/Subject';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import { clampDockHeight, useDockStore } from '../state/dock.js';
 import { TerminalPane } from '../components/TerminalPane.js';
 import { LogViewer } from '../components/LogViewer.js';
+import { TabActionsMenu, type TabMenuState } from '../components/TabActionsMenu.js';
+import { createTabTransferId, finishLocalTabTransfer, receiveTabTransfer, registerTabTransferSource } from '../tab-transfer.js';
+import { hasTabTransfer, readTabTransfer, shouldDetachTabDrag, writeTabTransfer } from '../tab-drag.js';
+import { detachTabWindow } from '../window-management.js';
+import { currentAppWindowContext } from '../window-context.js';
 
-export const BottomDock = memo(function BottomDock({ containerRef }: { containerRef: React.RefObject<HTMLDivElement | null> }) {
+export const BottomDock = memo(function BottomDock({
+  containerRef,
+  standalone = false,
+}: {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Fill a focused terminal/log utility window instead of the resizable app dock. */
+  standalone?: boolean;
+}) {
   const tabs = useDockStore((s) => s.tabs);
   const activeId = useDockStore((s) => s.activeId);
   const open = useDockStore((s) => s.open);
@@ -31,8 +39,12 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
   const setMaximized = useDockStore((s) => s.setMaximized);
   const terminalFocusRequest = useDockStore((s) => s.terminalFocusRequest);
   const terminalReconnectRequests = useDockStore((s) => s.terminalReconnectRequests);
-  const requestTerminalReconnect = useDockStore((s) => s.requestTerminalReconnect);
-  const [tabMenu, setTabMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [tabMenu, setTabMenu] = useState<TabMenuState | null>(null);
+  const [dragId, setDragId] = useState<string | null>(null);
+  const dragIndexRef = useRef<number | null>(null);
+  const dragTransferIdRef = useRef<string | null>(null);
+  const localDropRef = useRef(false);
+  const visible = standalone || open;
 
   // Escape restores a maximized dock via the global dismiss chain in
   // GlobalShortcuts — guarded there so a focused terminal keeps its Escape.
@@ -79,14 +91,14 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
       sx={{
         height: '100%',
         display: 'flex',
-        visibility: open ? 'visible' : 'hidden',
+        visibility: visible ? 'visible' : 'hidden',
         flexDirection: 'column',
-        borderTop: 1,
+        borderTop: standalone ? 0 : 1,
         borderColor: 'divider',
         bgcolor: 'background.paper',
       }}
     >
-      {!maximized && (
+      {!standalone && !maximized && (
         <Box
           onMouseDown={startResize}
           sx={{
@@ -102,13 +114,93 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
           <Box className="grip" sx={{ width: 36, height: 3, borderRadius: 2, bgcolor: 'divider', transition: 'all 120ms ease' }} />
         </Box>
       )}
-      <Box sx={{ display: 'flex', alignItems: 'center', borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
-        <Tabs value={activeId ?? false} onChange={(_e, v) => setActive(v as string)} variant="scrollable" sx={{ minHeight: 32, flex: 1 }}>
-          {tabs.map((tab) => (
+      <Box
+        className={standalone ? 'kubus-dock-window-titlebar' : undefined}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          minHeight: standalone ? 52 : undefined,
+          borderBottom: 1,
+          borderColor: 'divider',
+          flexShrink: 0,
+          WebkitAppRegion: standalone ? 'drag' : undefined,
+          pl: standalone ? 'env(titlebar-area-x, 0px)' : undefined,
+          pr: standalone
+            ? 'calc(100vw - env(titlebar-area-x, 0px) - env(titlebar-area-width, 100vw))'
+            : undefined,
+          '& button': { WebkitAppRegion: 'no-drag' },
+        }}
+      >
+        <Tabs
+          value={activeId ?? false}
+          onChange={(_e, v) => setActive(v as string)}
+          variant="scrollable"
+          sx={{ minHeight: standalone ? 52 : 32, flex: 1 }}
+        >
+          {tabs.map((tab, index) => (
             <Tab
               key={tab.id}
               value={tab.id}
-              sx={{ minHeight: 32, py: 0, textTransform: 'none' }}
+              draggable
+              sx={{ minHeight: standalone ? 52 : 32, py: 0, textTransform: 'none' }}
+              onDragStart={(event) => {
+                const transferId = createTabTransferId();
+                registerTabTransferSource(transferId, 'dock', tab.id);
+                writeTabTransfer(event.dataTransfer, transferId);
+                dragTransferIdRef.current = transferId;
+                dragIndexRef.current = index;
+                localDropRef.current = false;
+                setDragId(tab.id);
+              }}
+              onDragOver={(event) => {
+                if (dragIndexRef.current === null && !hasTabTransfer(event.dataTransfer)) return;
+                event.preventDefault();
+                event.dataTransfer.dropEffect = 'move';
+                const from = dragIndexRef.current;
+                if (from !== null && from !== index) {
+                  const state = useDockStore.getState();
+                  if (!!state.tabs[from]?.pinned === !!state.tabs[index]?.pinned) {
+                    state.moveTab(from, index);
+                    dragIndexRef.current = index;
+                  }
+                }
+              }}
+              onDrop={(event) => {
+                event.preventDefault();
+                const transferId = readTabTransfer(event.dataTransfer);
+                if (!transferId) return;
+                if (dragIndexRef.current !== null) {
+                  localDropRef.current = true;
+                  finishLocalTabTransfer(transferId);
+                  return;
+                }
+                void receiveTabTransfer(
+                  transferId,
+                  tab.id,
+                  event.clientX < event.currentTarget.getBoundingClientRect().left + event.currentTarget.clientWidth / 2 ? 'before' : 'after',
+                );
+              }}
+              onDragEnd={(event) => {
+                const transferId = dragTransferIdRef.current;
+                if (transferId && !localDropRef.current && event.dataTransfer.dropEffect === 'none') {
+                  if (window.kubusDesktop || shouldDetachTabDrag(event.nativeEvent)) {
+                    void detachTabWindow({
+                      kind: 'tab-transfer',
+                      surface: 'dock',
+                      transferId,
+                      title: tab.title,
+                      context: currentAppWindowContext(),
+                    }).then((detached) => {
+                      if (!detached) finishLocalTabTransfer(transferId);
+                    });
+                  } else {
+                    finishLocalTabTransfer(transferId);
+                  }
+                }
+                dragIndexRef.current = null;
+                dragTransferIdRef.current = null;
+                setDragId(null);
+              }}
               onMouseDown={(e) => {
                 // Prevent Chromium's middle-click autoscroll so onAuxClick fires cleanly.
                 if (e.button === 1) e.preventDefault();
@@ -117,20 +209,25 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
                 if (e.button === 1) closeTab(tab.id);
               }}
               onContextMenu={(e) => {
-                if (tab.kind !== 'terminal' && tab.kind !== 'node-shell') return;
                 e.preventDefault();
-                setTabMenu({ id: tab.id, x: e.clientX, y: e.clientY });
+                setTabMenu({ surface: 'dock', id: tab.id, title: tab.title, x: e.clientX, y: e.clientY });
               }}
               onKeyDown={(e) => {
-                if (tab.kind !== 'terminal' && tab.kind !== 'node-shell') return;
+                if (e.key === 'Delete') {
+                  e.preventDefault();
+                  closeTab(tab.id);
+                  return;
+                }
                 if (e.key !== 'ContextMenu' && !(e.shiftKey && e.key === 'F10')) return;
                 e.preventDefault();
                 const rect = e.currentTarget.getBoundingClientRect();
-                setTabMenu({ id: tab.id, x: rect.left + 8, y: rect.bottom - 4 });
+                setTabMenu({ surface: 'dock', id: tab.id, title: tab.title, x: rect.left + 8, y: rect.bottom - 4 });
               }}
               label={
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                   {tab.kind === 'terminal' || tab.kind === 'node-shell' ? <TerminalIcon sx={{ fontSize: 14 }} /> : <SubjectIcon sx={{ fontSize: 14 }} />}
+                  {tab.pinned ? <PushPinOutlinedIcon aria-label="Pinned" sx={{ fontSize: 13, transform: 'rotate(45deg)' }} /> : null}
+                  {tab.color ? <Box aria-label="Tab flag" sx={{ width: 7, height: 7, borderRadius: '50%', bgcolor: tab.color }} /> : null}
                   {tab.title}
                   <IconButton
                     component="span"
@@ -146,19 +243,24 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
                   </IconButton>
                 </Box>
               }
+              style={{ opacity: dragId === tab.id ? 0.5 : 1 }}
             />
           ))}
         </Tabs>
-        <Tooltip title={maximized ? 'Restore' : 'Maximize'}>
-          <IconButton size="small" onClick={() => setMaximized(!maximized)}>
-            {maximized ? <FullscreenExitIcon fontSize="small" /> : <FullscreenIcon fontSize="small" />}
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Minimize">
-          <IconButton size="small" onClick={() => setOpen(false)}>
-            <KeyboardArrowDownIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
+        {!standalone ? (
+          <>
+            <Tooltip title={maximized ? 'Restore' : 'Maximize'}>
+              <IconButton size="small" onClick={() => setMaximized(!maximized)}>
+                {maximized ? <FullscreenExitIcon fontSize="small" /> : <FullscreenIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Minimize">
+              <IconButton size="small" onClick={() => setOpen(false)}>
+                <KeyboardArrowDownIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </>
+        ) : null}
       </Box>
       <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
         {tabs.map((tab) => (
@@ -166,34 +268,17 @@ export const BottomDock = memo(function BottomDock({ containerRef }: { container
             {tab.kind === 'terminal' || tab.kind === 'node-shell' ? (
               <TerminalPane
                 tab={tab}
-                active={open && tab.id === activeId}
+                active={visible && tab.id === activeId}
                 focusRequest={terminalFocusRequest?.tabId === tab.id ? terminalFocusRequest.sequence : 0}
                 reconnectRequest={terminalReconnectRequests[tab.id] ?? 0}
               />
-            ) : open ? (
+            ) : visible ? (
               <LogViewer tab={tab} />
             ) : null}
           </Box>
         ))}
       </Box>
-      <Menu
-        open={tabMenu !== null}
-        onClose={() => setTabMenu(null)}
-        anchorReference="anchorPosition"
-        anchorPosition={tabMenu ? { top: tabMenu.y, left: tabMenu.x } : undefined}
-      >
-        <MenuItem
-          onClick={() => {
-            if (tabMenu) requestTerminalReconnect(tabMenu.id);
-            setTabMenu(null);
-          }}
-        >
-          <ListItemIcon>
-            <RestartAltIcon fontSize="small" />
-          </ListItemIcon>
-          <ListItemText>Reconnect</ListItemText>
-        </MenuItem>
-      </Menu>
+      <TabActionsMenu menu={tabMenu} onClose={() => setTabMenu(null)} />
     </Box>
   );
 });

--- a/client/src/layout/DockWindowShell.tsx
+++ b/client/src/layout/DockWindowShell.tsx
@@ -4,11 +4,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import { BottomDock } from './BottomDock.js';
 import { useDockStore } from '../state/dock.js';
-
-function closeUtilityWindow(): void {
-  if (window.kubusDesktop) window.kubusDesktop.closeWindow();
-  else window.close();
-}
+import { closeCurrentAppWindow } from '../window-management.js';
 
 /** Focused secondary renderer: one compact tab strip and its terminal/log content. */
 export const DockWindowShell = memo(function DockWindowShell() {
@@ -23,7 +19,7 @@ export const DockWindowShell = memo(function DockWindowShell() {
       hadContent.current = true;
       return;
     }
-    if (hadContent.current) closeUtilityWindow();
+    if (hadContent.current) closeCurrentAppWindow();
   }, [tabCount]);
 
   useEffect(() => {

--- a/client/src/layout/DockWindowShell.tsx
+++ b/client/src/layout/DockWindowShell.tsx
@@ -1,0 +1,85 @@
+import { memo, useEffect, useRef } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Typography from '@mui/material/Typography';
+import { BottomDock } from './BottomDock.js';
+import { useDockStore } from '../state/dock.js';
+
+function closeUtilityWindow(): void {
+  if (window.kubusDesktop) window.kubusDesktop.closeWindow();
+  else window.close();
+}
+
+/** Focused secondary renderer: one compact tab strip and its terminal/log content. */
+export const DockWindowShell = memo(function DockWindowShell() {
+  const tabCount = useDockStore((state) => state.tabs.length);
+  const activeId = useDockStore((state) => state.activeId);
+  const activeTitle = useDockStore((state) => state.tabs.find((tab) => tab.id === state.activeId)?.title);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hadContent = useRef(tabCount > 0);
+
+  useEffect(() => {
+    if (tabCount > 0) {
+      hadContent.current = true;
+      return;
+    }
+    if (hadContent.current) closeUtilityWindow();
+  }, [tabCount]);
+
+  useEffect(() => {
+    document.title = activeTitle ? `${activeTitle} — Kubus` : 'Kubus';
+  }, [activeTitle]);
+
+  useEffect(() => {
+    if (!activeId) return;
+    const tab = useDockStore.getState().tabs.find((candidate) => candidate.id === activeId);
+    if (tab?.kind === 'terminal' || tab?.kind === 'node-shell') {
+      useDockStore.getState().requestTerminalFocus(activeId);
+    }
+  }, [activeId]);
+
+  useEffect(() => {
+    const closeActive = () => {
+      const dock = useDockStore.getState();
+      if (dock.activeId) dock.closeTab(dock.activeId);
+    };
+    const cycle = (backwards: boolean) => {
+      const dock = useDockStore.getState();
+      if (dock.tabs.length < 2) return;
+      const index = Math.max(0, dock.tabs.findIndex((tab) => tab.id === dock.activeId));
+      dock.setActive(dock.tabs[(index + (backwards ? -1 : 1) + dock.tabs.length) % dock.tabs.length]!.id);
+    };
+    const offClose = window.kubusDesktop?.onCloseTab(closeActive);
+    const offCycle = window.kubusDesktop?.onCycleTab(cycle);
+    return () => {
+      offClose?.();
+      offCycle?.();
+    };
+  }, []);
+
+  if (tabCount === 0) {
+    return (
+      <Box
+        className="kubus-dock-window-loading"
+        sx={{
+          height: '100vh',
+          display: 'grid',
+          placeContent: 'center',
+          gap: 1.5,
+          justifyItems: 'center',
+          bgcolor: 'background.default',
+          WebkitAppRegion: 'drag',
+        }}
+      >
+        <CircularProgress size={22} />
+        <Typography variant="body2" color="text.secondary">Moving tab…</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box ref={containerRef} sx={{ height: '100vh', overflow: 'hidden' }}>
+      <BottomDock containerRef={containerRef} standalone />
+    </Box>
+  );
+});

--- a/client/src/layout/TabsBar.tsx
+++ b/client/src/layout/TabsBar.tsx
@@ -2,12 +2,11 @@ import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'rea
 import { layout } from '../theme.js';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import { useLocation, useNavigate } from 'react-router';
 import { useTabsStore } from '../state/tabs.js';
 import { useClustersStore } from '../state/clusters.js';
@@ -15,6 +14,11 @@ import { applySavedViewGridState } from '../state/saved-view.js';
 import { useApiResourcesForContexts } from '../api/queries.js';
 import { tabMeta } from './tab-meta.js';
 import { TruncationTooltip } from '../components/truncation.js';
+import { TabActionsMenu, type TabMenuState } from '../components/TabActionsMenu.js';
+import { createTabTransferId, finishLocalTabTransfer, receiveTabTransfer, registerTabTransferSource } from '../tab-transfer.js';
+import { hasTabTransfer, readTabTransfer, shouldDetachTabDrag, writeTabTransfer } from '../tab-drag.js';
+import { detachTabWindow } from '../window-management.js';
+import { currentAppWindowContext } from '../window-context.js';
 
 // Electron always starts at '/'; on the first mount we reopen the tab the user
 // left active. Module-scoped so StrictMode's double effect doesn't re-restore.
@@ -30,9 +34,11 @@ export const TabsBar = memo(function TabsBar() {
   const current = location.pathname + location.search;
   const activeTab = tabs.find((tab) => tab.id === activeId);
 
-  const [menu, setMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const [menu, setMenu] = useState<TabMenuState | null>(null);
   const [dragId, setDragId] = useState<string | null>(null);
   const dragIndexRef = useRef<number | null>(null);
+  const dragTransferIdRef = useRef<string | null>(null);
+  const localDropRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
 
@@ -63,6 +69,19 @@ export const TabsBar = memo(function TabsBar() {
     activeTabRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
   }, [activeId, tabs.length]);
 
+  // Cross-window claims mutate the store outside this component's event
+  // handlers. Subscribe once so an adopted page lands its router location in
+  // the same frame as ordinary tab activation.
+  useEffect(
+    () =>
+      useTabsStore.subscribe((state, previous) => {
+        if (state.activeId === previous.activeId) return;
+        const active = state.tabs.find((tab) => tab.id === state.activeId);
+        if (active && active.path !== window.location.pathname + window.location.search) void navigate(active.path);
+      }),
+    [navigate],
+  );
+
   // Store → router: after any tab mutation, land on the (new) active tab.
   const act = (mutate: () => void) => {
     mutate();
@@ -73,7 +92,6 @@ export const TabsBar = memo(function TabsBar() {
 
   const metas = useMemo(() => new Map(tabs.map((t) => [t.id, tabMeta(t.path, apiResources?.resources)])), [tabs, apiResources]);
   const closeTab = (id: string) => act(() => useTabsStore.getState().closeTab(id));
-  const menuIndex = menu ? tabs.findIndex((t) => t.id === menu.id) : -1;
 
   return (
     <Box
@@ -108,22 +126,61 @@ export const TabsBar = memo(function TabsBar() {
               tabIndex={active ? 0 : -1}
               draggable
               onDragStart={(e) => {
-                e.dataTransfer.effectAllowed = 'move';
+                const transferId = createTabTransferId();
+                registerTabTransferSource(transferId, 'page', tab.id);
+                writeTabTransfer(e.dataTransfer, transferId);
+                dragTransferIdRef.current = transferId;
+                localDropRef.current = false;
                 dragIndexRef.current = idx;
                 setDragId(tab.id);
               }}
               onDragOver={(e) => {
+                if (dragIndexRef.current === null && !hasTabTransfer(e.dataTransfer)) return;
                 e.preventDefault();
                 e.dataTransfer.dropEffect = 'move';
                 const from = dragIndexRef.current;
                 if (from !== null && from !== idx) {
-                  useTabsStore.getState().moveTab(from, idx);
-                  dragIndexRef.current = idx;
+                  const state = useTabsStore.getState();
+                  // Pinned and ordinary tabs are separate reorder groups. Do
+                  // not advance the live drag index when the store rejects a
+                  // boundary crossing, or the next hover would move a neighbor.
+                  if (!!state.tabs[from]?.pinned === !!state.tabs[idx]?.pinned) {
+                    state.moveTab(from, idx);
+                    dragIndexRef.current = idx;
+                  }
                 }
               }}
-              onDrop={(e) => e.preventDefault()}
-              onDragEnd={() => {
+              onDrop={(e) => {
+                e.preventDefault();
+                const transferId = readTabTransfer(e.dataTransfer);
+                if (!transferId) return;
+                if (dragIndexRef.current !== null) {
+                  localDropRef.current = true;
+                  finishLocalTabTransfer(transferId);
+                  return;
+                }
+                void receiveTabTransfer(transferId, tab.id, e.clientX < e.currentTarget.getBoundingClientRect().left + e.currentTarget.clientWidth / 2 ? 'before' : 'after');
+              }}
+              onDragEnd={(e) => {
+                const transferId = dragTransferIdRef.current;
+                const draggedTitle = tab.customTitle ?? meta.title;
+                if (transferId && !localDropRef.current && e.dataTransfer.dropEffect === 'none') {
+                  if (window.kubusDesktop || shouldDetachTabDrag(e.nativeEvent)) {
+                    void detachTabWindow({
+                      kind: 'tab-transfer',
+                      surface: 'page',
+                      transferId,
+                      title: draggedTitle,
+                      context: currentAppWindowContext(),
+                    }).then((detached) => {
+                      if (!detached) finishLocalTabTransfer(transferId);
+                    });
+                  } else {
+                    finishLocalTabTransfer(transferId);
+                  }
+                }
                 dragIndexRef.current = null;
+                dragTransferIdRef.current = null;
                 setDragId(null);
               }}
               onClick={() => act(() => useTabsStore.getState().setActive(tab.id))}
@@ -138,6 +195,18 @@ export const TabsBar = memo(function TabsBar() {
                   closeTab(tab.id);
                   // The focused element is gone; keep keyboard flow on the strip.
                   requestAnimationFrame(() => scrollRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]')?.focus());
+                  return;
+                }
+                if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+                  e.preventDefault();
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  setMenu({
+                    surface: 'page',
+                    id: tab.id,
+                    title: tab.customTitle ?? meta.title,
+                    x: rect.left + 8,
+                    y: rect.bottom - 4,
+                  });
                   return;
                 }
                 // Roving focus per the ARIA tabs pattern: arrows move focus
@@ -159,7 +228,7 @@ export const TabsBar = memo(function TabsBar() {
               }}
               onContextMenu={(e) => {
                 e.preventDefault();
-                setMenu({ id: tab.id, x: e.clientX, y: e.clientY });
+                setMenu({ surface: 'page', id: tab.id, title: tab.customTitle ?? meta.title, x: e.clientX, y: e.clientY });
               }}
               sx={{
                 display: 'flex',
@@ -178,21 +247,26 @@ export const TabsBar = memo(function TabsBar() {
                 userSelect: 'none',
                 opacity: dragId === tab.id ? 0.5 : 1,
                 ...(active
-                  ? { bgcolor: 'background.default', boxShadow: (theme) => `inset 0 2px 0 0 ${theme.palette.primary.main}` }
-                  : { color: 'text.secondary', '&:hover': { bgcolor: 'action.hover' } }),
+                  ? { bgcolor: 'background.default', boxShadow: (theme) => `inset 0 2px 0 0 ${tab.color ?? theme.palette.primary.main}` }
+                  : {
+                      color: 'text.secondary',
+                      boxShadow: tab.color ? `inset 0 2px 0 0 ${tab.color}` : undefined,
+                      '&:hover': { bgcolor: 'action.hover' },
+                    }),
                 '&:hover .tab-close, &:focus-within .tab-close': { opacity: 1 },
               }}
             >
               <Box sx={{ display: 'flex', color: 'text.secondary', '& svg': { fontSize: 15 } }}>{meta.icon}</Box>
-              <TruncationTooltip text={meta.title}>
+              {tab.pinned ? <PushPinOutlinedIcon aria-label="Pinned" sx={{ fontSize: 13, color: 'text.secondary', transform: 'rotate(45deg)' }} /> : null}
+              <TruncationTooltip text={tab.customTitle ?? meta.title}>
                 <Typography variant="body2" noWrap sx={{ flex: 1, fontSize: 12.5 }}>
-                  {meta.title}
+                  {tab.customTitle ?? meta.title}
                 </Typography>
               </TruncationTooltip>
               <IconButton
                 className="tab-close"
                 size="small"
-                aria-label={`Close ${meta.title} tab`}
+                aria-label={`Close ${tab.customTitle ?? meta.title} tab`}
                 onClick={(e) => {
                   e.stopPropagation();
                   closeTab(tab.id);
@@ -216,51 +290,7 @@ export const TabsBar = memo(function TabsBar() {
         </IconButton>
       </Tooltip>
       <Box sx={{ flex: 1 }} onDoubleClick={() => act(() => useTabsStore.getState().openTab('/'))} />
-      <Menu
-        open={!!menu}
-        onClose={() => setMenu(null)}
-        anchorReference="anchorPosition"
-        anchorPosition={menu ? { top: menu.y, left: menu.x } : undefined}
-      >
-        <MenuItem
-          dense
-          onClick={() => {
-            if (menu) act(() => useTabsStore.getState().duplicateTab(menu.id));
-            setMenu(null);
-          }}
-        >
-          Duplicate
-        </MenuItem>
-        <MenuItem
-          dense
-          onClick={() => {
-            if (menu) closeTab(menu.id);
-            setMenu(null);
-          }}
-        >
-          Close
-        </MenuItem>
-        <MenuItem
-          dense
-          disabled={tabs.length < 2}
-          onClick={() => {
-            if (menu) act(() => useTabsStore.getState().closeOthers(menu.id));
-            setMenu(null);
-          }}
-        >
-          Close others
-        </MenuItem>
-        <MenuItem
-          dense
-          disabled={menuIndex < 0 || menuIndex >= tabs.length - 1}
-          onClick={() => {
-            if (menu) act(() => useTabsStore.getState().closeRight(menu.id));
-            setMenu(null);
-          }}
-        >
-          Close to the right
-        </MenuItem>
-      </Menu>
+      <TabActionsMenu menu={menu} onClose={() => setMenu(null)} afterPageMutation={() => act(() => undefined)} />
     </Box>
   );
 });

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,7 +9,7 @@ import { ApiError, initAuthToken } from './api/http.js';
 import { isMutationErrorHandledLocally } from './api/mutation-errors.js';
 import { showErrorToast } from './state/toast.js';
 import App from './App.js';
-import { appWindowSurface, consumeAppWindowLaunch } from './window-management.js';
+import { appWindowSurface, closeCurrentAppWindow, consumeAppWindowLaunch } from './window-management.js';
 import { dockTabId, useDockStore, type DockTab } from './state/dock.js';
 import { pageTabId, useTabsStore } from './state/tabs.js';
 import { showToast } from './state/toast.js';
@@ -34,7 +34,8 @@ if (launch && sessionStorage.getItem(launchAppliedKey) !== launch.windowId) {
   } else {
     void (async () => {
       if (!(await receiveTabTransfer(launch.transferId, undefined, 'after', true))) {
-        showToast('warning', 'The tab could not be moved from the other window.');
+        if (launch.surface === 'dock') closeCurrentAppWindow();
+        else showToast('warning', 'The tab could not be moved from the other window.');
       }
     })();
   }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,8 +9,36 @@ import { ApiError, initAuthToken } from './api/http.js';
 import { isMutationErrorHandledLocally } from './api/mutation-errors.js';
 import { showErrorToast } from './state/toast.js';
 import App from './App.js';
+import { appWindowSurface, consumeAppWindowLaunch } from './window-management.js';
+import { dockTabId, useDockStore, type DockTab } from './state/dock.js';
+import { pageTabId, useTabsStore } from './state/tabs.js';
+import { showToast } from './state/toast.js';
+import { installCrossWindowStateSync } from './cross-window-state.js';
+import { receiveTabTransfer } from './tab-transfer.js';
+import { applyAppWindowContext } from './window-context.js';
 
 initAuthToken();
+installCrossWindowStateSync();
+
+const surface = appWindowSurface();
+const launch = consumeAppWindowLaunch();
+const launchAppliedKey = 'kubus-window-launch-applied';
+if (launch && sessionStorage.getItem(launchAppliedKey) !== launch.windowId) {
+  sessionStorage.setItem(launchAppliedKey, launch.windowId);
+  if (launch.context) applyAppWindowContext(launch.context);
+  if (launch.kind === 'page') {
+    const tab = { id: pageTabId(), ...launch.tab };
+    useTabsStore.setState({ tabs: [tab], activeId: tab.id, closedPaths: [] });
+  } else if (launch.kind === 'dock') {
+    useDockStore.getState().addTab({ id: dockTabId(), ...launch.tab } as DockTab);
+  } else {
+    void (async () => {
+      if (!(await receiveTabTransfer(launch.transferId, undefined, 'after', true))) {
+        showToast('warning', 'The tab could not be moved from the other window.');
+      }
+    })();
+  }
+}
 
 const queryClient = new QueryClient({
   mutationCache: new MutationCache({
@@ -36,7 +64,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
+        <App surface={surface} />
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -184,6 +184,13 @@ export function GlobalShortcuts() {
     };
 
     const cycleTab = (delta: number) => {
+      const dock = useDockStore.getState();
+      const focusedInDock = document.activeElement instanceof HTMLElement && !!document.activeElement.closest('.kubus-bottom-dock');
+      if (focusedInDock && dock.open && dock.tabs.length > 1) {
+        const idx = Math.max(0, dock.tabs.findIndex((tab) => tab.id === dock.activeId));
+        dock.setActive(dock.tabs[(idx + delta + dock.tabs.length) % dock.tabs.length]!.id);
+        return;
+      }
       const s = useTabsStore.getState();
       if (s.tabs.length < 2) return;
       const idx = Math.max(0, s.tabs.findIndex((t) => t.id === s.activeId));

--- a/client/src/state/clusters.ts
+++ b/client/src/state/clusters.ts
@@ -1,7 +1,9 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import type { StateStorage } from 'zustand/middleware';
 import { useUiPrefsStore } from './prefs.js';
-import { kubusStateStorage } from './persist-storage.js';
+import { kubusStateStorage, skipUnchangedStorageWrites } from './persist-storage.js';
+import { windowScopeId } from '../window-management.js';
 
 export interface ContextSettings {
   /**
@@ -48,11 +50,61 @@ interface ClustersState {
   removeContext: (name: string) => void;
 }
 
+interface WindowClusterContext {
+  selected: string[];
+  namespaces: string[];
+}
+
+const sessionStateStorage: StateStorage = {
+  getItem: (name) => sessionStorage.getItem(name),
+  setItem: (name, value) => sessionStorage.setItem(name, value),
+  removeItem: (name) => sessionStorage.removeItem(name),
+};
+
+const clusterWindowScope = windowScopeId();
+const clusterWindowStorage = clusterWindowScope === 'main' ? kubusStateStorage : sessionStateStorage;
+const clusterWindowKey = `kubus-window-clusters:${clusterWindowScope}`;
+const sharedClusterStorage = skipUnchangedStorageWrites(kubusStateStorage);
+
+function syncStorageValue(storage: StateStorage, name: string): string | null {
+  const value = storage.getItem(name);
+  return typeof value === 'string' || value === null ? value : null;
+}
+
+function parseWindowClusterContext(raw: string | null): WindowClusterContext | undefined {
+  try {
+    const value = JSON.parse(raw ?? 'null') as Partial<WindowClusterContext> | null;
+    if (!value || !Array.isArray(value.selected) || !Array.isArray(value.namespaces)) return undefined;
+    if (!value.selected.every((item) => typeof item === 'string') || !value.namespaces.every((item) => typeof item === 'string')) return undefined;
+    return { selected: value.selected, namespaces: value.namespaces };
+  } catch {
+    return undefined;
+  }
+}
+
+function legacyMainClusterContext(): WindowClusterContext | undefined {
+  if (clusterWindowScope !== 'main') return undefined;
+  try {
+    const envelope = JSON.parse(syncStorageValue(kubusStateStorage, 'kubus-clusters') ?? 'null') as {
+      state?: Partial<WindowClusterContext>;
+    } | null;
+    if (!envelope?.state) return undefined;
+    return parseWindowClusterContext(JSON.stringify(envelope.state));
+  } catch {
+    return undefined;
+  }
+}
+
+const initialWindowClusterContext =
+  parseWindowClusterContext(syncStorageValue(clusterWindowStorage, clusterWindowKey)) ??
+  legacyMainClusterContext() ??
+  { selected: [], namespaces: [] };
+
 export const useClustersStore = create<ClustersState>()(
   persist(
     (set) => ({
-      selected: [],
-      namespaces: [],
+      selected: initialWindowClusterContext.selected,
+      namespaces: initialWindowClusterContext.namespaces,
       themeMode: 'os',
       contextSettings: {},
       contextOrder: [],
@@ -83,9 +135,46 @@ export const useClustersStore = create<ClustersState>()(
           };
         }),
     }),
-    { name: 'kubus-clusters', version: 0, storage: createJSONStorage(() => kubusStateStorage) },
+    {
+      name: 'kubus-clusters',
+      version: 0,
+      storage: createJSONStorage(() => sharedClusterStorage),
+      // A window's active cluster/namespace context is deliberately absent:
+      // rehydrating app-wide cluster metadata must not navigate other windows.
+      partialize: ({ themeMode, contextSettings, contextOrder, pickerLayout }) => ({
+        themeMode,
+        contextSettings,
+        contextOrder,
+        pickerLayout,
+      }),
+      merge: (persisted, current) => ({
+        ...current,
+        ...(persisted as Partial<ClustersState>),
+        selected: current.selected,
+        namespaces: current.namespaces,
+      }),
+    },
   ),
 );
+
+let lastSelected = useClustersStore.getState().selected;
+let lastNamespaces = useClustersStore.getState().namespaces;
+
+function persistWindowClusterContext(selected: string[], namespaces: string[]): void {
+  try {
+    clusterWindowStorage.setItem(clusterWindowKey, JSON.stringify({ selected, namespaces } satisfies WindowClusterContext));
+  } catch {
+    /* a blocked/full session store must not break cluster switching */
+  }
+}
+
+persistWindowClusterContext(lastSelected, lastNamespaces);
+useClustersStore.subscribe((state) => {
+  if (state.selected === lastSelected && state.namespaces === lastNamespaces) return;
+  lastSelected = state.selected;
+  lastNamespaces = state.namespaces;
+  persistWindowClusterContext(lastSelected, lastNamespaces);
+});
 
 export function useIsProtected(ctx: string): boolean {
   const explicit = useClustersStore((s) => s.contextSettings[ctx]?.protected);

--- a/client/src/state/dock.ts
+++ b/client/src/state/dock.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { LogTargetKind } from '@kubus/shared';
 import { useDetailStore } from './detail.js';
+import { windowScopeId } from '../window-management.js';
 
 export interface TerminalTab {
   kind: 'terminal';
@@ -10,6 +11,14 @@ export interface TerminalTab {
   namespace: string;
   pod: string;
   container: string;
+  pinned?: boolean;
+  color?: string;
+  /** Stable server-side shell identity used for renderer handoff. */
+  terminalId?: string;
+  /** Opaque source-window token until a live handoff completes. */
+  transferId?: string;
+  /** Serialized xterm history captured immediately before a handoff. */
+  snapshot?: string;
 }
 
 export interface NodeShellTab {
@@ -18,6 +27,11 @@ export interface NodeShellTab {
   title: string;
   ctx: string;
   node: string;
+  pinned?: boolean;
+  color?: string;
+  terminalId?: string;
+  transferId?: string;
+  snapshot?: string;
 }
 
 export interface LogsTab {
@@ -34,6 +48,8 @@ export interface LogsTab {
   tailLines?: number;
   sinceSeconds?: number;
   previous?: boolean;
+  pinned?: boolean;
+  color?: string;
 }
 
 export type DockTab = TerminalTab | NodeShellTab | LogsTab;
@@ -48,6 +64,16 @@ interface DockState {
   terminalReconnectRequests: Record<string, number>;
   addTab: (tab: DockTab) => void;
   closeTab: (id: string) => void;
+  closeOthers: (id: string) => void;
+  closeRight: (id: string) => void;
+  duplicateTab: (id: string) => void;
+  renameTab: (id: string, title: string) => void;
+  setPinned: (id: string, pinned: boolean) => void;
+  setColor: (id: string, color?: string) => void;
+  moveTab: (from: number, to: number) => void;
+  adoptTab: (tab: DockTab, targetId?: string, edge?: 'before' | 'after') => boolean;
+  setTerminalSession: (id: string, terminalId?: string) => void;
+  clearTransfer: (id: string) => void;
   setActive: (id: string) => void;
   setOpen: (open: boolean) => void;
   setHeight: (height: number) => void;
@@ -65,34 +91,188 @@ export function clampDockHeight(height: number): number {
   return Math.max(160, Math.min(window.innerHeight - 200, height));
 }
 
+function pinnedCount(tabs: readonly DockTab[]): number {
+  const firstUnpinned = tabs.findIndex((tab) => !tab.pinned);
+  return firstUnpinned < 0 ? tabs.length : firstUnpinned;
+}
+
+function insertionIndex(tabs: readonly DockTab[], tab: DockTab, requested: number): number {
+  const boundary = pinnedCount(tabs);
+  return tab.pinned
+    ? Math.max(0, Math.min(requested, boundary))
+    : Math.max(boundary, Math.min(requested, tabs.length));
+}
+
+function duplicateDockTab(tab: DockTab): DockTab {
+  const copy = { ...tab, id: dockTabId() } as DockTab;
+  delete copy.pinned;
+  if (copy.kind === 'terminal' || copy.kind === 'node-shell') {
+    delete copy.terminalId;
+    delete copy.transferId;
+    delete copy.snapshot;
+  }
+  return copy as DockTab;
+}
+
+interface PersistedDockState {
+  tabs: DockTab[];
+  activeId?: string;
+  open: boolean;
+  height: number;
+  maximized: boolean;
+}
+
+const dockSessionKey = `kubus-dock:${windowScopeId()}`;
+
+function restoredDockState(): PersistedDockState | undefined {
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(dockSessionKey) ?? 'null') as Partial<PersistedDockState> | null;
+    if (!parsed || !Array.isArray(parsed.tabs) || !parsed.tabs.every((tab) => tab && ['terminal', 'node-shell', 'logs'].includes(tab.kind))) {
+      return undefined;
+    }
+    const activeId = parsed.tabs.some((tab) => tab.id === parsed.activeId) ? parsed.activeId : parsed.tabs[0]?.id;
+    return {
+      tabs: parsed.tabs,
+      activeId,
+      open: !!parsed.open && parsed.tabs.length > 0,
+      height: typeof parsed.height === 'number' ? clampDockHeight(parsed.height) : 320,
+      maximized: !!parsed.maximized && parsed.tabs.length > 0,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+const restored = restoredDockState();
+
 export const useDockStore = create<DockState>((set) => ({
-  tabs: [],
-  activeId: undefined,
-  open: false,
-  height: 320,
-  maximized: false,
+  tabs: restored?.tabs ?? [],
+  activeId: restored?.activeId,
+  open: restored?.open ?? false,
+  height: restored?.height ?? 320,
+  maximized: restored?.maximized ?? false,
   terminalFocusRequest: undefined,
   terminalReconnectRequests: {},
   addTab: (tab) => {
     // The detail drawer is modal and would cover the dock — close it so the
     // freshly opened terminal/log tab is actually visible.
     useDetailStore.getState().close();
-    set((s) => ({ tabs: [...s.tabs, tab], activeId: tab.id, open: true }));
+    set((s) => {
+      const at = insertionIndex(s.tabs, tab, s.tabs.length);
+      return { tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)], activeId: tab.id, open: true };
+    });
   },
   closeTab: (id) =>
     set((s) => {
+      const idx = s.tabs.findIndex((tab) => tab.id === id);
+      if (idx < 0) return s;
       const tabs = s.tabs.filter((t) => t.id !== id);
       const terminalReconnectRequests = { ...s.terminalReconnectRequests };
       delete terminalReconnectRequests[id];
       return {
         tabs,
-        activeId: s.activeId === id ? tabs[tabs.length - 1]?.id : s.activeId,
+        activeId: s.activeId === id ? tabs[Math.min(idx, tabs.length - 1)]?.id : s.activeId,
         open: tabs.length > 0 ? s.open : false,
         maximized: tabs.length > 0 ? s.maximized : false,
         terminalFocusRequest: s.terminalFocusRequest?.tabId === id ? undefined : s.terminalFocusRequest,
         terminalReconnectRequests,
       };
     }),
+  closeOthers: (id) =>
+    set((s) => {
+      if (!s.tabs.some((tab) => tab.id === id)) return s;
+      const tabs = s.tabs.filter((tab) => tab.id === id || tab.pinned);
+      const keptIds = new Set(tabs.map((tab) => tab.id));
+      return {
+        tabs,
+        activeId: id,
+        terminalReconnectRequests: Object.fromEntries(
+          Object.entries(s.terminalReconnectRequests).filter(([tabId]) => keptIds.has(tabId)),
+        ),
+      };
+    }),
+  closeRight: (id) =>
+    set((s) => {
+      const idx = s.tabs.findIndex((tab) => tab.id === id);
+      if (idx < 0) return s;
+      const closingIds = new Set(s.tabs.slice(idx + 1).filter((tab) => !tab.pinned).map((tab) => tab.id));
+      if (!closingIds.size) return s;
+      const tabs = s.tabs.filter((tab) => !closingIds.has(tab.id));
+      return {
+        tabs,
+        activeId: s.activeId && closingIds.has(s.activeId) ? id : s.activeId,
+        terminalReconnectRequests: Object.fromEntries(
+          Object.entries(s.terminalReconnectRequests).filter(([tabId]) => !closingIds.has(tabId)),
+        ),
+      };
+    }),
+  duplicateTab: (id) =>
+    set((s) => {
+      const idx = s.tabs.findIndex((tab) => tab.id === id);
+      if (idx < 0) return s;
+      const tab = duplicateDockTab(s.tabs[idx]!);
+      const at = insertionIndex(s.tabs, tab, idx + 1);
+      return { tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)], activeId: tab.id, open: true };
+    }),
+  renameTab: (id, title) =>
+    set((s) => ({
+      tabs: s.tabs.map((tab) => (tab.id === id && title.trim() ? { ...tab, title: title.trim().slice(0, 200) } : tab)),
+    })),
+  setPinned: (id, pinned) =>
+    set((s) => {
+      const idx = s.tabs.findIndex((tab) => tab.id === id);
+      if (idx < 0 || !!s.tabs[idx]!.pinned === pinned) return s;
+      const tabs = [...s.tabs];
+      const [source] = tabs.splice(idx, 1);
+      const tab = { ...source!, pinned: pinned || undefined } as DockTab;
+      tabs.splice(pinnedCount(tabs), 0, tab);
+      return { tabs };
+    }),
+  setColor: (id, color) =>
+    set((s) => ({ tabs: s.tabs.map((tab) => (tab.id === id ? { ...tab, color: color || undefined } : tab)) })),
+  moveTab: (from, to) =>
+    set((s) => {
+      if (from === to || from < 0 || to < 0 || from >= s.tabs.length || to >= s.tabs.length) return s;
+      if (!!s.tabs[from]!.pinned !== !!s.tabs[to]!.pinned) return s;
+      const tabs = [...s.tabs];
+      const [tab] = tabs.splice(from, 1);
+      tabs.splice(to, 0, tab!);
+      return { tabs };
+    }),
+  adoptTab: (tab, targetId, edge = 'after') => {
+    let adopted = false;
+    set((s) => {
+      if (s.tabs.some((candidate) => candidate.id === tab.id)) return s;
+      const targetIdx = targetId ? s.tabs.findIndex((candidate) => candidate.id === targetId) : s.tabs.length - 1;
+      const requested = targetIdx < 0 ? s.tabs.length : targetIdx + (edge === 'after' ? 1 : 0);
+      const at = insertionIndex(s.tabs, tab, requested);
+      adopted = true;
+      return {
+        tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)],
+        activeId: tab.id,
+        open: true,
+      };
+    });
+    return adopted;
+  },
+  setTerminalSession: (id, terminalId) =>
+    set((s) => ({
+      tabs: s.tabs.map((tab) =>
+        tab.id === id && (tab.kind === 'terminal' || tab.kind === 'node-shell')
+          ? { ...tab, terminalId }
+          : tab,
+      ),
+    })),
+  clearTransfer: (id) =>
+    set((s) => ({
+      tabs: s.tabs.map((tab) => {
+        if (tab.id !== id || (tab.kind !== 'terminal' && tab.kind !== 'node-shell')) return tab;
+        const next = { ...tab };
+        delete next.transferId;
+        delete next.snapshot;
+        return next;
+      }),
+    })),
   setActive: (id) => set({ activeId: id, open: true }),
   setOpen: (open) => set(open ? { open } : { open, maximized: false }),
   setHeight: (height) => set({ height: clampDockHeight(height) }),
@@ -122,3 +302,22 @@ export const useDockStore = create<DockState>((set) => ({
       };
     }),
 }));
+
+// Session storage survives a renderer reload but not an app/browser restart:
+// exactly the lifetime of the server-side terminal reattach grace period.
+useDockStore.subscribe((state) => {
+  try {
+    sessionStorage.setItem(
+      dockSessionKey,
+      JSON.stringify({
+        tabs: state.tabs,
+        activeId: state.activeId,
+        open: state.open,
+        height: state.height,
+        maximized: state.maximized,
+      } satisfies PersistedDockState),
+    );
+  } catch {
+    /* unavailable/full session storage must never break tab interactions */
+  }
+});

--- a/client/src/state/persist-storage.ts
+++ b/client/src/state/persist-storage.ts
@@ -58,3 +58,18 @@ export const kubusStateStorage: StateStorage = {
     browserStorage()?.removeItem(name);
   },
 };
+
+/** Avoid cross-window broadcasts when a local-only store action partializes to identical shared data. */
+export function skipUnchangedStorageWrites(base: StateStorage): StateStorage {
+  return {
+    getItem: (name) => base.getItem(name),
+    setItem: (name, value) => {
+      const current = base.getItem(name);
+      if (current instanceof Promise) {
+        return current.then((resolved) => resolved === value ? undefined : base.setItem(name, value));
+      }
+      return current === value ? undefined : base.setItem(name, value);
+    },
+    removeItem: (name) => base.removeItem(name),
+  };
+}

--- a/client/src/state/prefs.ts
+++ b/client/src/state/prefs.ts
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import type { StateStorage } from 'zustand/middleware';
 import { usePaneActive } from '../layout/pane-context.js';
-import { kubusStateStorage } from './persist-storage.js';
+import { kubusStateStorage, skipUnchangedStorageWrites } from './persist-storage.js';
+import { windowScopeId } from '../window-management.js';
 
 export type TableDensity = 'compact' | 'comfortable';
 export type RefreshRate = 'fast' | 'normal' | 'slow' | 'off';
@@ -56,6 +58,38 @@ interface UiPrefsState {
 
 export type TableSortModel = ReadonlyArray<{ field: string; sort: 'asc' | 'desc' | null | undefined }>;
 
+const sessionStateStorage: StateStorage = {
+  getItem: (name) => sessionStorage.getItem(name),
+  setItem: (name, value) => sessionStorage.setItem(name, value),
+  removeItem: (name) => sessionStorage.removeItem(name),
+};
+
+const prefsWindowScope = windowScopeId();
+const prefsWindowStorage = prefsWindowScope === 'main' ? kubusStateStorage : sessionStateStorage;
+const prefsWindowKey = `kubus-window-ui:${prefsWindowScope}`;
+const sharedPrefsStorage = skipUnchangedStorageWrites(kubusStateStorage);
+
+function syncStorageValue(storage: StateStorage, name: string): string | null {
+  const value = storage.getItem(name);
+  return typeof value === 'string' || value === null ? value : null;
+}
+
+function storedNavCollapsed(): boolean {
+  try {
+    const scoped = JSON.parse(syncStorageValue(prefsWindowStorage, prefsWindowKey) ?? 'null') as { navCollapsed?: unknown } | null;
+    if (typeof scoped?.navCollapsed === 'boolean') return scoped.navCollapsed;
+    if (prefsWindowScope !== 'main') return false;
+    const legacy = JSON.parse(syncStorageValue(kubusStateStorage, 'kubus-prefs') ?? 'null') as {
+      state?: { navCollapsed?: unknown };
+    } | null;
+    return typeof legacy?.state?.navCollapsed === 'boolean' ? legacy.state.navCollapsed : false;
+  } catch {
+    return false;
+  }
+}
+
+const initialNavCollapsed = storedNavCollapsed();
+
 function replaceTableValue<T>(values: Record<string, T>, tableId: string, value: T | undefined): Record<string, T> {
   const next = { ...values };
   if (value === undefined) delete next[tableId];
@@ -74,7 +108,7 @@ export const useUiPrefsStore = create<UiPrefsState>()(
       copyOnSelect: false,
       rightClickAction: 'copy-paste',
       protectByDefault: false,
-      navCollapsed: false,
+      navCollapsed: initialNavCollapsed,
       cronHumanSchedule: false,
       highUsagePct: 80,
       underRequestedFactor: 2,
@@ -102,9 +136,52 @@ export const useUiPrefsStore = create<UiPrefsState>()(
           sortModels: replaceTableValue(s.sortModels, tableId, state.sort),
         })),
     }),
-    { name: 'kubus-prefs', version: 0, storage: createJSONStorage(() => kubusStateStorage) },
+    {
+      name: 'kubus-prefs',
+      version: 0,
+      storage: createJSONStorage(() => sharedPrefsStorage),
+      partialize: (state) => ({
+        tableDensity: state.tableDensity,
+        monoFontSize: state.monoFontSize,
+        refreshRate: state.refreshRate,
+        defaultTailLines: state.defaultTailLines,
+        defaultShell: state.defaultShell,
+        copyOnSelect: state.copyOnSelect,
+        rightClickAction: state.rightClickAction,
+        protectByDefault: state.protectByDefault,
+        cronHumanSchedule: state.cronHumanSchedule,
+        highUsagePct: state.highUsagePct,
+        underRequestedFactor: state.underRequestedFactor,
+        debugMode: state.debugMode,
+        columnWidths: state.columnWidths,
+        columnVisibility: state.columnVisibility,
+        sortModels: state.sortModels,
+      }),
+      merge: (persisted, current) => ({
+        ...current,
+        ...(persisted as Partial<UiPrefsState>),
+        navCollapsed: current.navCollapsed,
+      }),
+    },
   ),
 );
+
+let lastNavCollapsed = useUiPrefsStore.getState().navCollapsed;
+
+function persistWindowUiState(navCollapsed: boolean): void {
+  try {
+    prefsWindowStorage.setItem(prefsWindowKey, JSON.stringify({ navCollapsed }));
+  } catch {
+    /* a blocked/full session store must not break layout preferences */
+  }
+}
+
+persistWindowUiState(lastNavCollapsed);
+useUiPrefsStore.subscribe((state) => {
+  if (state.navCollapsed === lastNavCollapsed) return;
+  lastNavCollapsed = state.navCollapsed;
+  persistWindowUiState(lastNavCollapsed);
+});
 
 /**
  * Scale a polled query's base interval by the user's refresh-rate preset.

--- a/client/src/state/tabs.ts
+++ b/client/src/state/tabs.ts
@@ -3,6 +3,7 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 import type { StateStorage } from 'zustand/middleware';
 import type { SavedViewGridState } from '@kubus/shared';
 import { kubusStateStorage } from './persist-storage.js';
+import { windowScopeId } from '../window-management.js';
 
 export interface PageTab {
   id: string;
@@ -10,6 +11,10 @@ export interface PageTab {
   path: string;
   /** Saved-view state waiting to be applied the first time this tab is activated. */
   pendingSavedView?: SavedViewGridState;
+  /** Optional user label; route-derived metadata remains the fallback. */
+  customTitle?: string;
+  pinned?: boolean;
+  color?: string;
 }
 
 interface TabsState {
@@ -23,15 +28,20 @@ interface TabsState {
   closeOthers: (id: string) => void;
   closeRight: (id: string) => void;
   duplicateTab: (id: string) => void;
+  renameTab: (id: string, title?: string) => void;
+  setPinned: (id: string, pinned: boolean) => void;
+  setColor: (id: string, color?: string) => void;
   /** Restore the most recently closed tab (after the active one) and activate it. */
   reopenTab: () => void;
   setActive: (id: string) => void;
   moveTab: (from: number, to: number) => void;
+  /** Adopt an existing identity received from another window. */
+  adoptTab: (tab: PageTab, targetId?: string, edge?: 'before' | 'after') => boolean;
   /** Mirror the router location into the active tab (creates the first tab). */
   syncLocation: (path: string) => void;
 }
 
-function pageTabId(): string {
+export function pageTabId(): string {
   return `tab-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
 }
 
@@ -70,11 +80,24 @@ function freshTab(path: string, pendingSavedView?: SavedViewGridState): PageTab 
   return { id: pageTabId(), path, pendingSavedView };
 }
 
+function pinnedCount(tabs: readonly PageTab[]): number {
+  return tabs.findIndex((tab) => !tab.pinned) < 0 ? tabs.length : tabs.findIndex((tab) => !tab.pinned);
+}
+
+function insertionIndex(tabs: readonly PageTab[], tab: PageTab, requested: number): number {
+  const boundary = pinnedCount(tabs);
+  return tab.pinned
+    ? Math.max(0, Math.min(requested, boundary))
+    : Math.max(boundary, Math.min(requested, tabs.length));
+}
+
 function recordClosed(closedPaths: string[], ...paths: string[]): string[] {
   return [...closedPaths, ...paths].slice(-10);
 }
 
 const initialTab = freshTab('/');
+const scopeId = windowScopeId();
+const tabsStorageName = scopeId === 'main' ? 'kubus-tabs' : `kubus-tabs:${scopeId}`;
 
 export const useTabsStore = create<TabsState>()(
   persist(
@@ -86,7 +109,8 @@ export const useTabsStore = create<TabsState>()(
         set((s) => {
           const tab = freshTab(path, opts?.pendingSavedView);
           const activeIdx = s.tabs.findIndex((t) => t.id === s.activeId);
-          const at = opts?.afterActive && activeIdx >= 0 ? activeIdx + 1 : s.tabs.length;
+          const requested = opts?.afterActive && activeIdx >= 0 ? activeIdx + 1 : s.tabs.length;
+          const at = insertionIndex(s.tabs, tab, requested);
           return {
             tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)],
             activeId: opts?.activate === false ? s.activeId : tab.id,
@@ -121,15 +145,19 @@ export const useTabsStore = create<TabsState>()(
         set((s) => {
           const tab = s.tabs.find((t) => t.id === id);
           if (!tab) return s;
-          const closedPaths = recordClosed(s.closedPaths, ...s.tabs.filter((t) => t.id !== id).map((t) => t.path));
-          return { tabs: [tab], activeId: id, closedPaths };
+          const closing = s.tabs.filter((t) => t.id !== id && !t.pinned);
+          const tabs = s.tabs.filter((t) => t.id === id || t.pinned);
+          const closedPaths = recordClosed(s.closedPaths, ...closing.map((t) => t.path));
+          return { tabs, activeId: id, closedPaths };
         }),
       closeRight: (id) =>
         set((s) => {
           const idx = s.tabs.findIndex((t) => t.id === id);
           if (idx < 0) return s;
-          const closedPaths = recordClosed(s.closedPaths, ...s.tabs.slice(idx + 1).map((t) => t.path));
-          const tabs = s.tabs.slice(0, idx + 1);
+          const closing = s.tabs.slice(idx + 1).filter((tab) => !tab.pinned);
+          const closingIds = new Set(closing.map((tab) => tab.id));
+          const closedPaths = recordClosed(s.closedPaths, ...closing.map((t) => t.path));
+          const tabs = s.tabs.filter((tab) => !closingIds.has(tab.id));
           const activeId = tabs.some((t) => t.id === s.activeId) ? s.activeId : id;
           return { tabs, activeId, closedPaths };
         }),
@@ -139,7 +167,8 @@ export const useTabsStore = create<TabsState>()(
           if (path === undefined) return s;
           const tab = freshTab(path);
           const activeIdx = s.tabs.findIndex((t) => t.id === s.activeId);
-          const at = activeIdx >= 0 ? activeIdx + 1 : s.tabs.length;
+          const requested = activeIdx >= 0 ? activeIdx + 1 : s.tabs.length;
+          const at = insertionIndex(s.tabs, tab, requested);
           return {
             closedPaths: s.closedPaths.slice(0, -1),
             tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)],
@@ -151,18 +180,51 @@ export const useTabsStore = create<TabsState>()(
           const idx = s.tabs.findIndex((t) => t.id === id);
           if (idx < 0) return s;
           const source = s.tabs[idx]!;
-          const tab = freshTab(source.path, source.pendingSavedView);
-          return { tabs: [...s.tabs.slice(0, idx + 1), tab, ...s.tabs.slice(idx + 1)], activeId: tab.id };
+          const tab = { ...freshTab(source.path, source.pendingSavedView), customTitle: source.customTitle, color: source.color };
+          const at = insertionIndex(s.tabs, tab, idx + 1);
+          return { tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)], activeId: tab.id };
         }),
+      renameTab: (id, title) =>
+        set((s) => ({
+          tabs: s.tabs.map((tab) =>
+            tab.id === id ? { ...tab, customTitle: title?.trim().slice(0, 200) || undefined } : tab,
+          ),
+        })),
+      setPinned: (id, pinned) =>
+        set((s) => {
+          const idx = s.tabs.findIndex((tab) => tab.id === id);
+          if (idx < 0 || !!s.tabs[idx]!.pinned === pinned) return s;
+          const tabs = [...s.tabs];
+          const [source] = tabs.splice(idx, 1);
+          const tab = { ...source!, pinned: pinned || undefined };
+          const at = pinned ? pinnedCount(tabs) : pinnedCount(tabs);
+          tabs.splice(at, 0, tab);
+          return { tabs };
+        }),
+      setColor: (id, color) =>
+        set((s) => ({ tabs: s.tabs.map((tab) => (tab.id === id ? { ...tab, color: color || undefined } : tab)) })),
       setActive: (id) => set({ activeId: id }),
       moveTab: (from, to) =>
         set((s) => {
           if (from === to || from < 0 || to < 0 || from >= s.tabs.length || to >= s.tabs.length) return s;
+          if (!!s.tabs[from]!.pinned !== !!s.tabs[to]!.pinned) return s;
           const tabs = [...s.tabs];
           const [moved] = tabs.splice(from, 1);
           tabs.splice(to, 0, moved!);
           return { tabs };
         }),
+      adoptTab: (tab, targetId, edge = 'after') => {
+        let adopted = false;
+        set((s) => {
+          if (s.tabs.some((candidate) => candidate.id === tab.id)) return s;
+          const targetIdx = targetId ? s.tabs.findIndex((candidate) => candidate.id === targetId) : s.tabs.length - 1;
+          const requested = targetIdx < 0 ? s.tabs.length : targetIdx + (edge === 'after' ? 1 : 0);
+          const at = insertionIndex(s.tabs, tab, requested);
+          adopted = true;
+          return { tabs: [...s.tabs.slice(0, at), tab, ...s.tabs.slice(at)], activeId: tab.id };
+        });
+        return adopted;
+      },
       syncLocation: (path) =>
         set((s) => {
           // Fall back to the first tab if activeId is stale (e.g. corrupt persist).
@@ -175,6 +237,6 @@ export const useTabsStore = create<TabsState>()(
           return { activeId: active.id, tabs: s.tabs.map((t) => (t.id === active.id ? { ...t, path } : t)) };
         }),
     }),
-    { name: 'kubus-tabs', version: 0, storage: createJSONStorage(() => debouncedStorage(kubusStateStorage, 250)) },
+    { name: tabsStorageName, version: 0, storage: createJSONStorage(() => debouncedStorage(kubusStateStorage, 250)) },
   ),
 );

--- a/client/src/tab-drag.ts
+++ b/client/src/tab-drag.ts
@@ -1,0 +1,30 @@
+export const TAB_TRANSFER_MIME = 'application/x-kubus-tab-transfer';
+
+export function writeTabTransfer(data: DataTransfer, transferId: string): void {
+  data.clearData();
+  data.setData(TAB_TRANSFER_MIME, transferId);
+  data.effectAllowed = 'move';
+}
+
+export function readTabTransfer(data: DataTransfer): string | undefined {
+  const transferId = data.getData(TAB_TRANSFER_MIME);
+  return transferId || undefined;
+}
+
+export function hasTabTransfer(data: DataTransfer): boolean {
+  return [...data.types].includes(TAB_TRANSFER_MIME);
+}
+
+/** A rejected drop is a detach only when the pointer actually left this window. */
+export function shouldDetachTabDrag(
+  event: Pick<DragEvent, 'dataTransfer' | 'screenX' | 'screenY'>,
+  bounds = { screenX: window.screenX, screenY: window.screenY, outerWidth: window.outerWidth, outerHeight: window.outerHeight },
+): boolean {
+  if (event.dataTransfer?.dropEffect === 'move') return false;
+  return (
+    event.screenX < bounds.screenX ||
+    event.screenX >= bounds.screenX + bounds.outerWidth ||
+    event.screenY < bounds.screenY ||
+    event.screenY >= bounds.screenY + bounds.outerHeight
+  );
+}

--- a/client/src/tab-transfer.ts
+++ b/client/src/tab-transfer.ts
@@ -1,0 +1,210 @@
+import { useDockStore, type DockTab } from './state/dock.js';
+import { useTabsStore, type PageTab } from './state/tabs.js';
+import { terminalHandle } from './terminal-registry.js';
+
+const CHANNEL_NAME = 'kubus-tab-transfer-v1';
+const CLAIM_TIMEOUT_MS = 10_000;
+const SOURCE_TTL_MS = 2 * 60_000;
+
+export type TransferableTab =
+  | { surface: 'page'; tab: PageTab }
+  | { surface: 'dock'; tab: DockTab };
+
+type TransferMessage =
+  | { kind: 'claim'; requestId: string; transferId: string }
+  | { kind: 'offer'; requestId: string; transferId: string; offered?: TransferableTab }
+  | { kind: 'cancel'; transferId: string }
+  | { kind: 'complete'; transferId: string };
+
+interface TransferSource {
+  prepare: () => Promise<boolean>;
+  snapshot: () => TransferableTab | undefined;
+  cancel: () => void;
+  complete: () => void;
+  prepared?: Promise<TransferableTab | undefined>;
+  expires: ReturnType<typeof setTimeout>;
+}
+
+let channel: BroadcastChannel | undefined;
+const sources = new Map<string, TransferSource>();
+const claims = new Map<
+  string,
+  {
+    resolve: (tab: TransferableTab | undefined) => void;
+    retry: ReturnType<typeof setInterval>;
+    timer: ReturnType<typeof setTimeout>;
+  }
+>();
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createTabTransferId(): string {
+  return `transfer-${randomId()}`;
+}
+
+function transferChannel(): BroadcastChannel | undefined {
+  if (channel || typeof BroadcastChannel === 'undefined') return channel;
+  try {
+    channel = new BroadcastChannel(CHANNEL_NAME);
+  } catch {
+    return undefined;
+  }
+  channel.addEventListener('message', (event: MessageEvent<TransferMessage>) => {
+    const message = event.data;
+    if (!message || typeof message !== 'object') return;
+    if (message.kind === 'claim') {
+      const source = sources.get(message.transferId);
+      if (!source) return;
+      source.prepared ??= (async () => {
+        try {
+          return (await source.prepare()) ? source.snapshot() : undefined;
+        } catch {
+          return undefined;
+        }
+      })();
+      void source.prepared.then((offered) => {
+        channel?.postMessage({ ...message, kind: 'offer', offered } satisfies TransferMessage);
+      });
+      return;
+    }
+    if (message.kind === 'offer') {
+      const claim = claims.get(message.requestId);
+      if (!claim) return;
+      clearInterval(claim.retry);
+      clearTimeout(claim.timer);
+      claims.delete(message.requestId);
+      claim.resolve(message.offered);
+      return;
+    }
+    if (message.kind === 'cancel') {
+      const source = sources.get(message.transferId);
+      if (source) {
+        source.cancel();
+        source.prepared = undefined;
+      }
+      return;
+    }
+    const source = sources.get(message.transferId);
+    if (!source) return;
+    clearTimeout(source.expires);
+    sources.delete(message.transferId);
+    source.complete();
+  });
+  return channel;
+}
+
+function registerSource(transferId: string, options: Omit<TransferSource, 'expires' | 'prepared'>): void {
+  const expires = setTimeout(() => {
+    const source = sources.get(transferId);
+    source?.cancel();
+    sources.delete(transferId);
+  }, SOURCE_TTL_MS);
+  sources.set(transferId, { ...options, expires });
+  transferChannel();
+}
+
+/** Register a store tab as the source of an opaque cross-window handoff. */
+export function registerTabTransferSource(transferId: string, surface: TransferableTab['surface'], tabId: string): void {
+  if (surface === 'page') {
+    registerSource(transferId, {
+      prepare: async () => true,
+      snapshot: () => {
+        const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+        return tab ? { surface: 'page', tab } : undefined;
+      },
+      cancel: () => undefined,
+      complete: () => useTabsStore.getState().closeTab(tabId),
+    });
+    return;
+  }
+
+  registerSource(transferId, {
+    prepare: async () => {
+      const tab = useDockStore.getState().tabs.find((candidate) => candidate.id === tabId);
+      if (!tab) return false;
+      if (tab.kind === 'logs' || !tab.terminalId) return true;
+      return terminalHandle(tabId)?.prepareTransfer() ?? false;
+    },
+    snapshot: () => {
+      const tab = useDockStore.getState().tabs.find((candidate) => candidate.id === tabId);
+      if (!tab) return undefined;
+      if (tab.kind === 'terminal' || tab.kind === 'node-shell') {
+        return {
+          surface: 'dock',
+          tab: { ...tab, snapshot: terminalHandle(tabId)?.snapshot() },
+        };
+      }
+      return { surface: 'dock', tab };
+    },
+    cancel: () => terminalHandle(tabId)?.cancelTransfer(),
+    complete: () => useDockStore.getState().closeTab(tabId),
+  });
+}
+
+/** Retire a token after a reorder/drop handled entirely in this renderer. */
+export function finishLocalTabTransfer(transferId: string): void {
+  const source = sources.get(transferId);
+  if (!source) return;
+  clearTimeout(source.expires);
+  sources.delete(transferId);
+  source.cancel();
+}
+
+export function claimTabTransfer(transferId: string): Promise<TransferableTab | undefined> {
+  const bus = transferChannel();
+  if (!bus) return Promise.resolve(undefined);
+  const requestId = randomId();
+  return new Promise((resolve) => {
+    const request = () => bus.postMessage({ kind: 'claim', requestId, transferId } satisfies TransferMessage);
+    const retry = setInterval(request, 250);
+    const timer = setTimeout(() => {
+      clearInterval(retry);
+      claims.delete(requestId);
+      bus.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
+      resolve(undefined);
+    }, CLAIM_TIMEOUT_MS);
+    claims.set(requestId, { resolve, retry, timer });
+    request();
+  });
+}
+
+export function completeTabTransfer(transferId: string): void {
+  transferChannel()?.postMessage({ kind: 'complete', transferId } satisfies TransferMessage);
+}
+
+export function cancelTabTransfer(transferId: string): void {
+  transferChannel()?.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
+}
+
+/** Claim and insert a tab. Live terminals complete only after server-side attach. */
+export async function receiveTabTransfer(
+  transferId: string,
+  targetId?: string,
+  edge: 'before' | 'after' = 'after',
+  replacePlaceholder = false,
+): Promise<boolean> {
+  const offered = await claimTabTransfer(transferId);
+  if (!offered) return false;
+
+  if (offered.surface === 'page') {
+    if (replacePlaceholder) useTabsStore.setState({ tabs: [], activeId: undefined });
+    const adopted = useTabsStore.getState().adoptTab(offered.tab, targetId, edge);
+    if (adopted) completeTabTransfer(transferId);
+    else transferChannel()?.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
+    return adopted;
+  }
+
+  const live =
+    (offered.tab.kind === 'terminal' || offered.tab.kind === 'node-shell') &&
+    !!offered.tab.terminalId;
+  const incoming = live ? { ...offered.tab, transferId } : offered.tab;
+  const adopted = useDockStore.getState().adoptTab(incoming, targetId, edge);
+  if (!adopted) {
+    transferChannel()?.postMessage({ kind: 'cancel', transferId } satisfies TransferMessage);
+    return false;
+  }
+  if (!live) completeTabTransfer(transferId);
+  return true;
+}

--- a/client/src/tab-window-actions.ts
+++ b/client/src/tab-window-actions.ts
@@ -1,0 +1,45 @@
+import type { AppWindowDockTab } from '@kubus/shared';
+import { useDockStore, type DockTab } from './state/dock.js';
+import { useTabsStore } from './state/tabs.js';
+import { createTabTransferId, finishLocalTabTransfer, registerTabTransferSource } from './tab-transfer.js';
+import { detachTabWindow, openAppWindow } from './window-management.js';
+import { currentAppWindowContext } from './window-context.js';
+
+export type TabSurface = 'page' | 'dock';
+
+function dockLaunchTab(tab: DockTab): AppWindowDockTab {
+  const { id: _id, ...copy } = tab;
+  if (copy.kind === 'terminal' || copy.kind === 'node-shell') {
+    const { terminalId: _terminalId, transferId: _transferId, snapshot: _snapshot, ...launch } = copy;
+    return launch;
+  }
+  return copy;
+}
+
+/** Open the same content as an independent tab/session in another window. */
+export function openTabInNewWindow(surface: TabSurface, tabId: string, title: string): boolean {
+  if (surface === 'page') {
+    const tab = useTabsStore.getState().tabs.find((candidate) => candidate.id === tabId);
+    if (!tab) return false;
+    const { id: _id, ...copy } = tab;
+    return openAppWindow({ kind: 'page', title, context: currentAppWindowContext(), tab: copy });
+  }
+  const tab = useDockStore.getState().tabs.find((candidate) => candidate.id === tabId);
+  return tab ? openAppWindow({ kind: 'dock', title, context: currentAppWindowContext(), tab: dockLaunchTab(tab) }) : false;
+}
+
+/** Move the existing identity; live terminal sessions are reattached, not redialed. */
+export function moveTabToNewWindow(surface: TabSurface, tabId: string, title: string): boolean {
+  const transferId = createTabTransferId();
+  registerTabTransferSource(transferId, surface, tabId);
+  const opened = openAppWindow({ kind: 'tab-transfer', surface, transferId, title, context: currentAppWindowContext() });
+  if (!opened) finishLocalTabTransfer(transferId);
+  return opened;
+}
+
+export function detachDraggedTab(surface: TabSurface, tabId: string, title: string): string {
+  const transferId = createTabTransferId();
+  registerTabTransferSource(transferId, surface, tabId);
+  void detachTabWindow({ kind: 'tab-transfer', surface, transferId, title, context: currentAppWindowContext() });
+  return transferId;
+}

--- a/client/src/terminal-registry.ts
+++ b/client/src/terminal-registry.ts
@@ -1,0 +1,21 @@
+export interface TerminalHandle {
+  /** Ask the server to freeze output at an ordered transfer boundary. */
+  prepareTransfer: () => Promise<boolean>;
+  /** Resume the source session if the destination never claims it. */
+  cancelTransfer: () => void;
+  /** ANSI serialization of the visible terminal and scrollback. */
+  snapshot: () => string;
+}
+
+const terminals = new Map<string, TerminalHandle>();
+
+export function registerTerminal(tabId: string, handle: TerminalHandle): () => void {
+  terminals.set(tabId, handle);
+  return () => {
+    if (terminals.get(tabId) === handle) terminals.delete(tabId);
+  };
+}
+
+export function terminalHandle(tabId: string | null | undefined): TerminalHandle | undefined {
+  return tabId ? terminals.get(tabId) : undefined;
+}

--- a/client/src/window-context.ts
+++ b/client/src/window-context.ts
@@ -1,0 +1,21 @@
+import type { AppWindowContext } from '@kubus/shared';
+import { useClustersStore } from './state/clusters.js';
+import { useUiPrefsStore } from './state/prefs.js';
+
+/** Snapshot only the working context a new window needs to start in the same place. */
+export function currentAppWindowContext(): AppWindowContext {
+  const clusters = useClustersStore.getState();
+  return {
+    selected: [...clusters.selected],
+    namespaces: [...clusters.namespaces],
+    navCollapsed: useUiPrefsStore.getState().navCollapsed,
+  };
+}
+
+/** Apply a launch snapshot once; subsequent changes remain local to this window. */
+export function applyAppWindowContext(context: AppWindowContext): void {
+  const clusters = useClustersStore.getState();
+  clusters.setSelected([...context.selected]);
+  clusters.setNamespaces([...context.namespaces]);
+  useUiPrefsStore.getState().set({ navCollapsed: context.navCollapsed });
+}

--- a/client/src/window-management.ts
+++ b/client/src/window-management.ts
@@ -1,0 +1,190 @@
+import type { AppWindowLaunch } from '@kubus/shared';
+import { authToken } from './api/http.js';
+
+const LAUNCH_FRAGMENT_KEY = 'launch';
+const WINDOW_SCOPE_KEY = 'kubus-window-scope';
+const WINDOW_SURFACE_KEY = 'kubus-window-surface';
+
+export type AppWindowSurface = 'app' | 'dock';
+
+type AppWindowRequest =
+  | Omit<Extract<AppWindowLaunch, { kind: 'page' }>, 'windowId'>
+  | Omit<Extract<AppWindowLaunch, { kind: 'dock' }>, 'windowId'>
+  | Omit<Extract<AppWindowLaunch, { kind: 'tab-transfer' }>, 'windowId'>;
+
+function randomId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+  const binary = atob(padded);
+  return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)));
+}
+
+const boundedString = (value: unknown, max = 4096): value is string => typeof value === 'string' && value.length <= max;
+const optionalString = (value: unknown, max = 4096): boolean => value === undefined || boundedString(value, max);
+const optionalBoolean = (value: unknown): boolean => value === undefined || typeof value === 'boolean';
+
+function validWindowContext(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!value || typeof value !== 'object') return false;
+  const context = value as Record<string, unknown>;
+  return (
+    Array.isArray(context.selected) &&
+    context.selected.length <= 1000 &&
+    context.selected.every((item) => boundedString(item, 1000)) &&
+    Array.isArray(context.namespaces) &&
+    context.namespaces.length <= 1000 &&
+    context.namespaces.every((item) => boundedString(item, 1000)) &&
+    typeof context.navCollapsed === 'boolean'
+  );
+}
+
+function validDockTab(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const tab = value as Record<string, unknown>;
+  if (!boundedString(tab.title, 500) || !boundedString(tab.ctx, 1000)) return false;
+  if (!optionalBoolean(tab.pinned) || !optionalString(tab.color, 100)) return false;
+  if (tab.kind === 'terminal') {
+    return [tab.namespace, tab.pod, tab.container].every((field) => boundedString(field, 1000));
+  }
+  if (tab.kind === 'node-shell') return boundedString(tab.node, 1000);
+  if (tab.kind !== 'logs' || !boundedString(tab.namespace, 1000)) return false;
+  if (!Array.isArray(tab.pods) || tab.pods.length > 1000 || !tab.pods.every((pod) => boundedString(pod, 1000))) return false;
+  return (
+    optionalString(tab.container, 1000) &&
+    optionalBoolean(tab.follow) &&
+    optionalBoolean(tab.previous) &&
+    (tab.tailLines === undefined || (typeof tab.tailLines === 'number' && Number.isFinite(tab.tailLines))) &&
+    (tab.sinceSeconds === undefined || (typeof tab.sinceSeconds === 'number' && Number.isFinite(tab.sinceSeconds)))
+  );
+}
+
+export function isAppWindowLaunch(value: unknown): value is AppWindowLaunch {
+  if (!value || typeof value !== 'object') return false;
+  const launch = value as Record<string, unknown>;
+  if (!boundedString(launch.windowId, 200) || !launch.windowId || !boundedString(launch.title, 500)) return false;
+  if (!validWindowContext(launch.context)) return false;
+  if (launch.kind === 'tab-transfer') {
+    return (
+      (launch.surface === 'page' || launch.surface === 'dock') &&
+      boundedString(launch.transferId, 200) &&
+      !!launch.transferId
+    );
+  }
+  if (!launch.tab || typeof launch.tab !== 'object') return false;
+  if (launch.kind === 'dock') return validDockTab(launch.tab);
+  if (launch.kind !== 'page') return false;
+  const tab = launch.tab as Record<string, unknown>;
+  return (
+    boundedString(tab.path, 8192) &&
+    tab.path.startsWith('/') &&
+    !tab.path.startsWith('//') &&
+    optionalString(tab.customTitle, 200) &&
+    optionalString(tab.color, 100) &&
+    optionalBoolean(tab.pinned) &&
+    (tab.pendingSavedView === undefined || (!!tab.pendingSavedView && typeof tab.pendingSavedView === 'object'))
+  );
+}
+
+export function encodeAppWindowLaunch(launch: AppWindowLaunch): string {
+  return encodeBase64Url(JSON.stringify(launch));
+}
+
+export function decodeAppWindowLaunch(value: string): AppWindowLaunch | undefined {
+  try {
+    const parsed: unknown = JSON.parse(decodeBase64Url(value));
+    return isAppWindowLaunch(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function launchFromLocation(): AppWindowLaunch | undefined {
+  const fragment = new URLSearchParams(window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash);
+  const encoded = fragment.get(LAUNCH_FRAGMENT_KEY);
+  return encoded ? decodeAppWindowLaunch(encoded) : undefined;
+}
+
+/** Read without consuming so stores can choose a per-window persistence scope during module initialization. */
+export function peekAppWindowLaunch(): AppWindowLaunch | undefined {
+  return window.kubusDesktop?.windowLaunch ?? launchFromLocation();
+}
+
+/** Stable layout-storage scope: secondary windows never overwrite the primary window's tab list. */
+export function windowScopeId(): string {
+  const launchId = peekAppWindowLaunch()?.windowId;
+  if (launchId) {
+    sessionStorage.setItem(WINDOW_SCOPE_KEY, launchId);
+    return launchId;
+  }
+  return sessionStorage.getItem(WINDOW_SCOPE_KEY) ?? 'main';
+}
+
+/** The renderer shell is sticky across reloads after the one-shot launch is consumed. */
+export function appWindowSurface(): AppWindowSurface {
+  const launch = peekAppWindowLaunch();
+  if (launch) {
+    const surface = launch.kind === 'dock' || (launch.kind === 'tab-transfer' && launch.surface === 'dock')
+      ? 'dock'
+      : 'app';
+    sessionStorage.setItem(WINDOW_SURFACE_KEY, surface);
+    return surface;
+  }
+  return sessionStorage.getItem(WINDOW_SURFACE_KEY) === 'dock' ? 'dock' : 'app';
+}
+
+/** Consume the one-shot browser fragment. Electron retains its launch across reloads. */
+export function consumeAppWindowLaunch(): AppWindowLaunch | undefined {
+  const launch = peekAppWindowLaunch();
+  if (!launch || window.kubusDesktop?.windowLaunch) return launch;
+  const url = new URL(window.location.href);
+  const fragment = new URLSearchParams(url.hash.startsWith('#') ? url.hash.slice(1) : url.hash);
+  fragment.delete(LAUNCH_FRAGMENT_KEY);
+  url.hash = fragment.toString();
+  window.history.replaceState({}, '', url.toString());
+  return launch;
+}
+
+/** Ask Electron for a native window, with a same-origin browser fallback. */
+export function openAppWindow(request: AppWindowRequest): boolean {
+  const launch = { ...request, windowId: randomId() } as AppWindowLaunch;
+  if (window.kubusDesktop) {
+    window.kubusDesktop.openWindow(launch);
+    return true;
+  }
+
+  const url = new URL(window.location.href);
+  url.pathname = '/';
+  url.search = '';
+  const token = authToken();
+  if (token) url.searchParams.set('token', token);
+  const fragment = new URLSearchParams();
+  fragment.set(LAUNCH_FRAGMENT_KEY, encodeAppWindowLaunch(launch));
+  url.hash = fragment.toString();
+  // Supplying the `noopener` feature makes standards-compliant browsers return
+  // null even when the popup was created. We need the return value to distinguish
+  // a blocked popup from a successful handoff, so sever the opener explicitly.
+  const opened = window.open(url.toString(), '_blank');
+  if (!opened) return false;
+  opened.opener = null;
+  return true;
+}
+
+/** Native cursor bounds avoid accidental detach while a tab is dropped inside any Kubus window. */
+export async function detachTabWindow(request: Omit<Extract<AppWindowLaunch, { kind: 'tab-transfer' }>, 'windowId'>): Promise<boolean> {
+  const launch = { ...request, windowId: randomId() } as Extract<AppWindowLaunch, { kind: 'tab-transfer' }>;
+  if (window.kubusDesktop) {
+    return window.kubusDesktop.detachTab(launch);
+  }
+  return openAppWindow(request);
+}

--- a/client/src/window-management.ts
+++ b/client/src/window-management.ts
@@ -180,6 +180,12 @@ export function openAppWindow(request: AppWindowRequest): boolean {
   return true;
 }
 
+/** Close only this renderer's native window or script-opened browser popup. */
+export function closeCurrentAppWindow(): void {
+  if (window.kubusDesktop) window.kubusDesktop.closeWindow();
+  else window.close();
+}
+
 /** Native cursor bounds avoid accidental detach while a tab is dropped inside any Kubus window. */
 export async function detachTabWindow(request: Omit<Extract<AppWindowLaunch, { kind: 'tab-transfer' }>, 'windowId'>): Promise<boolean> {
   const launch = { ...request, windowId: randomId() } as Extract<AppWindowLaunch, { kind: 'tab-transfer' }>;

--- a/electron/package.json
+++ b/electron/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@kubus/server": "workspace:*",
+    "@kubus/shared": "workspace:*",
     "@types/node": "^24.13.3",
     "electron": "^43.3.0",
     "electron-builder": "^26.15.3",

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -10,11 +10,13 @@ import {
   ipcMain,
   Menu,
   nativeTheme,
+  screen,
   shell,
   type MenuItemConstructorOptions,
 } from 'electron';
 import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@kubus/server';
+import type { AppWindowLaunch } from '@kubus/shared';
 import { initMainLog, installCrashCapture, mainLog, mainLogPath } from './main-log.js';
 
 // GUI apps on macOS/Linux don't inherit the shell PATH; kubeconfig exec
@@ -38,7 +40,10 @@ const TITLEBAR_HEIGHT = 52;
 const UPDATE_MANIFEST_URL = 'https://kubus-app.dev/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 
-let mainWindow: BrowserWindow | undefined;
+let primaryWindow: BrowserWindow | undefined;
+let appUrl: string | undefined;
+const managedWindows = new Set<BrowserWindow>();
+const windowLaunches = new Map<number, AppWindowLaunch>();
 let server: RunningServer | undefined;
 let closing: Promise<void> | undefined;
 let updateCheck: Promise<UpdateCheckResult> | undefined;
@@ -65,7 +70,7 @@ function routeFromDeepLink(raw: string): string | undefined {
 }
 
 function openRoute(route: string): void {
-  const win = mainWindow;
+  const win = primaryWindow ?? managedWindows.values().next().value;
   if (win && rendererRouteReady) {
     win.webContents.send('kubus:open-route', route);
   } else {
@@ -132,8 +137,16 @@ interface AppInfo {
 const windowStateFile = () => path.join(app.getPath('userData'), 'window-state.json');
 const clientStateFile = () => path.join(app.getPath('userData'), 'client-state.json');
 
-function isMainWindowSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
-  return !!mainWindow && event.sender === mainWindow.webContents;
+function senderWindow(event: IpcMainEvent | IpcMainInvokeEvent): BrowserWindow | undefined {
+  return [...managedWindows].find((win) => win.webContents === event.sender);
+}
+
+function isManagedWindowSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
+  return senderWindow(event) !== undefined;
+}
+
+function isPrimaryWindowSender(event: IpcMainEvent | IpcMainInvokeEvent): boolean {
+  return !!primaryWindow && event.sender === primaryWindow.webContents;
 }
 
 function loadWindowState(): WindowState {
@@ -301,17 +314,58 @@ async function checkForUpdate(force = false): Promise<UpdateCheckResult> {
   }
 }
 
-function createWindow(url: string): void {
+function parseWindowLaunch(value: unknown): AppWindowLaunch | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const launch = value as Record<string, unknown>;
+  if (
+    typeof launch.windowId !== 'string' ||
+    !launch.windowId ||
+    launch.windowId.length > 200 ||
+    typeof launch.title !== 'string' ||
+    launch.title.length > 500
+  ) {
+    return undefined;
+  }
+  if (launch.context !== undefined) {
+    if (!launch.context || typeof launch.context !== 'object') return undefined;
+    const context = launch.context as Record<string, unknown>;
+    const validList = (items: unknown): items is string[] =>
+      Array.isArray(items) &&
+      items.length <= 1000 &&
+      items.every((item) => typeof item === 'string' && item.length <= 1000);
+    if (!validList(context.selected) || !validList(context.namespaces) || typeof context.navCollapsed !== 'boolean') return undefined;
+  }
+  if (launch.kind === 'tab-transfer') {
+    return (launch.surface === 'page' || launch.surface === 'dock') &&
+      typeof launch.transferId === 'string' && !!launch.transferId && launch.transferId.length <= 200
+      ? (value as AppWindowLaunch)
+      : undefined;
+  }
+  if ((launch.kind !== 'page' && launch.kind !== 'dock') || !launch.tab || typeof launch.tab !== 'object') return undefined;
+  const tab = launch.tab as Record<string, unknown>;
+  if (launch.kind === 'page') {
+    return typeof tab.path === 'string' && tab.path.startsWith('/') && !tab.path.startsWith('//') && tab.path.length <= 8192
+      ? (value as AppWindowLaunch)
+      : undefined;
+  }
+  return typeof tab.kind === 'string' && ['terminal', 'node-shell', 'logs'].includes(tab.kind) && typeof tab.title === 'string'
+    ? (value as AppWindowLaunch)
+    : undefined;
+}
+
+function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
   const state = loadWindowState();
-  mainWindow = new BrowserWindow({
+  const isPrimary = !primaryWindow;
+  const win = new BrowserWindow({
     width: state.width,
     height: state.height,
-    x: state.x,
-    y: state.y,
+    x: state.x === undefined || isPrimary ? state.x : state.x + 28,
+    y: state.y === undefined || isPrimary ? state.y : state.y + 28,
     minWidth: 800,
     minHeight: 500,
-    title: 'Kubus',
+    title: launch ? `${launch.title} — Kubus` : 'Kubus',
     show: false,
+    backgroundColor: overlayColors().color,
     icon: windowIcon(),
     // Frameless look on every platform: the client's TopBar is the titlebar
     // (drag region + env(titlebar-area-*) paddings live in the client CSS).
@@ -320,28 +374,46 @@ function createWindow(url: string): void {
     titleBarOverlay: isMac ? true : { ...overlayColors(), height: TITLEBAR_HEIGHT },
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      webSecurity: true,
+      allowRunningInsecureContent: false,
+      webviewTag: false,
+      navigateOnDragDrop: false,
     },
   });
-  if (state.maximized) mainWindow.maximize();
+  managedWindows.add(win);
+  const webContentsId = win.webContents.id;
+  if (launch) windowLaunches.set(webContentsId, launch);
+  if (isPrimary) primaryWindow = win;
+  if (state.maximized && isPrimary) win.maximize();
   // The menu stays installed so its accelerators (zoom, reload, devtools,
   // fullscreen) keep working, but the bar itself is macOS-only chrome.
-  if (!isMac) mainWindow.setMenuBarVisibility(false);
-  mainWindow.once('ready-to-show', () => mainWindow?.show());
-  mainWindow.on('close', () => {
-    if (mainWindow) saveWindowState(mainWindow);
+  if (!isMac) win.setMenuBarVisibility(false);
+  win.once('ready-to-show', () => {
+    if (!win.isDestroyed()) win.show();
   });
-  mainWindow.on('closed', () => {
-    mainWindow = undefined;
-    rendererRouteReady = false;
+  win.on('close', () => {
+    if (win === primaryWindow) saveWindowState(win);
+  });
+  win.on('closed', () => {
+    managedWindows.delete(win);
+    windowLaunches.delete(webContentsId);
+    if (win === primaryWindow) {
+      primaryWindow = managedWindows.values().next().value;
+      // Existing renderers registered their deep-link listener during boot.
+      rendererRouteReady = !!primaryWindow;
+    }
   });
   // A reload restarts the SPA; hold routes until it re-registers.
-  mainWindow.webContents.on('did-start-loading', () => {
-    rendererRouteReady = false;
+  win.webContents.on('did-start-loading', () => {
+    if (win === primaryWindow) rendererRouteReady = false;
   });
-  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+  win.webContents.on('render-process-gone', (_event, details) => {
     mainLog('error', `window renderer gone (${details.reason}, exit code ${details.exitCode})`);
   });
-  mainWindow.webContents.setWindowOpenHandler(({ url: external }) => {
+  win.webContents.setWindowOpenHandler(({ url: external }) => {
     void shell.openExternal(external);
     return { action: 'deny' };
   });
@@ -349,37 +421,37 @@ function createWindow(url: string): void {
   // it can close the focused dock tab (logs/terminal) first, and only close the
   // whole window when nothing is docked. preventDefault() stops the native menu
   // accelerator from firing (and keeps the key out of the page).
-  mainWindow.webContents.on('before-input-event', (event, input) => {
+  win.webContents.on('before-input-event', (event, input) => {
     if (input.type !== 'keyDown') return;
     const key = input.key.toLowerCase();
     // Cmd/Ctrl+W closes the focused dock/page tab — never the window.
     if (key === 'w' && !input.alt && !input.shift && (isMac ? input.meta && !input.control : input.control && !input.meta)) {
       event.preventDefault();
-      mainWindow?.webContents.send('kubus:close-tab');
+      win.webContents.send('kubus:close-tab');
       return;
     }
     // Browser-style page-tab cycling; the payload is true to cycle backwards.
     if (input.control && !input.meta && !input.alt && (key === 'tab' || key === 'pageup' || key === 'pagedown')) {
       event.preventDefault();
-      mainWindow?.webContents.send('kubus:cycle-tab', key === 'tab' ? input.shift : key === 'pageup');
+      win.webContents.send('kubus:cycle-tab', key === 'tab' ? input.shift : key === 'pageup');
       return;
     }
     if (isMac && input.meta && input.shift && !input.control && !input.alt && (input.code === 'BracketLeft' || input.code === 'BracketRight')) {
       event.preventDefault();
-      mainWindow?.webContents.send('kubus:cycle-tab', input.code === 'BracketLeft');
+      win.webContents.send('kubus:cycle-tab', input.code === 'BracketLeft');
     }
   });
-  void mainWindow.loadURL(url);
+  void win.loadURL(url);
+  return win;
 }
 
 ipcMain.on('kubus:close-window', (event) => {
-  if (!isMainWindowSender(event)) return;
-  mainWindow?.close();
+  senderWindow(event)?.close();
 });
 
 ipcMain.on('kubus:set-titlebar-overlay', (event, options: unknown) => {
-  if (isMac || !isMainWindowSender(event)) return;
-  const win = mainWindow;
+  if (isMac) return;
+  const win = senderWindow(event);
   if (!win) return;
   const { color, symbolColor } = (options ?? {}) as { color?: unknown; symbolColor?: unknown };
   if (typeof color !== 'string' || typeof symbolColor !== 'string') return;
@@ -395,7 +467,7 @@ ipcMain.on('kubus:set-titlebar-overlay', (event, options: unknown) => {
 // reply parks the renderer main thread forever.
 ipcMain.on('kubus:state:get-all', (event) => {
   try {
-    event.returnValue = isMainWindowSender(event) ? { ...loadClientState() } : {};
+    event.returnValue = isManagedWindowSender(event) ? { ...loadClientState() } : {};
   } catch {
     event.returnValue = {};
   }
@@ -432,27 +504,33 @@ function flushClientState(): void {
     // Disk write failed (full disk, permissions …): keep the state pending
     // and retry with backoff, and tell the renderer so it can mirror the
     // snapshot into browser storage as a fallback.
-    mainWindow?.webContents.send('kubus:state:write-failed');
+    for (const win of managedWindows) win.webContents.send('kubus:state:write-failed');
     scheduleClientStateFlush(state, STATE_RETRY_MS);
   }
 }
 
 ipcMain.on('kubus:state:set-item', (event, name: unknown, value: unknown) => {
-  if (!isMainWindowSender(event) || typeof name !== 'string' || typeof value !== 'string') return;
+  if (!isManagedWindowSender(event) || typeof name !== 'string' || typeof value !== 'string') return;
   scheduleClientStateFlush({ ...loadClientState(), [name]: value });
+  for (const win of managedWindows) {
+    if (win.webContents !== event.sender) win.webContents.send('kubus:state:changed', name, value);
+  }
 });
 
 ipcMain.on('kubus:state:remove-item', (event, name: unknown) => {
-  if (!isMainWindowSender(event) || typeof name !== 'string') return;
+  if (!isManagedWindowSender(event) || typeof name !== 'string') return;
   const next = { ...loadClientState() };
   delete next[name];
   scheduleClientStateFlush(next);
+  for (const win of managedWindows) {
+    if (win.webContents !== event.sender) win.webContents.send('kubus:state:changed', name, null);
+  }
 });
 
 // The renderer pulls the pending deep link once its route listener is
 // attached; from then on links are pushed over kubus:open-route.
 ipcMain.handle('kubus:get-pending-route', (event): string | null => {
-  if (!isMainWindowSender(event)) return null;
+  if (!isPrimaryWindowSender(event)) return null;
   rendererRouteReady = true;
   const route = pendingRoute ?? null;
   pendingRoute = undefined;
@@ -460,13 +538,13 @@ ipcMain.handle('kubus:get-pending-route', (event): string | null => {
 });
 
 ipcMain.handle('kubus:get-app-info', (event): AppInfo | undefined => {
-  if (!isMainWindowSender(event)) return undefined;
+  if (!isManagedWindowSender(event)) return undefined;
   const enginePath = process.env.KUBUS_HELM_ENGINE;
   return { name: app.getName(), version: app.getVersion(), helmEngine: !!enginePath && existsSync(enginePath) };
 });
 
 ipcMain.handle('kubus:check-for-update', async (event, options?: { force?: unknown }): Promise<UpdateCheckResult> => {
-  if (!isMainWindowSender(event)) {
+  if (!isManagedWindowSender(event)) {
     return { available: false, currentVersion: app.getVersion(), reason: 'invalid-sender' };
   }
   if (options?.force === true) updateCheck = checkForUpdate(true);
@@ -474,13 +552,40 @@ ipcMain.handle('kubus:check-for-update', async (event, options?: { force?: unkno
   return updateCheck;
 });
 
+ipcMain.on('kubus:window-launch', (event) => {
+  event.returnValue = isManagedWindowSender(event) ? windowLaunches.get(event.sender.id) : undefined;
+});
+
+ipcMain.on('kubus:open-window', (event, value: unknown) => {
+  if (!isManagedWindowSender(event) || !appUrl) return;
+  const launch = parseWindowLaunch(value);
+  if (launch) createWindow(appUrl, launch);
+});
+
+ipcMain.handle('kubus:detach-tab', (event, value: unknown): boolean => {
+  if (!isManagedWindowSender(event) || !appUrl) return false;
+  const launch = parseWindowLaunch(value);
+  if (launch?.kind !== 'tab-transfer') return false;
+  const cursor = screen.getCursorScreenPoint();
+  const insideWindow = [...managedWindows]
+    .filter((win) => !win.isDestroyed() && win.isVisible() && !win.isMinimized())
+    .some((win) => {
+      const bounds = win.getBounds();
+      return cursor.x >= bounds.x && cursor.x < bounds.x + bounds.width && cursor.y >= bounds.y && cursor.y < bounds.y + bounds.height;
+    });
+  if (insideWindow) return false;
+  createWindow(appUrl, launch);
+  return true;
+});
+
 if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
   app.on('second-instance', (_event, argv) => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
+    const win = primaryWindow ?? managedWindows.values().next().value;
+    if (win) {
+      if (win.isMinimized()) win.restore();
+      win.focus();
     }
     // Windows/Linux deliver a deep link to the running instance as an argv
     // entry of the second process.
@@ -521,7 +626,8 @@ if (!app.requestSingleInstanceLock()) {
     // the persistent main-process log and the exportable diagnostic buffer.
     mainLog('info', `server listening at ${new URL(server.url).origin}`);
     buildMenu();
-    createWindow(server.url);
+    appUrl = server.url;
+    createWindow(appUrl);
   });
 
   // The server (and its port-forwards) is tied to the window, so quit

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -43,6 +43,8 @@ const UPDATE_CHECK_TIMEOUT_MS = 10_000;
 let primaryWindow: BrowserWindow | undefined;
 let appUrl: string | undefined;
 const managedWindows = new Set<BrowserWindow>();
+const applicationWindows = new Set<BrowserWindow>();
+const routeReadyWindows = new Set<BrowserWindow>();
 const windowLaunches = new Map<number, AppWindowLaunch>();
 let server: RunningServer | undefined;
 let closing: Promise<void> | undefined;
@@ -55,10 +57,6 @@ let updateCheck: Promise<UpdateCheckResult> | undefined;
 
 const PROTOCOL = 'kubus';
 let pendingRoute: string | undefined;
-// True once the renderer has called kubus:get-pending-route, i.e. its route
-// listener is attached. Pushing before that (did-finish-load fires before the
-// SPA mounts) would drop the link on cold start.
-let rendererRouteReady = false;
 
 /** kubus://r/apps/v1/deployments?sel=… → "/r/apps/v1/deployments?sel=…". */
 function routeFromDeepLink(raw: string): string | undefined {
@@ -70,8 +68,13 @@ function routeFromDeepLink(raw: string): string | undefined {
 }
 
 function openRoute(route: string): void {
-  const win = primaryWindow ?? managedWindows.values().next().value;
-  if (win && rendererRouteReady) {
+  let win = primaryWindow;
+  if (!win) {
+    // A focused terminal/log window has no application router. Keep the route
+    // pending and restore a full application window to receive it.
+    pendingRoute = route;
+    if (appUrl) win = createWindow(appUrl);
+  } else if (routeReadyWindows.has(win)) {
     win.webContents.send('kubus:open-route', route);
   } else {
     // Cold start or mid-boot: held until the renderer pulls it.
@@ -353,9 +356,14 @@ function parseWindowLaunch(value: unknown): AppWindowLaunch | undefined {
     : undefined;
 }
 
+function isApplicationLaunch(launch?: AppWindowLaunch): boolean {
+  return !launch || launch.kind === 'page' || (launch.kind === 'tab-transfer' && launch.surface === 'page');
+}
+
 function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
   const state = loadWindowState();
-  const isPrimary = !primaryWindow;
+  const applicationSurface = isApplicationLaunch(launch);
+  const isPrimary = applicationSurface && !primaryWindow;
   const win = new BrowserWindow({
     width: state.width,
     height: state.height,
@@ -384,6 +392,7 @@ function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
     },
   });
   managedWindows.add(win);
+  if (applicationSurface) applicationWindows.add(win);
   const webContentsId = win.webContents.id;
   if (launch) windowLaunches.set(webContentsId, launch);
   if (isPrimary) primaryWindow = win;
@@ -399,16 +408,17 @@ function createWindow(url: string, launch?: AppWindowLaunch): BrowserWindow {
   });
   win.on('closed', () => {
     managedWindows.delete(win);
+    applicationWindows.delete(win);
+    routeReadyWindows.delete(win);
     windowLaunches.delete(webContentsId);
     if (win === primaryWindow) {
-      primaryWindow = managedWindows.values().next().value;
-      // Existing renderers registered their deep-link listener during boot.
-      rendererRouteReady = !!primaryWindow;
+      // Only another full application renderer can own navigation/deep links.
+      primaryWindow = applicationWindows.values().next().value;
     }
   });
   // A reload restarts the SPA; hold routes until it re-registers.
   win.webContents.on('did-start-loading', () => {
-    if (win === primaryWindow) rendererRouteReady = false;
+    routeReadyWindows.delete(win);
   });
   win.webContents.on('render-process-gone', (_event, details) => {
     mainLog('error', `window renderer gone (${details.reason}, exit code ${details.exitCode})`);
@@ -530,8 +540,12 @@ ipcMain.on('kubus:state:remove-item', (event, name: unknown) => {
 // The renderer pulls the pending deep link once its route listener is
 // attached; from then on links are pushed over kubus:open-route.
 ipcMain.handle('kubus:get-pending-route', (event): string | null => {
+  const win = senderWindow(event);
+  if (!win || !applicationWindows.has(win)) return null;
+  // Every full app renderer installs the listener. Remember readiness now so
+  // an already-loaded page window can safely become the navigation owner.
+  routeReadyWindows.add(win);
   if (!isPrimaryWindowSender(event)) return null;
-  rendererRouteReady = true;
   const route = pendingRoute ?? null;
   pendingRoute = undefined;
   return route;
@@ -582,16 +596,19 @@ if (!app.requestSingleInstanceLock()) {
   app.quit();
 } else {
   app.on('second-instance', (_event, argv) => {
+    // Windows/Linux deliver a deep link to the running instance as an argv
+    // entry of the second process.
+    const link = argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
+    const route = link ? routeFromDeepLink(link) : undefined;
+    if (route) {
+      openRoute(route);
+      return;
+    }
     const win = primaryWindow ?? managedWindows.values().next().value;
     if (win) {
       if (win.isMinimized()) win.restore();
       win.focus();
     }
-    // Windows/Linux deliver a deep link to the running instance as an argv
-    // entry of the second process.
-    const link = argv.find((arg) => arg.startsWith(`${PROTOCOL}://`));
-    const route = link ? routeFromDeepLink(link) : undefined;
-    if (route) openRoute(route);
   });
 
   void app.whenReady().then(async () => {

--- a/electron/src/preload.ts
+++ b/electron/src/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
+import type { AppWindowLaunch } from '@kubus/shared';
 
 // Client state is mirrored here and persisted with fire-and-forget messages.
 // sendSync is deliberately avoided for the steady-state path: it parks the
@@ -14,6 +15,15 @@ const stateSnapshot: Record<string, string> = (() => {
   }
 })();
 
+const windowLaunch: AppWindowLaunch | undefined = (() => {
+  try {
+    const value: unknown = ipcRenderer.sendSync('kubus:window-launch');
+    return value && typeof value === 'object' ? (value as AppWindowLaunch) : undefined;
+  } catch {
+    return undefined;
+  }
+})();
+
 // The disk-side write failed in the main process: mirror the snapshot into
 // origin-scoped localStorage so a relaunch on the same origin can migrate it
 // back (kubusStateStorage.getItem reads browser storage when the desktop
@@ -26,9 +36,20 @@ ipcRenderer.on('kubus:state:write-failed', () => {
   }
 });
 
+// Other native windows share the main-process state cache. Mirror changes
+// into this preload snapshot, then ask the matching Zustand store to rehydrate.
+ipcRenderer.on('kubus:state:changed', (_event, name: unknown, value: unknown) => {
+  if (typeof name !== 'string') return;
+  if (typeof value === 'string') stateSnapshot[name] = value;
+  else if (value === null) delete stateSnapshot[name];
+  else return;
+  window.dispatchEvent(new CustomEvent('kubus:state-changed', { detail: { name } }));
+});
+
 // Desktop bridge for stable client state plus native window integrations.
 contextBridge.exposeInMainWorld('kubusDesktop', {
   platform: process.platform,
+  windowLaunch,
   stateStorage: {
     getItem(name: string): string | null {
       return stateSnapshot[name] ?? null;
@@ -50,6 +71,12 @@ contextBridge.exposeInMainWorld('kubusDesktop', {
   },
   checkForUpdate(options?: { force?: boolean }) {
     return ipcRenderer.invoke('kubus:check-for-update', options);
+  },
+  openWindow(launch: AppWindowLaunch): void {
+    ipcRenderer.send('kubus:open-window', launch);
+  },
+  detachTab(launch: Extract<AppWindowLaunch, { kind: 'tab-transfer' }>): Promise<boolean> {
+    return ipcRenderer.invoke('kubus:detach-tab', launch) as Promise<boolean>;
   },
   // Fires when the user presses the OS close-window chord (Cmd/Ctrl+W). Returns
   // an unsubscribe. The renderer closes the focused dock tab or page tab; it

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-serialize':
+        specifier: ^0.14.0
+        version: 0.14.0
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -133,6 +136,9 @@ importers:
       '@kubus/server':
         specifier: workspace:*
         version: link:../server
+      '@kubus/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -1705,6 +1711,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-serialize@0.14.0':
+    resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -5508,6 +5517,8 @@ snapshots:
   '@xmldom/xmldom@0.8.13': {}
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-serialize@0.14.0': {}
 
   '@xterm/xterm@6.0.0': {}
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -31,6 +31,7 @@ import { broadcastWatchMessage, registerWatchSocket } from './ws/watch-socket.js
 import { registerLogsSocket } from './ws/logs-socket.js';
 import { registerExecSocket } from './ws/exec-socket.js';
 import { registerNodeShellSocket } from './ws/node-shell-socket.js';
+import { ExecSessionRegistry } from './ws/transferable-exec.js';
 import { HelmOperationManager } from './helm/operations.js';
 import { appLogPinoSink } from './logging/log-buffer.js';
 
@@ -41,6 +42,7 @@ export interface AppContext {
   sshTunnels: SshTunnelManager;
   settings: SettingsStore;
   helmOperations: HelmOperationManager;
+  execSessions: ExecSessionRegistry;
   /** Raw --kubeconfig CLI flag (cleared when the user resets the override). */
   cliKubeconfig: string | undefined;
 }
@@ -80,7 +82,8 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   const clusters = new ClusterManager(app.log, effectiveOverride, sshTunnels);
   const portForwards = new PortForwardManager(clusters, app.log);
   const helmOperations = new HelmOperationManager(app.log, (operation) => broadcastWatchMessage({ op: 'helm-operation', operation }));
-  const ctx: AppContext = { config, clusters, portForwards, sshTunnels, settings, helmOperations, cliKubeconfig: config.kubeconfigOverride };
+  const execSessions = new ExecSessionRegistry();
+  const ctx: AppContext = { config, clusters, portForwards, sshTunnels, settings, helmOperations, execSessions, cliKubeconfig: config.kubeconfigOverride };
 
   await app.register(fastifyWebsocket, {
     options: {
@@ -149,6 +152,7 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
   }
 
   app.addHook('onClose', async () => {
+    execSessions.dispose();
     portForwards.stopAll();
     clusters.dispose();
     sshTunnels.stopAll();

--- a/server/src/ws/exec-socket.ts
+++ b/server/src/ws/exec-socket.ts
@@ -17,18 +17,28 @@ export function registerExecSocket(app: FastifyInstance, ctx: AppContext): void 
   app.get('/ws/exec', { websocket: true }, (socket: WebSocket, req: FastifyRequest) => {
     const q = req.query as Record<string, string | undefined>;
     try {
+      const cols = Number(q.cols ?? 80) || 80;
+      const rows = Number(q.rows ?? 24) || 24;
+      if (q.terminalId) {
+        if (!ctx.execSessions.attach(q.terminalId, socket, cols, rows)) {
+          socket.send(JSON.stringify({ op: 'exit', code: 1, message: 'The terminal session is no longer available.' }));
+          socket.close();
+        }
+        return;
+      }
       const handle = ctx.clusters.get(q.ctx ?? '');
       // Login shells (-l) so /etc/profile.d is sourced — debug images
       // (debugbox, netshoot) define their helper functions there. Unknown
       // custom executables stay untouched because they may not accept -l.
       const command = shellCommand(q.shell);
-      void runExecBridge(socket, handle, {
+      const transferable = ctx.execSessions.create(socket);
+      void runExecBridge(transferable as unknown as WebSocket, handle, {
         namespace: q.namespace ?? '',
         pod: q.pod ?? '',
         container: q.container ?? '',
         command,
-        cols: Number(q.cols ?? 80) || 80,
-        rows: Number(q.rows ?? 24) || 24,
+        cols,
+        rows,
       });
     } catch (err) {
       if (socket.readyState === socket.OPEN) {

--- a/server/src/ws/node-shell-socket.ts
+++ b/server/src/ws/node-shell-socket.ts
@@ -16,39 +16,51 @@ export function registerNodeShellSocket(app: FastifyInstance, ctx: AppContext): 
       if (socket.readyState === socket.OPEN) socket.send(JSON.stringify({ op: 'exit', code: 1, message }));
       socket.close();
     };
+    const cols = Number(q.cols ?? 80) || 80;
+    const rows = Number(q.rows ?? 24) || 24;
+    if (q.terminalId) {
+      if (!ctx.execSessions.attach(q.terminalId, socket, cols, rows)) sendExit('The terminal session is no longer available.');
+      return;
+    }
+    const transferable = ctx.execSessions.create(socket);
+    const stableSocket = transferable as unknown as WebSocket;
+    const sendStableExit = (message: string) => {
+      if (stableSocket.readyState === stableSocket.OPEN) stableSocket.send(JSON.stringify({ op: 'exit', code: 1, message }));
+      stableSocket.close();
+    };
     void (async () => {
       let cleanup: (() => void) | undefined;
       try {
         const handle = ctx.clusters.get(q.ctx ?? '');
         const node = q.node ?? '';
         if (!node) {
-          sendExit('node is required');
+          sendStableExit('node is required');
           return;
         }
-        if (socket.readyState === socket.OPEN) {
-          socket.send(Buffer.from(`Starting privileged debug pod on ${node}…\r\n`), { binary: true });
+        if (stableSocket.readyState === stableSocket.OPEN) {
+          stableSocket.send(Buffer.from(`Starting privileged debug pod on ${node}…\r\n`), { binary: true });
         }
         const { namespace, pod, container } = await createNodeShellPod(handle, node);
         cleanup = () => {
           deleteNodeShellPod(handle, pod).catch((err) => app.log.warn({ pod, err: String(err) }, 'node-shell pod cleanup failed'));
         };
-        if (socket.readyState !== socket.OPEN) {
+        if (stableSocket.readyState !== stableSocket.OPEN) {
           // Browser left while the pod was starting.
           cleanup();
           return;
         }
-        await runExecBridge(socket, handle, {
+        await runExecBridge(stableSocket, handle, {
           namespace,
           pod,
           container,
           command: NODE_SHELL_COMMAND,
-          cols: Number(q.cols ?? 80) || 80,
-          rows: Number(q.rows ?? 24) || 24,
+          cols,
+          rows,
           onClose: cleanup,
         });
       } catch (err) {
         cleanup?.();
-        sendExit(err instanceof Error ? err.message : String(err));
+        sendStableExit(err instanceof Error ? err.message : String(err));
       }
     })();
   });

--- a/server/src/ws/transferable-exec.ts
+++ b/server/src/ws/transferable-exec.ts
@@ -1,0 +1,205 @@
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import type { WebSocket } from 'ws';
+import { EXEC_SESSION_CLOSE_REASON } from '@kubus/shared';
+
+const REATTACH_GRACE_MS = 15_000;
+const MAX_TRANSFER_BUFFER_BYTES = 4 * 1024 * 1024;
+
+/**
+ * A stable WebSocket-shaped facade whose browser socket can be replaced.
+ * Kubernetes exec owns this facade, so moving a tab between renderers does
+ * not close the upstream shell. Output is bounded and buffered while the new
+ * window claims the session.
+ */
+export class TransferableExecSocket extends EventEmitter {
+  readonly OPEN = 1;
+  private current: WebSocket;
+  private closed = false;
+  private detached = false;
+  private bufferingTransfer = false;
+  private detachTimer: NodeJS.Timeout | undefined;
+  private readonly controls = new Map<string, string>();
+  private readonly transferBuffer: Buffer[] = [];
+  private bufferedTransferBytes = 0;
+
+  constructor(
+    readonly terminalId: string,
+    socket: WebSocket,
+    private readonly reattachGraceMs = REATTACH_GRACE_MS,
+  ) {
+    super();
+    this.current = socket;
+    this.bind(socket);
+  }
+
+  get readyState(): number {
+    return this.closed ? 3 : this.OPEN;
+  }
+
+  /** Attach a new renderer and atomically retire the previous browser socket. */
+  attach(socket: WebSocket, cols: number, rows: number): boolean {
+    if (this.closed) return false;
+    if (this.detachTimer) clearTimeout(this.detachTimer);
+    this.detachTimer = undefined;
+    this.detached = false;
+
+    const previous = this.current;
+    this.unbind(previous);
+    this.current = socket;
+    this.bind(socket);
+    if (previous.readyState === previous.OPEN) previous.close(1000, 'terminal transferred');
+
+    for (const frame of this.controls.values()) {
+      if (socket.readyState === socket.OPEN) socket.send(frame);
+    }
+    this.bufferingTransfer = false;
+    this.flushTransferBuffer();
+    this.emit('message', Buffer.from(JSON.stringify({ op: 'resize', cols, rows })), false);
+    return true;
+  }
+
+  send(data: string | Buffer, options?: { binary?: boolean }): void {
+    if (this.closed) return;
+    if (typeof data === 'string') {
+      try {
+        const control = JSON.parse(data) as { op?: unknown };
+        if (typeof control.op === 'string' && control.op === 'session') this.controls.set(control.op, data);
+      } catch {
+        /* ordinary text frame */
+      }
+    }
+    if (
+      Buffer.isBuffer(data) &&
+      options?.binary &&
+      (this.bufferingTransfer || this.detached || this.current.readyState !== this.current.OPEN)
+    ) {
+      this.bufferTransferData(data);
+      return;
+    }
+    if (this.current.readyState !== this.current.OPEN) return;
+    if (options) this.current.send(data, options);
+    else this.current.send(data);
+  }
+
+  ping(): void {
+    if (this.current.readyState === this.current.OPEN) this.current.ping();
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.closed) return;
+    const socket = this.current;
+    this.finish();
+    if (socket.readyState === socket.OPEN) socket.close(code, reason);
+  }
+
+  private readonly handleMessage = (data: Buffer, isBinary: boolean): void => {
+    if (!isBinary) {
+      try {
+        const control = JSON.parse(data.toString('utf8')) as { op?: unknown };
+        if (control.op === 'prepare-transfer') {
+          this.bufferingTransfer = true;
+          if (this.current.readyState === this.current.OPEN) {
+            this.current.send(JSON.stringify({ op: 'transfer-ready' }));
+          }
+          return;
+        }
+        if (control.op === 'cancel-transfer') {
+          this.bufferingTransfer = false;
+          this.flushTransferBuffer();
+          return;
+        }
+      } catch {
+        /* forwarded as terminal text below */
+      }
+    }
+    this.emit('message', data, isBinary);
+  };
+
+  private readonly handleClose = (code: number, reason: Buffer): void => {
+    if (this.closed || this.detached) return;
+    if (code === 1000 && reason.toString('utf8') === EXEC_SESSION_CLOSE_REASON) {
+      this.finish();
+      return;
+    }
+    this.detached = true;
+    if (this.reattachGraceMs <= 0) {
+      this.finish();
+      return;
+    }
+    this.detachTimer = setTimeout(() => {
+      this.detachTimer = undefined;
+      this.finish();
+    }, this.reattachGraceMs);
+    this.detachTimer.unref?.();
+  };
+
+  private bind(socket: WebSocket): void {
+    socket.on('message', this.handleMessage);
+    socket.once('close', this.handleClose);
+  }
+
+  private unbind(socket: WebSocket): void {
+    socket.removeListener('message', this.handleMessage);
+    socket.removeListener('close', this.handleClose);
+  }
+
+  private bufferTransferData(data: Buffer): void {
+    let buffered = Buffer.from(data);
+    if (buffered.byteLength >= MAX_TRANSFER_BUFFER_BYTES) {
+      this.transferBuffer.length = 0;
+      buffered = buffered.subarray(buffered.byteLength - MAX_TRANSFER_BUFFER_BYTES);
+      this.bufferedTransferBytes = 0;
+    }
+    while (
+      this.transferBuffer.length > 0 &&
+      this.bufferedTransferBytes + buffered.byteLength > MAX_TRANSFER_BUFFER_BYTES
+    ) {
+      this.bufferedTransferBytes -= this.transferBuffer.shift()!.byteLength;
+    }
+    this.transferBuffer.push(buffered);
+    this.bufferedTransferBytes += buffered.byteLength;
+  }
+
+  private flushTransferBuffer(): void {
+    const buffered = this.transferBuffer.splice(0);
+    this.bufferedTransferBytes = 0;
+    if (this.current.readyState !== this.current.OPEN) return;
+    for (const chunk of buffered) this.current.send(chunk, { binary: true });
+  }
+
+  private finish(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.detached = false;
+    if (this.detachTimer) clearTimeout(this.detachTimer);
+    this.detachTimer = undefined;
+    this.transferBuffer.length = 0;
+    this.bufferedTransferBytes = 0;
+    this.unbind(this.current);
+    this.emit('close');
+  }
+}
+
+/** Stable terminal identities shared by pod-shell and node-shell endpoints. */
+export class ExecSessionRegistry {
+  private readonly sessions = new Map<string, TransferableExecSocket>();
+
+  create(socket: WebSocket, reattachGraceMs?: number): TransferableExecSocket {
+    const terminalId = `terminal-${randomUUID()}`;
+    const transferable = new TransferableExecSocket(terminalId, socket, reattachGraceMs);
+    this.sessions.set(terminalId, transferable);
+    transferable.once('close', () => this.sessions.delete(terminalId));
+    transferable.send(JSON.stringify({ op: 'session', terminalId }));
+    return transferable;
+  }
+
+  attach(terminalId: string, socket: WebSocket, cols: number, rows: number): boolean {
+    return this.sessions.get(terminalId)?.attach(socket, cols, rows) ?? false;
+  }
+
+  dispose(): void {
+    for (const session of this.sessions.values()) session.close();
+    this.sessions.clear();
+  }
+}

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -7,6 +7,86 @@ export interface AppInfo {
   helmEngine: boolean;
 }
 
+/** WebSocket close reason which intentionally ends a server-side terminal session. */
+export const EXEC_SESSION_CLOSE_REASON = 'kubus terminal closed';
+
+/** Per-window working context copied once when a secondary window is created. */
+export interface AppWindowContext {
+  selected: string[];
+  namespaces: string[];
+  navCollapsed: boolean;
+}
+
+/** Serializable tab descriptions accepted when a renderer opens a fresh window. */
+export type AppWindowDockTab =
+  | {
+      kind: 'terminal';
+      title: string;
+      ctx: string;
+      namespace: string;
+      pod: string;
+      container: string;
+      pinned?: boolean;
+      color?: string;
+    }
+  | {
+      kind: 'node-shell';
+      title: string;
+      ctx: string;
+      node: string;
+      pinned?: boolean;
+      color?: string;
+    }
+  | {
+      kind: 'logs';
+      title: string;
+      ctx: string;
+      namespace: string;
+      pods: string[];
+      sources?: Array<{ pod: string; containers: string[] }>;
+      target?: { kind: LogTargetKind; name: string };
+      container?: string;
+      follow?: boolean;
+      tailLines?: number;
+      sinceSeconds?: number;
+      previous?: boolean;
+      pinned?: boolean;
+      color?: string;
+    };
+
+/** One secondary Kubus window requested by a renderer. */
+export type AppWindowLaunch =
+  | {
+      kind: 'page';
+      windowId: string;
+      title: string;
+      context?: AppWindowContext;
+      tab: {
+        path: string;
+        pendingSavedView?: SavedViewGridState;
+        customTitle?: string;
+        pinned?: boolean;
+        color?: string;
+      };
+    }
+  | {
+      kind: 'dock';
+      windowId: string;
+      title: string;
+      context?: AppWindowContext;
+      tab: AppWindowDockTab;
+    }
+  | {
+      /** Opaque claim token; the tab itself travels over the same-origin window bus. */
+      kind: 'tab-transfer';
+      /** Chooses the destination shell before the opaque tab is claimed. */
+      surface: 'page' | 'dock';
+      windowId: string;
+      transferId: string;
+      title: string;
+      context?: AppWindowContext;
+    };
+
 export type AppLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
 /** One diagnostic log record from the in-memory app log buffer. */

--- a/shared/src/ws-protocol.ts
+++ b/shared/src/ws-protocol.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { HelmOperation, KubeObject, PortForwardInfo } from './api-types.js';
+export { EXEC_SESSION_CLOSE_REASON } from './api-types.js';
 
 /** Messages the client sends on /ws/watch. */
 export const watchClientMessageSchema = z.discriminatedUnion('op', [
@@ -51,7 +52,14 @@ export type LogServerMessage =
 /** Text frames on /ws/exec; binary frames carry raw terminal bytes. */
 export const execClientControlSchema = z.discriminatedUnion('op', [
   z.object({ op: z.literal('resize'), cols: z.number().int().positive(), rows: z.number().int().positive() }),
+  /** Freeze output before a live terminal is handed to another renderer. */
+  z.object({ op: z.literal('prepare-transfer') }),
+  /** Resume output when a prepared handoff is abandoned. */
+  z.object({ op: z.literal('cancel-transfer') }),
 ]);
 export type ExecClientControl = z.infer<typeof execClientControlSchema>;
 
-export type ExecServerControl = { op: 'exit'; code?: number; message?: string };
+export type ExecServerControl =
+  | { op: 'session'; terminalId: string }
+  | { op: 'transfer-ready' }
+  | { op: 'exit'; code?: number; message?: string };

--- a/tests/e2e/specs/tab-windows.spec.ts
+++ b/tests/e2e/specs/tab-windows.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test';
+import { gotoApp } from '../helpers/app.js';
+import { namespace } from '../helpers/cluster.mjs';
+
+test('page tabs expose the complete menu and open an isolated synchronized window', async ({ page }) => {
+  await gotoApp(page, '/r/core/v1/pods');
+  const podsTab = page.getByRole('tab', { name: /Pods/ }).first();
+  await expect(podsTab).toBeVisible({ timeout: 20_000 });
+
+  await podsTab.click({ button: 'right' });
+  for (const action of [
+    'Rename tab',
+    'Pin tab',
+    'Duplicate tab',
+    'Open in new window',
+    'Move to new window',
+    'Close tab',
+    'Close other tabs',
+    'Close tabs to the right',
+  ]) {
+    await expect(page.getByRole('menuitem', { name: action, exact: true })).toBeVisible();
+  }
+
+  await page.getByRole('menuitem', { name: 'Rename tab' }).click();
+  await page.getByRole('textbox', { name: 'Tab name' }).fill('Production pods');
+  await page.getByRole('button', { name: 'Rename' }).click();
+  await expect(page.getByRole('tab', { name: /Production pods/ })).toBeVisible();
+
+  await page.getByRole('tab', { name: /Production pods/ }).click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Pin tab' }).click();
+  await expect(page.getByRole('tab', { name: /Production pods/ }).getByLabel('Pinned')).toBeVisible();
+
+  await page.getByRole('tab', { name: /Production pods/ }).click({ button: 'right' });
+  await page.getByRole('button', { name: 'Flag tab #42a5f5' }).click();
+  await expect.poll(() => page.getByRole('tab', { name: /Production pods/ }).evaluate((element) => getComputedStyle(element).boxShadow))
+    .toContain('rgb(66, 165, 245)');
+
+  await page.getByRole('tab', { name: /Production pods/ }).click({ button: 'right' });
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('menuitem', { name: 'Open in new window' }).click();
+  const popup = await popupPromise;
+  await expect(popup).toHaveURL(/\/r\/core\/v1\/pods/);
+  await expect(popup.getByRole('tab', { name: /Production pods/ })).toBeVisible();
+  await expect(popup.getByRole('tab')).toHaveCount(1);
+  await expect(page.getByRole('tab', { name: /Production pods/ })).toBeVisible();
+  await popup.close();
+});
+
+test('moves a live shell with its process state and scrollback intact', async ({ page }) => {
+  await gotoApp(page, '/r/core/v1/pods');
+  const row = page.getByRole('row').filter({ hasText: 'logger' }).filter({ hasText: namespace }).first();
+  await expect(row).toBeVisible({ timeout: 20_000 });
+  await row.click({ button: 'right' });
+  await page.getByRole('menuitem', { name: 'Shell' }).click();
+
+  const sourceTerminal = page.locator('.xterm');
+  const sourceInput = page.locator('.xterm-helper-textarea');
+  await expect(sourceTerminal).toBeVisible({ timeout: 20_000 });
+  await sourceInput.focus();
+  await page.keyboard.type("export KUBUS_HANDOFF='still-here'");
+  await page.keyboard.press('Enter');
+  await page.keyboard.type("printf 'SOURCE-%s\\n' \"$KUBUS_HANDOFF\"");
+  await page.keyboard.press('Enter');
+  await expect(sourceTerminal).toContainText('SOURCE-still-here', { timeout: 10_000 });
+
+  const sourceTab = page.getByRole('tab', { name: /sh: logger/ });
+  await sourceTab.click({ button: 'right' });
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('menuitem', { name: 'Move to new window' }).click();
+  const popup = await popupPromise;
+
+  const destinationTerminal = popup.locator('.xterm');
+  const destinationInput = popup.locator('.xterm-helper-textarea');
+  await expect(popup.locator('.kubus-dock-window-titlebar')).toBeVisible();
+  await expect(popup.locator('.MuiDrawer-root')).toHaveCount(0);
+  await expect(popup.getByRole('button', { name: 'New tab' })).toHaveCount(0);
+  await expect(destinationTerminal).toBeVisible({ timeout: 20_000 });
+  await expect(destinationTerminal).toContainText('SOURCE-still-here', { timeout: 10_000 });
+  await expect(sourceTab).toHaveCount(0, { timeout: 10_000 });
+
+  await destinationInput.focus();
+  await popup.keyboard.type("printf 'DEST-%s\\n' \"$KUBUS_HANDOFF\"");
+  await popup.keyboard.press('Enter');
+  await expect(destinationTerminal).toContainText('DEST-still-here', { timeout: 10_000 });
+  await popup.close();
+});
+
+test('opens logs in a focused utility window without the Kubus application chrome', async ({ page }) => {
+  test.setTimeout(60_000);
+  await gotoApp(page, '/r/core/v1/pods');
+  const row = page.getByRole('row').filter({ hasText: 'logger' }).filter({ hasText: namespace }).first();
+  await expect(row).toBeVisible({ timeout: 20_000 });
+  await row.getByRole('checkbox').check();
+  await page.getByRole('button', { name: /^Logs/ }).click();
+  await expect(page.getByText('kubus-e2e log line').first()).toBeVisible({ timeout: 30_000 });
+
+  const sourceDock = page.locator('.kubus-bottom-dock');
+  const sourceTab = sourceDock.getByRole('tab').filter({ hasText: /logs:/i }).first();
+  await sourceTab.click({ button: 'right' });
+  const popupPromise = page.waitForEvent('popup');
+  await page.getByRole('menuitem', { name: 'Open in new window' }).click();
+  const popup = await popupPromise;
+
+  await expect(popup.locator('.kubus-dock-window-titlebar')).toBeVisible();
+  await expect(popup.locator('.MuiDrawer-root')).toHaveCount(0);
+  await expect(popup.getByRole('button', { name: 'New tab' })).toHaveCount(0);
+  await expect(popup.getByText('kubus-e2e log line').first()).toBeVisible({ timeout: 30_000 });
+  await expect(sourceTab).toBeVisible();
+  await popup.close();
+});

--- a/tests/e2e/specs/tab-windows.spec.ts
+++ b/tests/e2e/specs/tab-windows.spec.ts
@@ -108,3 +108,29 @@ test('opens logs in a focused utility window without the Kubus application chrom
   await expect(sourceTab).toBeVisible();
   await popup.close();
 });
+
+test('closes a focused utility window when its initial tab handoff expires', async ({ page }) => {
+  test.setTimeout(25_000);
+  await gotoApp(page);
+
+  const popupPromise = page.waitForEvent('popup');
+  await page.evaluate(() => {
+    const launch = {
+      kind: 'tab-transfer',
+      surface: 'dock',
+      windowId: 'expired-transfer-window',
+      title: 'Missing terminal',
+      transferId: 'missing-transfer-token',
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(launch));
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    const encoded = btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+    window.open(`${window.location.origin}/?token=dev#launch=${encoded}`, '_blank');
+  });
+  const popup = await popupPromise;
+
+  await expect(popup.locator('.kubus-dock-window-loading')).toBeVisible();
+  await expect.poll(() => popup.isClosed(), { timeout: 15_000 }).toBe(true);
+  expect(page.isClosed()).toBe(false);
+});

--- a/tests/electron/specs/desktop.spec.ts
+++ b/tests/electron/specs/desktop.spec.ts
@@ -46,14 +46,17 @@ test('boots the real desktop shell behind the restricted preload bridge', async 
       [
         'checkForUpdate',
         'closeWindow',
+        'detachTab',
         'getAppInfo',
         'getPendingRoute',
         'onCloseTab',
         'onCycleTab',
         'onOpenRoute',
+        'openWindow',
         'platform',
         'setTitleBarOverlay',
         'stateStorage',
+        'windowLaunch',
       ].sort(),
     );
     expect(surface.info).toMatchObject({ name: 'Kubus', version: expect.stringMatching(/^\d+\.\d+\.\d+$/) });
@@ -63,6 +66,166 @@ test('boots the real desktop shell behind the restricted preload bridge', async 
     expect(new URL(surface.url).hostname).toBe('127.0.0.1');
     expect(new URL(surface.url).searchParams.has('token')).toBe(false);
     expect(pageErrors).toEqual([]);
+  } finally {
+    await launched.close();
+  }
+});
+
+test('opens a routed native window and synchronizes shared renderer state both ways', async () => {
+  const launched = await launchElectron();
+
+  try {
+    const secondaryPromise = launched.app.waitForEvent('window');
+    await launched.page.evaluate(() => {
+      window.kubusDesktop?.openWindow({
+        kind: 'page',
+        windowId: 'electron-secondary',
+        title: 'Pods',
+        tab: { path: '/r/core/v1/pods', customTitle: 'Native pods', color: '#42a5f5' },
+      });
+    });
+    const secondary = await secondaryPromise;
+    await expect(secondary).toHaveURL(/\/r\/core\/v1\/pods$/);
+    await expect(secondary.getByRole('tab', { name: /Native pods/ })).toBeVisible();
+    expect(await secondary.evaluate(() => window.kubusDesktop?.windowLaunch?.windowId)).toBe('electron-secondary');
+    expect(await launched.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length)).toBe(2);
+
+    await launched.page.evaluate(() => window.kubusDesktop?.stateStorage.setItem('electron-window-sync', 'from-primary'));
+    await expect.poll(() => secondary.evaluate(() => window.kubusDesktop?.stateStorage.getItem('electron-window-sync')))
+      .toBe('from-primary');
+    await secondary.evaluate(() => window.kubusDesktop?.stateStorage.setItem('electron-window-sync', 'from-secondary'));
+    await expect.poll(() => launched.page.evaluate(() => window.kubusDesktop?.stateStorage.getItem('electron-window-sync')))
+      .toBe('from-secondary');
+
+    // Theme is durable app-wide configuration and should update live.
+    await launched.page.getByRole('button', { name: 'Toggle theme' }).click();
+    await secondary.getByRole('button', { name: 'Toggle theme' }).hover();
+    await expect(secondary.getByRole('tooltip')).toContainText('Switch to dark mode');
+
+    await secondary.evaluate(() => window.kubusDesktop?.closeWindow());
+    await expect.poll(() => secondary.isClosed()).toBe(true);
+    expect(launched.page.isClosed()).toBe(false);
+    expect(await launched.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length)).toBe(1);
+  } finally {
+    await launched.close();
+  }
+});
+
+test('opens terminal and log content in focused native utility windows', async () => {
+  const launched = await launchElectron();
+
+  try {
+    const secondaryPromise = launched.app.waitForEvent('window');
+    await launched.page.evaluate(() => {
+      window.kubusDesktop?.openWindow({
+        kind: 'dock',
+        windowId: 'electron-log-utility',
+        title: 'Logs: logger',
+        context: { selected: [], namespaces: ['default'], navCollapsed: false },
+        tab: {
+          kind: 'logs',
+          title: 'Logs: logger',
+          ctx: 'kind-a',
+          namespace: 'default',
+          pods: ['logger'],
+        },
+      });
+    });
+    const logUtility = await secondaryPromise;
+
+    await expect(logUtility.locator('.kubus-dock-window-titlebar')).toBeVisible();
+    await expect(logUtility.getByRole('tab', { name: /Logs: logger/ })).toBeVisible();
+    await expect(logUtility.locator('.MuiDrawer-root')).toHaveCount(0);
+    await expect(logUtility.getByRole('button', { name: 'New tab' })).toHaveCount(0);
+    await expect(logUtility.locator('.kubus-bottom-dock')).toHaveCSS('height', /.+/);
+    expect(await logUtility.evaluate(() => window.kubusDesktop?.windowLaunch?.windowId)).toBe('electron-log-utility');
+
+    // The utility BrowserWindow owns its content: closing its last dock tab
+    // closes that window, without affecting the main application window.
+    await logUtility.getByRole('button', { name: 'Close Logs: logger' }).click();
+    await expect.poll(() => logUtility.isClosed()).toBe(true);
+    expect(launched.page.isClosed()).toBe(false);
+
+    const terminalPromise = launched.app.waitForEvent('window');
+    await launched.page.evaluate(() => {
+      window.kubusDesktop?.openWindow({
+        kind: 'dock',
+        windowId: 'electron-terminal-utility',
+        title: 'sh: logger',
+        context: { selected: [], namespaces: ['default'], navCollapsed: false },
+        tab: {
+          kind: 'terminal',
+          title: 'sh: logger',
+          ctx: 'kind-a',
+          namespace: 'default',
+          pod: 'logger',
+          container: 'logger',
+        },
+      });
+    });
+    const terminalUtility = await terminalPromise;
+
+    await expect(terminalUtility.locator('.kubus-dock-window-titlebar')).toBeVisible();
+    await expect(terminalUtility.locator('.xterm')).toBeVisible();
+    await expect(terminalUtility.locator('.MuiDrawer-root')).toHaveCount(0);
+    await expect(terminalUtility.getByRole('button', { name: 'New tab' })).toHaveCount(0);
+
+    // Durable presentation preferences are critical shared state even though
+    // each window's tabs, navigation and active working context stay local.
+    const before = await terminalUtility.evaluate(() => getComputedStyle(document.body).backgroundColor);
+    // os -> light leaves pixels unchanged on this light runner; light -> dark
+    // proves the shared preference reached the utility renderer.
+    await launched.page.getByRole('button', { name: 'Toggle theme' }).click();
+    await launched.page.getByRole('button', { name: 'Toggle theme' }).click();
+    await expect.poll(() => terminalUtility.evaluate(() => getComputedStyle(document.body).backgroundColor)).not.toBe(before);
+
+    await terminalUtility.getByRole('button', { name: 'Close sh: logger' }).click();
+    await expect.poll(() => terminalUtility.isClosed()).toBe(true);
+    expect(launched.page.isClosed()).toBe(false);
+  } finally {
+    await launched.close();
+  }
+});
+
+test('moves a page tab through the native window handoff path', async () => {
+  const launched = await launchElectron({ deepLink: 'kubus://r/core/v1/pods' });
+
+  try {
+    const podsTab = launched.page.getByRole('tab', { name: /Pods/ }).first();
+    await expect(podsTab).toBeVisible();
+    await launched.page.getByRole('button', { name: 'New tab' }).click();
+    await expect(launched.page.getByRole('tab', { name: /Overview/ })).toBeVisible();
+
+    // Window layout is copied for continuity, then becomes independent.
+    await launched.page.setViewportSize({ width: 1200, height: 800 });
+    const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+    const primaryDrawer = launched.page.locator('.MuiDrawer-root').first();
+    await launched.page.keyboard.press(`${modifier}+b`);
+    await expect(primaryDrawer).toHaveCSS('width', '0px');
+
+    // Re-resolve by strip position after the nav-width transition; Chromium
+    // can keep the pre-transition accessibility node stale for a frame.
+    await launched.page.locator('[role="tab"]').first().click({ button: 'right' });
+    const secondaryPromise = launched.app.waitForEvent('window');
+    await launched.page.getByRole('menuitem', { name: 'Move to new window', exact: true }).click();
+    const secondary = await secondaryPromise;
+
+    await expect(secondary).toHaveURL(/\/r\/core\/v1\/pods$/);
+    await expect(secondary.getByRole('tab', { name: /Pods/ })).toBeVisible();
+    await expect(secondary.locator('.kubus-dock-window-titlebar')).toHaveCount(0);
+    await expect(launched.page.getByRole('tab', { name: /Pods/ })).toHaveCount(0);
+    await expect(launched.page.getByRole('tab', { name: /Overview/ })).toBeVisible();
+    expect(await launched.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length)).toBe(2);
+
+    await secondary.setViewportSize({ width: 1200, height: 800 });
+    const secondaryDrawer = secondary.locator('.MuiDrawer-root').first();
+    await expect(secondaryDrawer).toHaveCSS('width', '0px');
+    await secondary.keyboard.press(`${modifier}+b`);
+    await expect(secondaryDrawer).toHaveCSS('width', '228px');
+    await expect(primaryDrawer).toHaveCSS('width', '0px');
+
+    await secondary.evaluate(() => window.kubusDesktop?.closeWindow());
+    await expect.poll(() => secondary.isClosed()).toBe(true);
   } finally {
     await launched.close();
   }

--- a/tests/electron/specs/desktop.spec.ts
+++ b/tests/electron/specs/desktop.spec.ts
@@ -187,6 +187,73 @@ test('opens terminal and log content in focused native utility windows', async (
   }
 });
 
+test('restores a full app for deep links without adopting utility-window bounds', async () => {
+  const launched = await launchElectron();
+  const windowStateFile = path.join(launched.userDataDir, 'window-state.json');
+
+  try {
+    const utilityPromise = launched.app.waitForEvent('window');
+    await launched.page.evaluate(() => {
+      window.kubusDesktop?.openWindow({
+        kind: 'dock',
+        windowId: 'electron-lifecycle-utility',
+        title: 'Logs: logger',
+        tab: {
+          kind: 'logs',
+          title: 'Logs: logger',
+          ctx: 'kind-a',
+          namespace: 'default',
+          pods: ['logger'],
+        },
+      });
+    });
+    const utility = await utilityPromise;
+    await expect(utility.locator('.kubus-dock-window-titlebar')).toBeVisible();
+
+    const expectedAppBounds = await launched.app.evaluate(({ BrowserWindow }) => {
+      const windows = BrowserWindow.getAllWindows();
+      const appWindow = windows.find((window) => window.getTitle() === 'Kubus');
+      const utilityWindow = windows.find((window) => window !== appWindow);
+      if (!appWindow || !utilityWindow) throw new Error('expected application and utility windows');
+      appWindow.setBounds({ width: 1100, height: 720, x: 40, y: 50 });
+      utilityWindow.setBounds({ width: 820, height: 540, x: 220, y: 180 });
+      return appWindow.getNormalBounds();
+    });
+
+    await launched.page.evaluate(() => window.kubusDesktop?.closeWindow());
+    await expect.poll(() => launched.page.isClosed()).toBe(true);
+    await expect.poll(() => {
+      if (!existsSync(windowStateFile)) return undefined;
+      return JSON.parse(readFileSync(windowStateFile, 'utf8')) as Record<string, unknown>;
+    }).toMatchObject({ ...expectedAppBounds });
+
+    const replacementPromise = launched.app.waitForEvent('window');
+    await launched.app.evaluate(({ app }) => {
+      app.emit(
+        'second-instance',
+        {} as never,
+        ['kubus', 'kubus://events?source=utility-only'],
+        '',
+        {},
+      );
+    });
+    const replacementApp = await replacementPromise;
+
+    await expect(replacementApp).toHaveURL(/\/events\?source=utility-only$/);
+    await expect(replacementApp.locator('.kubus-dock-window-titlebar')).toHaveCount(0);
+    await expect(replacementApp.getByRole('tablist', { name: 'Open pages' })).toBeVisible();
+    await expect(replacementApp.getByRole('button', { name: 'New tab' })).toBeVisible();
+    await expect(utility.locator('.kubus-dock-window-titlebar')).toBeVisible();
+
+    const savedAppBounds = readFileSync(windowStateFile, 'utf8');
+    await utility.evaluate(() => window.kubusDesktop?.closeWindow());
+    await expect.poll(() => utility.isClosed()).toBe(true);
+    expect(readFileSync(windowStateFile, 'utf8')).toBe(savedAppBounds);
+  } finally {
+    await launched.close();
+  }
+});
+
 test('moves a page tab through the native window handoff path', async () => {
   const launched = await launchElectron({ deepLink: 'kubus://r/core/v1/pods' });
 

--- a/tests/unit/client/bottom-dock.test.tsx
+++ b/tests/unit/client/bottom-dock.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BottomDock } from '../../../client/src/layout/BottomDock';
 import { useDockStore, type DockTab, type NodeShellTab, type TerminalTab } from '../../../client/src/state/dock';
@@ -43,6 +43,15 @@ beforeEach(() => {
 });
 
 describe('BottomDock terminal tab menu', () => {
+  it('renders a focused utility shell without app-dock window controls', () => {
+    const { container } = render(<BottomDock containerRef={{ current: document.createElement('div') }} standalone />);
+
+    expect(container.querySelector('.kubus-dock-window-titlebar')).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Maximize' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Minimize' })).not.toBeInTheDocument();
+    expect(screen.getByTestId(`terminal-${terminal.id}`)).toBeVisible();
+  });
+
   it('requests a new terminal connection from the right-click menu', () => {
     render(<BottomDock containerRef={{ current: document.createElement('div') }} />);
 
@@ -59,5 +68,24 @@ describe('BottomDock terminal tab menu', () => {
     fireEvent.contextMenu(screen.getByRole('tab', { name: /logs/ }), { clientX: 24, clientY: 36 });
 
     expect(screen.queryByRole('menuitem', { name: 'Reconnect' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Open in new window' })).toBeVisible();
+    expect(screen.getByRole('menuitem', { name: 'Move to new window' })).toBeVisible();
+    expect(screen.getByRole('menuitem', { name: 'Close tabs to the right' })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('renames and flags terminal tabs from the shared menu', async () => {
+    render(<BottomDock containerRef={{ current: document.createElement('div') }} />);
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /shell/ }), { clientX: 24, clientY: 36 });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename tab' }));
+    const input = screen.getByRole('textbox', { name: 'Tab name' });
+    fireEvent.change(input, { target: { value: 'API shell' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    expect(useDockStore.getState().tabs[0]?.title).toBe('API shell');
+    await waitForElementToBeRemoved(() => screen.queryByRole('dialog'));
+
+    fireEvent.contextMenu(screen.getByRole('tab', { name: /API shell/ }), { clientX: 24, clientY: 36 });
+    fireEvent.click(screen.getByRole('button', { name: 'Flag tab #42a5f5' }));
+    expect(useDockStore.getState().tabs[0]?.color).toBe('#42a5f5');
   });
 });

--- a/tests/unit/client/cross-window-state.test.ts
+++ b/tests/unit/client/cross-window-state.test.ts
@@ -1,0 +1,117 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installCrossWindowStateSync } from '../../../client/src/cross-window-state.js';
+import { applyAppWindowContext, currentAppWindowContext } from '../../../client/src/window-context.js';
+import { useClustersStore } from '../../../client/src/state/clusters.js';
+import { useNavigationStore } from '../../../client/src/state/navigation.js';
+import { useUiPrefsStore } from '../../../client/src/state/prefs.js';
+import { skipUnchangedStorageWrites } from '../../../client/src/state/persist-storage.js';
+
+function publishStorage(name: string, state: Record<string, unknown>): void {
+  const value = JSON.stringify({ state, version: 0 });
+  localStorage.setItem(name, value);
+  window.dispatchEvent(new StorageEvent('storage', { key: name, newValue: value }));
+}
+
+beforeAll(() => installCrossWindowStateSync());
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  useClustersStore.setState({
+    selected: ['window-a'],
+    namespaces: ['team-a'],
+    themeMode: 'light',
+    contextSettings: {},
+    contextOrder: [],
+    pickerLayout: 'list',
+  });
+  useUiPrefsStore.setState({ tableDensity: 'compact', navCollapsed: true });
+  useNavigationStore.setState({ favorites: [], savedViews: [] });
+});
+
+describe('cross-window state boundaries', () => {
+  it('rehydrates shared cluster metadata without replacing the local working context', async () => {
+    publishStorage('kubus-clusters', {
+      themeMode: 'dark',
+      contextSettings: { prod: { protected: true } },
+      contextOrder: ['prod'],
+      pickerLayout: 'grid',
+      // Legacy/hostile extra fields must still remain window-local.
+      selected: ['window-b'],
+      namespaces: ['team-b'],
+    });
+
+    await vi.waitFor(() => expect(useClustersStore.getState().themeMode).toBe('dark'));
+    expect(useClustersStore.getState()).toMatchObject({
+      selected: ['window-a'],
+      namespaces: ['team-a'],
+      contextSettings: { prod: { protected: true } },
+      contextOrder: ['prod'],
+      pickerLayout: 'grid',
+    });
+  });
+
+  it('syncs durable UI preferences while preserving this window nav layout', async () => {
+    publishStorage('kubus-prefs', {
+      tableDensity: 'comfortable',
+      navCollapsed: false,
+    });
+
+    await vi.waitFor(() => expect(useUiPrefsStore.getState().tableDensity).toBe('comfortable'));
+    expect(useUiPrefsStore.getState().navCollapsed).toBe(true);
+  });
+
+  it('keeps saved definitions live across windows', async () => {
+    publishStorage('kubus-navigation', {
+      favorites: [{ id: 'pods', title: 'Pods' }],
+      savedViews: [{ id: 'errors', title: 'Errors', path: '/events?q=error' }],
+    });
+
+    await vi.waitFor(() => expect(useNavigationStore.getState().favorites).toHaveLength(1));
+    expect(useNavigationStore.getState().savedViews).toEqual([
+      { id: 'errors', title: 'Errors', path: '/events?q=error' },
+    ]);
+  });
+
+  it('copies launch context once and then allows the destination to diverge', () => {
+    applyAppWindowContext({ selected: ['source'], namespaces: ['production'], navCollapsed: false });
+    expect(currentAppWindowContext()).toEqual({
+      selected: ['source'],
+      namespaces: ['production'],
+      navCollapsed: false,
+    });
+
+    useClustersStore.getState().setSelected(['destination']);
+    useUiPrefsStore.getState().set({ navCollapsed: true });
+    expect(currentAppWindowContext()).toEqual({
+      selected: ['destination'],
+      namespaces: ['production'],
+      navCollapsed: true,
+    });
+  });
+
+  it('does not persist window-local fields in app-wide store payloads', () => {
+    useClustersStore.getState().setSelected(['private-window']);
+    useUiPrefsStore.getState().set({ navCollapsed: false });
+
+    const clusters = JSON.parse(localStorage.getItem('kubus-clusters') ?? '{}') as { state?: Record<string, unknown> };
+    const prefs = JSON.parse(localStorage.getItem('kubus-prefs') ?? '{}') as { state?: Record<string, unknown> };
+    expect(clusters.state).not.toHaveProperty('selected');
+    expect(clusters.state).not.toHaveProperty('namespaces');
+    expect(prefs.state).not.toHaveProperty('navCollapsed');
+  });
+
+  it('does not broadcast when a local-only action leaves shared data unchanged', () => {
+    const setItem = vi.fn();
+    const storage = skipUnchangedStorageWrites({
+      getItem: () => 'same',
+      setItem,
+      removeItem: vi.fn(),
+    });
+
+    storage.setItem('shared', 'same');
+    expect(setItem).not.toHaveBeenCalled();
+    storage.setItem('shared', 'changed');
+    expect(setItem).toHaveBeenCalledExactlyOnceWith('shared', 'changed');
+  });
+});

--- a/tests/unit/client/state.test.ts
+++ b/tests/unit/client/state.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clampDetailWidth } from '../../../client/src/state/detail';
-import { clampDockHeight, useDockStore, type DockTab } from '../../../client/src/state/dock';
+import { clampDockHeight, useDockStore, type DockTab, type TerminalTab } from '../../../client/src/state/dock';
 import { forwardPrefKey } from '../../../client/src/state/portforward-prefs';
 import { errorDetails } from '../../../client/src/state/toast';
 import { namespaceVisible } from '../../../client/src/state/clusters';
@@ -106,6 +106,68 @@ describe('useDockStore terminal focus requests', () => {
     before.requestTerminalReconnect(terminal.id);
     useDockStore.getState().closeTab(terminal.id);
     expect(useDockStore.getState().terminalReconnectRequests).toEqual({});
+  });
+});
+
+describe('useDockStore tab quality-of-life actions', () => {
+  const terminal = (id: string, pinned = false): TerminalTab => ({
+    kind: 'terminal',
+    id,
+    title: id,
+    ctx: 'kind-a',
+    namespace: 'default',
+    pod: id,
+    container: 'app',
+    pinned: pinned || undefined,
+  });
+
+  beforeEach(() => {
+    useDockStore.setState({
+      tabs: [terminal('pinned', true), terminal('a'), terminal('b'), terminal('c')],
+      activeId: 'b',
+      open: true,
+      terminalReconnectRequests: {},
+    });
+  });
+
+  it('renames, flags, pins, and keeps the pinned partition stable', () => {
+    const store = useDockStore.getState();
+    store.renameTab('b', '  API shell  ');
+    store.setColor('b', '#42a5f5');
+    store.setPinned('b', true);
+    expect(useDockStore.getState().tabs.map((tab) => [tab.id, tab.title, tab.pinned, tab.color])).toEqual([
+      ['pinned', 'pinned', true, undefined],
+      ['b', 'API shell', true, '#42a5f5'],
+      ['a', 'a', undefined, undefined],
+      ['c', 'c', undefined, undefined],
+    ]);
+
+    useDockStore.getState().moveTab(1, 2);
+    expect(useDockStore.getState().tabs.map((tab) => tab.id)).toEqual(['pinned', 'b', 'a', 'c']);
+  });
+
+  it('duplicates as a fresh session and strips server handoff state', () => {
+    useDockStore.setState({
+      tabs: [{ ...terminal('live'), terminalId: 'terminal-1', transferId: 'transfer-1', snapshot: 'history', color: '#f00' }],
+      activeId: 'live',
+    });
+    useDockStore.getState().duplicateTab('live');
+    const copy = useDockStore.getState().tabs[1];
+    expect(copy).toMatchObject({ kind: 'terminal', title: 'live', color: '#f00' });
+    expect(copy?.id).not.toBe('live');
+    expect(copy).not.toHaveProperty('terminalId');
+    expect(copy).not.toHaveProperty('transferId');
+    expect(copy).not.toHaveProperty('snapshot');
+  });
+
+  it('close-other and close-right preserve pinned tabs', () => {
+    useDockStore.getState().closeOthers('b');
+    expect(useDockStore.getState().tabs.map((tab) => tab.id)).toEqual(['pinned', 'b']);
+
+    useDockStore.setState({ tabs: [terminal('pinned', true), terminal('a'), terminal('b'), terminal('c')], activeId: 'c' });
+    useDockStore.getState().closeRight('a');
+    expect(useDockStore.getState().tabs.map((tab) => tab.id)).toEqual(['pinned', 'a']);
+    expect(useDockStore.getState().activeId).toBe('a');
   });
 });
 
@@ -268,6 +330,32 @@ describe('useTabsStore', () => {
     expect(useTabsStore.getState().tabs.map((t) => t.path)).toEqual(['/a', '/x', '/b', '/c']);
   });
 
+  it('keeps new and reopened tabs behind the pinned group', () => {
+    const tabs = seed(['/pinned-a', '/pinned-b', '/ordinary'], 0);
+    useTabsStore.setState({
+      tabs: tabs.map((tab, index) => ({ ...tab, pinned: index < 2 || undefined })),
+      closedPaths: ['/closed'],
+    });
+
+    useTabsStore.getState().openTab('/new', { afterActive: true });
+    expect(useTabsStore.getState().tabs.map((tab) => tab.path)).toEqual([
+      '/pinned-a',
+      '/pinned-b',
+      '/new',
+      '/ordinary',
+    ]);
+
+    useTabsStore.getState().setActive('t0');
+    useTabsStore.getState().reopenTab();
+    expect(useTabsStore.getState().tabs.map((tab) => tab.path)).toEqual([
+      '/pinned-a',
+      '/pinned-b',
+      '/closed',
+      '/new',
+      '/ordinary',
+    ]);
+  });
+
   it('closing the active tab activates its right neighbor and records the path', () => {
     seed(['/a', '/b', '/c'], 1);
     useTabsStore.getState().closeTab('t1');
@@ -335,6 +423,31 @@ describe('useTabsStore', () => {
     const before = useTabsStore.getState();
     useTabsStore.getState().moveTab(0, 5);
     expect(useTabsStore.getState()).toBe(before);
+  });
+
+  it('renames, flags, pins, duplicates, and preserves pinned tabs during bulk close', () => {
+    seed(['/a', '/b', '/c']);
+    useTabsStore.getState().renameTab('t1', '  Workloads  ');
+    useTabsStore.getState().setColor('t1', '#42a5f5');
+    useTabsStore.getState().setPinned('t0', true);
+    useTabsStore.getState().duplicateTab('t1');
+    let state = useTabsStore.getState();
+    expect(state.tabs[0]).toMatchObject({ id: 't0', pinned: true });
+    expect(state.tabs.find((tab) => tab.id === 't1')).toMatchObject({ customTitle: 'Workloads', color: '#42a5f5' });
+    expect(state.tabs[2]).toMatchObject({ path: '/b', customTitle: 'Workloads', color: '#42a5f5' });
+    expect(state.tabs[2]).not.toHaveProperty('pinned');
+
+    useTabsStore.getState().closeOthers('t1');
+    state = useTabsStore.getState();
+    expect(state.tabs.map((tab) => tab.id)).toEqual(['t0', 't1']);
+  });
+
+  it('adopts an existing cross-window identity at the requested edge', () => {
+    seed(['/a', '/b']);
+    expect(useTabsStore.getState().adoptTab({ id: 'remote', path: '/helm' }, 't1', 'before')).toBe(true);
+    expect(useTabsStore.getState().tabs.map((tab) => tab.id)).toEqual(['t0', 'remote', 't1']);
+    expect(useTabsStore.getState().activeId).toBe('remote');
+    expect(useTabsStore.getState().adoptTab({ id: 'remote', path: '/again' })).toBe(false);
   });
 
   it('syncLocation mirrors the router path into the active tab', () => {

--- a/tests/unit/client/tab-transfer.test.ts
+++ b/tests/unit/client/tab-transfer.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+class TestBroadcastChannel {
+  static readonly instances = new Set<TestBroadcastChannel>();
+  private readonly listeners = new Set<(event: MessageEvent) => void>();
+
+  constructor(readonly name: string) {
+    TestBroadcastChannel.instances.add(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
+    if (type === 'message') this.listeners.add(listener);
+  }
+
+  postMessage(data: unknown): void {
+    for (const channel of TestBroadcastChannel.instances) {
+      if (channel === this || channel.name !== this.name) continue;
+      queueMicrotask(() => {
+        for (const listener of channel.listeners) listener({ data } as MessageEvent);
+      });
+    }
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  TestBroadcastChannel.instances.clear();
+});
+
+describe('cross-window Kubus tab transfer', () => {
+  it('moves a page identity and removes the source only after destination adoption', async () => {
+    vi.stubGlobal('BroadcastChannel', TestBroadcastChannel);
+    vi.resetModules();
+    const source = await import('../../../client/src/tab-transfer.js');
+    const sourceTabs = await import('../../../client/src/state/tabs.js');
+    sourceTabs.useTabsStore.setState({
+      tabs: [{ id: 'page-source', path: '/helm', customTitle: 'Releases', color: '#42a5f5' }],
+      activeId: 'page-source',
+      closedPaths: [],
+    });
+    source.registerTabTransferSource('page-transfer', 'page', 'page-source');
+
+    vi.resetModules();
+    const destination = await import('../../../client/src/tab-transfer.js');
+    const destinationTabs = await import('../../../client/src/state/tabs.js');
+    destinationTabs.useTabsStore.setState({
+      tabs: [{ id: 'placeholder', path: '/' }],
+      activeId: 'placeholder',
+      closedPaths: [],
+    });
+
+    expect(await destination.receiveTabTransfer('page-transfer', undefined, 'after', true)).toBe(true);
+    expect(destinationTabs.useTabsStore.getState().tabs).toEqual([
+      { id: 'page-source', path: '/helm', customTitle: 'Releases', color: '#42a5f5' },
+    ]);
+    await vi.waitFor(() => expect(sourceTabs.useTabsStore.getState().tabs[0]?.path).toBe('/'));
+  });
+
+  it('keeps a live terminal source until the destination confirms server attachment', async () => {
+    vi.stubGlobal('BroadcastChannel', TestBroadcastChannel);
+    vi.resetModules();
+    const source = await import('../../../client/src/tab-transfer.js');
+    const sourceDock = await import('../../../client/src/state/dock.js');
+    const sourceRegistry = await import('../../../client/src/terminal-registry.js');
+    const prepare = vi.fn(async () => true);
+    const cancel = vi.fn();
+    sourceDock.useDockStore.setState({
+      tabs: [{
+        kind: 'terminal',
+        id: 'terminal-source',
+        title: 'sh: api-0',
+        ctx: 'dev',
+        namespace: 'default',
+        pod: 'api-0',
+        container: 'app',
+        terminalId: 'terminal-live',
+      }],
+      activeId: 'terminal-source',
+      open: true,
+    });
+    sourceRegistry.registerTerminal('terminal-source', {
+      prepareTransfer: prepare,
+      cancelTransfer: cancel,
+      snapshot: () => '\u001b[32mhistory\u001b[0m',
+    });
+    source.registerTabTransferSource('terminal-transfer', 'dock', 'terminal-source');
+
+    vi.resetModules();
+    const destination = await import('../../../client/src/tab-transfer.js');
+    const destinationDock = await import('../../../client/src/state/dock.js');
+    destinationDock.useDockStore.setState({ tabs: [], activeId: undefined, open: false });
+
+    expect(await destination.receiveTabTransfer('terminal-transfer')).toBe(true);
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(destinationDock.useDockStore.getState().tabs[0]).toMatchObject({
+      id: 'terminal-source',
+      terminalId: 'terminal-live',
+      transferId: 'terminal-transfer',
+      snapshot: '\u001b[32mhistory\u001b[0m',
+    });
+    expect(sourceDock.useDockStore.getState().tabs).toHaveLength(1);
+
+    destination.completeTabTransfer('terminal-transfer');
+    await vi.waitFor(() => expect(sourceDock.useDockStore.getState().tabs).toHaveLength(0));
+    expect(cancel).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/client/window-management.test.ts
+++ b/tests/unit/client/window-management.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AppWindowLaunch } from '@kubus/shared';
 import {
+  closeCurrentAppWindow,
   decodeAppWindowLaunch,
   encodeAppWindowLaunch,
   isAppWindowLaunch,
 } from '../../../client/src/window-management.js';
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete window.kubusDesktop;
+});
 
 describe('secondary Kubus window payloads', () => {
   it('round-trips unicode page and dock launches', () => {
@@ -59,5 +63,17 @@ describe('secondary Kubus window payloads', () => {
       tab: { path: '/' },
     })).toBe(false);
     expect(decodeAppWindowLaunch('not-json')).toBeUndefined();
+  });
+
+  it('closes only the current native window or browser popup', () => {
+    const closeWindow = vi.fn();
+    window.kubusDesktop = { closeWindow } as unknown as NonNullable<typeof window.kubusDesktop>;
+    closeCurrentAppWindow();
+    expect(closeWindow).toHaveBeenCalledOnce();
+
+    delete window.kubusDesktop;
+    const closePopup = vi.spyOn(window, 'close').mockImplementation(() => undefined);
+    closeCurrentAppWindow();
+    expect(closePopup).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/client/window-management.test.ts
+++ b/tests/unit/client/window-management.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AppWindowLaunch } from '@kubus/shared';
+import {
+  decodeAppWindowLaunch,
+  encodeAppWindowLaunch,
+  isAppWindowLaunch,
+} from '../../../client/src/window-management.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('secondary Kubus window payloads', () => {
+  it('round-trips unicode page and dock launches', () => {
+    const page: AppWindowLaunch = {
+      kind: 'page',
+      windowId: 'window-page',
+      title: 'München — 工作负载',
+      context: { selected: ['kind-a'], namespaces: ['production'], navCollapsed: true },
+      tab: { path: '/r/apps/v1/deployments?q=api', customTitle: 'Production', pinned: true, color: '#42a5f5' },
+    };
+    const terminal: AppWindowLaunch = {
+      kind: 'dock',
+      windowId: 'window-terminal',
+      title: 'Shell',
+      tab: {
+        kind: 'terminal',
+        title: 'sh: api-0',
+        ctx: 'kind-a',
+        namespace: 'default',
+        pod: 'api-0',
+        container: 'app',
+      },
+    };
+
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(page))).toEqual(page);
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(terminal))).toEqual(terminal);
+  });
+
+  it('round-trips only an opaque token for live moves', () => {
+    const launch: AppWindowLaunch = {
+      kind: 'tab-transfer',
+      surface: 'dock',
+      windowId: 'window-transfer',
+      title: 'Shell',
+      transferId: 'opaque-token',
+    };
+    expect(decodeAppWindowLaunch(encodeAppWindowLaunch(launch))).toEqual(launch);
+  });
+
+  it('rejects malformed, external, and oversized launch payloads', () => {
+    expect(isAppWindowLaunch({ kind: 'page', windowId: 'w', title: 'Unsafe', tab: { path: '//evil.example' } })).toBe(false);
+    expect(isAppWindowLaunch({ kind: 'tab-transfer', surface: 'dock', windowId: 'w', title: 'Missing', transferId: '' })).toBe(false);
+    expect(isAppWindowLaunch({ kind: 'tab-transfer', surface: 'full-app', windowId: 'w', title: 'Bad shell', transferId: 'token' })).toBe(false);
+    expect(isAppWindowLaunch({ kind: 'dock', windowId: 'w', title: 'Bad', tab: { kind: 'terminal' } })).toBe(false);
+    expect(isAppWindowLaunch({
+      kind: 'page',
+      windowId: 'w',
+      title: 'Bad context',
+      context: { selected: 'not-an-array', namespaces: [], navCollapsed: false },
+      tab: { path: '/' },
+    })).toBe(false);
+    expect(decodeAppWindowLaunch('not-json')).toBeUndefined();
+  });
+});

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -38,6 +38,9 @@ const electron = vi.hoisted(() => {
     });
     readonly isMaximized = vi.fn(() => this.maximized);
     readonly isMinimized = vi.fn(() => this.minimized);
+    readonly isDestroyed = vi.fn(() => false);
+    readonly isVisible = vi.fn(() => true);
+    readonly getBounds = vi.fn(() => this.normalBounds);
     readonly restore = vi.fn(() => {
       this.minimized = false;
     });
@@ -106,6 +109,7 @@ const electron = vi.hoisted(() => {
     ipcHandlers,
     menu,
     nativeTheme: { shouldUseDarkColors: false },
+    screen: { getCursorScreenPoint: vi.fn(() => ({ x: 5000, y: 5000 })) },
     serverClose,
     shell,
     startServer,
@@ -120,6 +124,7 @@ vi.mock('electron', () => ({
   ipcMain: electron.ipcMain,
   Menu: electron.menu,
   nativeTheme: electron.nativeTheme,
+  screen: electron.screen,
   shell: electron.shell,
 }));
 vi.mock('fix-path', () => ({ default: electron.fixPath }));
@@ -200,6 +205,13 @@ describe('Electron main process', () => {
     });
     expect(win.options.webPreferences).toEqual({
       preload: expect.stringMatching(/electron[\\/](?:src|dist)[\\/]preload\.js$/),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      webSecurity: true,
+      allowRunningInsecureContent: false,
+      webviewTag: false,
+      navigateOnDragDrop: false,
     });
     if (process.platform === 'darwin') expect(win.setMenuBarVisibility).not.toHaveBeenCalled();
     else expect(win.setMenuBarVisibility).toHaveBeenCalledWith(false);
@@ -308,6 +320,47 @@ describe('Electron main process', () => {
       meta: false,
     });
     expect(keyUp.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('opens validated secondary windows and detaches only outside existing window bounds', async () => {
+    const win = await loadMain();
+    const openWindow = registered(electron.ipcListeners, 'kubus:open-window');
+    const launch = {
+      kind: 'page',
+      windowId: 'window-page',
+      title: 'Pods',
+      context: { selected: ['kind-a'], namespaces: ['production'], navCollapsed: true },
+      tab: { path: '/r/core/v1/pods' },
+    };
+    openWindow({ sender: win.webContents }, launch);
+    expect(electron.BrowserWindow.instances).toHaveLength(2);
+    expect(electron.BrowserWindow.instances[1]?.options.title).toBe('Pods — Kubus');
+    expect(electron.BrowserWindow.instances[1]?.loadURL).toHaveBeenCalledWith('http://127.0.0.1:41234/?token=secret-test-token');
+
+    openWindow({ sender: win.webContents }, { ...launch, tab: { path: '//evil.example' } });
+    expect(electron.BrowserWindow.instances).toHaveLength(2);
+    openWindow({ sender: win.webContents }, { ...launch, context: { selected: 'invalid', namespaces: [], navCollapsed: false } });
+    expect(electron.BrowserWindow.instances).toHaveLength(2);
+
+    const detach = registered(electron.ipcHandlers, 'kubus:detach-tab');
+    expect(detach({ sender: win.webContents }, {
+      kind: 'tab-transfer',
+      surface: 'dock',
+      windowId: 'window-transfer',
+      title: 'Shell',
+      transferId: 'opaque-token',
+    })).toBe(true);
+    expect(electron.BrowserWindow.instances).toHaveLength(3);
+
+    electron.screen.getCursorScreenPoint.mockReturnValue({ x: 40, y: 40 });
+    expect(detach({ sender: win.webContents }, {
+      kind: 'tab-transfer',
+      surface: 'dock',
+      windowId: 'window-transfer-2',
+      title: 'Shell',
+      transferId: 'opaque-token-2',
+    })).toBe(false);
+    expect(electron.BrowserWindow.instances).toHaveLength(3);
   });
 
   it('queues deep links until the renderer is ready, then pushes subsequent routes', async () => {

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -11,6 +11,7 @@ const electron = vi.hoisted(() => {
   const ipcHandlers = new Map<string, Handler>();
 
   class MockWebContents {
+    readonly id = ++state.nextWebContentsId;
     readonly handlers = new Map<string, Handler>();
     readonly send = vi.fn();
     readonly on = vi.fn((name: string, handler: Handler) => {
@@ -83,7 +84,7 @@ const electron = vi.hoisted(() => {
       return app;
     }),
   };
-  const state = { userDataPath: '' };
+  const state = { userDataPath: '', nextWebContentsId: 0 };
   const serverClose = vi.fn(async () => undefined);
   const startServer = vi.fn(async () => ({ url: 'http://127.0.0.1:41234/?token=secret-test-token', close: serverClose }));
   const appendAppLog = vi.fn();
@@ -165,6 +166,7 @@ beforeEach(() => {
   electron.serverClose.mockResolvedValue(undefined);
   electron.startServer.mockResolvedValue({ url: 'http://127.0.0.1:41234/?token=secret-test-token', close: electron.serverClose });
   electron.nativeTheme.shouldUseDarkColors = false;
+  electron.state.nextWebContentsId = 0;
 
   userDataPath = mkdtempSync(path.join(tmpdir(), 'kubus-electron-unit-'));
   electron.state.userDataPath = userDataPath;
@@ -389,6 +391,51 @@ describe('Electron main process', () => {
     expect(win.restore).toHaveBeenCalledOnce();
     expect(win.focus).toHaveBeenCalled();
     expect(win.webContents.send).toHaveBeenCalledWith('kubus:open-route', '/events');
+  });
+
+  it('keeps deep links and saved bounds owned by full application windows', async () => {
+    const win = await loadMain();
+    const getPendingRoute = registered(electron.ipcHandlers, 'kubus:get-pending-route');
+    expect(getPendingRoute({ sender: win.webContents })).toBeNull();
+
+    const openWindow = registered(electron.ipcListeners, 'kubus:open-window');
+    openWindow({ sender: win.webContents }, {
+      kind: 'dock',
+      windowId: 'utility-only',
+      title: 'Logs',
+      tab: { kind: 'logs', title: 'Logs', ctx: 'kind-a', namespace: 'default', pods: ['logger'] },
+    });
+    const utility = electron.BrowserWindow.instances[1]!;
+    win.normalBounds = { width: 1400, height: 860, x: 30, y: 40 };
+    utility.normalBounds = { width: 820, height: 520, x: 400, y: 300 };
+
+    win.handlers.get('close')?.();
+    win.handlers.get('closed')?.();
+    expect(JSON.parse(readFileSync(path.join(userDataPath, 'window-state.json'), 'utf8'))).toEqual({
+      width: 1400,
+      height: 860,
+      x: 30,
+      y: 40,
+      maximized: false,
+    });
+    // A utility renderer never advertises itself as a route-capable app.
+    expect(getPendingRoute({ sender: utility.webContents })).toBeNull();
+
+    appHandler('open-url')({ preventDefault: vi.fn() }, 'kubus://events?source=utility-only');
+    expect(electron.BrowserWindow.instances).toHaveLength(3);
+    const replacementApp = electron.BrowserWindow.instances[2]!;
+    expect(utility.webContents.send).not.toHaveBeenCalledWith('kubus:open-route', expect.anything());
+    expect(replacementApp.focus).toHaveBeenCalledOnce();
+    expect(getPendingRoute({ sender: replacementApp.webContents })).toBe('/events?source=utility-only');
+
+    utility.handlers.get('close')?.();
+    utility.handlers.get('closed')?.();
+    expect(JSON.parse(readFileSync(path.join(userDataPath, 'window-state.json'), 'utf8'))).toMatchObject({
+      width: 1400,
+      height: 860,
+      x: 30,
+      y: 40,
+    });
   });
 
   it('validates update manifests and never services a foreign renderer', async () => {

--- a/tests/unit/electron/preload.test.ts
+++ b/tests/unit/electron/preload.test.ts
@@ -39,6 +39,7 @@ vi.mock('electron', () => ({
 
 interface DesktopBridge {
   platform: string;
+  windowLaunch?: unknown;
   stateStorage: {
     getItem(name: string): string | null;
     setItem(name: string, value: string): void;
@@ -47,6 +48,8 @@ interface DesktopBridge {
   setTitleBarOverlay(options: { color: string; symbolColor: string }): void;
   getAppInfo(): Promise<unknown>;
   checkForUpdate(options?: { force?: boolean }): Promise<unknown>;
+  openWindow(launch: unknown): void;
+  detachTab(launch: unknown): Promise<boolean>;
   onCloseTab(callback: () => void): () => void;
   onCycleTab(callback: (backwards: boolean) => void): () => void;
   onOpenRoute(callback: (route: string) => void): () => void;
@@ -60,7 +63,7 @@ async function loadBridge(snapshot: unknown = {}): Promise<DesktopBridge> {
       throw snapshot;
     });
   } else {
-    electron.ipcRenderer.sendSync.mockReturnValue(snapshot);
+    electron.ipcRenderer.sendSync.mockImplementation((channel: string) => channel === 'kubus:state:get-all' ? snapshot : undefined);
   }
   await import('../../../electron/src/preload.js');
   expect(electron.exposeInMainWorld).toHaveBeenCalledOnce();
@@ -108,6 +111,10 @@ describe('Electron preload bridge', () => {
 
     bridge.setTitleBarOverlay({ color: '#111111', symbolColor: '#eeeeee' });
     bridge.closeWindow();
+    const launch = { kind: 'tab-transfer', surface: 'dock', windowId: 'window-1', transferId: 'token', title: 'Shell' } as const;
+    bridge.openWindow(launch);
+    electron.ipcRenderer.invoke.mockResolvedValueOnce(true);
+    await expect(bridge.detachTab(launch)).resolves.toBe(true);
     await expect(bridge.getAppInfo()).resolves.toEqual({ name: 'Kubus' });
     await expect(bridge.checkForUpdate({ force: true })).resolves.toEqual({ available: false });
     await expect(bridge.getPendingRoute()).resolves.toBe('/pending');
@@ -117,6 +124,8 @@ describe('Electron preload bridge', () => {
       symbolColor: '#eeeeee',
     });
     expect(electron.ipcRenderer.send).toHaveBeenCalledWith('kubus:close-window');
+    expect(electron.ipcRenderer.send).toHaveBeenCalledWith('kubus:open-window', launch);
+    expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith('kubus:detach-tab', launch);
     expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith('kubus:get-app-info');
     expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith('kubus:check-for-update', { force: true });
     expect(electron.ipcRenderer.invoke).toHaveBeenCalledWith('kubus:get-pending-route');

--- a/tests/unit/server/exec-socket.test.ts
+++ b/tests/unit/server/exec-socket.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import type { AppContext } from '../../../server/src/app.js';
 import { registerExecSocket } from '../../../server/src/ws/exec-socket.js';
+import { ExecSessionRegistry } from '../../../server/src/ws/transferable-exec.js';
 
 type Handler = (socket: unknown, request: unknown) => unknown;
 
@@ -64,7 +65,7 @@ it.each([
       };
     },
   };
-  const ctx = { clusters: { get: () => handle } } as unknown as AppContext;
+  const ctx = { clusters: { get: () => handle }, execSessions: new ExecSessionRegistry() } as unknown as AppContext;
   registerExecSocket(app, ctx);
 
   const socket = new FakeSocket();

--- a/tests/unit/server/transferable-exec.test.ts
+++ b/tests/unit/server/transferable-exec.test.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { EXEC_SESSION_CLOSE_REASON } from '@kubus/shared';
+import { ExecSessionRegistry, TransferableExecSocket } from '../../../server/src/ws/transferable-exec.js';
+
+class FakeSocket extends EventEmitter {
+  readonly OPEN = 1;
+  readyState = this.OPEN;
+  readonly sent: Array<{ data: string | Buffer; binary?: boolean }> = [];
+
+  send(data: string | Buffer, options?: { binary?: boolean }): void {
+    this.sent.push({ data, binary: options?.binary });
+  }
+
+  ping(): void {}
+
+  close(code = 1000, reason = ''): void {
+    if (this.readyState !== this.OPEN) return;
+    this.readyState = 3;
+    this.emit('close', code, Buffer.from(reason));
+  }
+
+  receive(value: unknown): void {
+    this.emit('message', Buffer.from(typeof value === 'string' ? value : JSON.stringify(value)), false);
+  }
+}
+
+describe('transferable Kubernetes exec sessions', () => {
+  it('freezes output, swaps renderers, replays identity, and flushes buffered bytes in order', () => {
+    const source = new FakeSocket();
+    const registry = new ExecSessionRegistry();
+    const stable = registry.create(source as never);
+    const controls: Array<Record<string, unknown>> = [];
+    stable.on('message', (data: Buffer, binary: boolean) => {
+      if (!binary) controls.push(JSON.parse(data.toString('utf8')) as Record<string, unknown>);
+    });
+
+    const session = JSON.parse(String(source.sent[0]?.data)) as { terminalId: string };
+    source.receive({ op: 'prepare-transfer' });
+    expect(source.sent.map((frame) => String(frame.data))).toContain(JSON.stringify({ op: 'transfer-ready' }));
+
+    stable.send(Buffer.from('first\r\n'), { binary: true });
+    expect(source.sent.some((frame) => Buffer.isBuffer(frame.data) && frame.data.toString() === 'first\r\n')).toBe(false);
+
+    const destination = new FakeSocket();
+    expect(registry.attach(session.terminalId, destination as never, 132, 43)).toBe(true);
+    expect(destination.sent.map((frame) => String(frame.data))).toEqual([
+      JSON.stringify({ op: 'session', terminalId: session.terminalId }),
+      'first\r\n',
+    ]);
+    expect(controls).toContainEqual({ op: 'resize', cols: 132, rows: 43 });
+    expect(source.readyState).toBe(3);
+  });
+
+  it('keeps an unexpectedly detached renderer attachable during the grace period', () => {
+    vi.useFakeTimers();
+    const source = new FakeSocket();
+    const stable = new TransferableExecSocket('terminal-grace', source as never, 1_000);
+    const closed = vi.fn();
+    stable.on('close', closed);
+
+    source.close(1006, 'renderer gone');
+    vi.advanceTimersByTime(900);
+    const destination = new FakeSocket();
+    expect(stable.attach(destination as never, 80, 24)).toBe(true);
+    vi.advanceTimersByTime(200);
+    expect(closed).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('ends immediately for an intentional tab close', () => {
+    const source = new FakeSocket();
+    const stable = new TransferableExecSocket('terminal-close', source as never);
+    const closed = vi.fn();
+    stable.on('close', closed);
+
+    source.close(1000, EXEC_SESSION_CLOSE_REASON);
+    expect(closed).toHaveBeenCalledOnce();
+    expect(stable.readyState).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- add a complete shared tab menu for page, terminal, node-shell, and log tabs
- support rename, pin, color flags, duplicate, open/move to a new window, close, close others, and close tabs to the right
- support tab reordering, cross-window drag/drop, and detach-to-window behavior
- preserve live terminal process state and scrollback when moving a session
- render terminal and log windows as focused utility windows without the full Kubus application chrome
- add native Electron multi-window creation, title-bar integration, shortcuts, persistence, and safe IPC validation
- keep critical durable preferences synchronized while tabs, navigation state, selected contexts, namespaces, and window layout remain independent

## Why

Terminal and log workflows benefit from being moved onto another monitor or arranged beside the main resource view. Previously, tabs did not offer the full set of window and lifecycle controls, and terminal sessions could not move between renderers without losing their live process state.

## User impact

Page tabs continue to open as full Kubus windows. Terminal and log tabs open in compact, content-focused windows with the same tab quality-of-life actions. Closing the last utility tab closes only that utility window, and Electron follows the same behavior as the browser implementation.

## Validation

- 960 unit tests passed
- 27 browser Playwright tests passed
- 7 Electron Playwright tests passed against real BrowserWindows
- shared, client, server, and Electron builds passed
- TypeScript typechecking passed
- lint and diff checks passed