### PR TITLE
Fix socket and editor teardown races

### DIFF
--- a/client/src/components/HelmInstallDialog.tsx
+++ b/client/src/components/HelmInstallDialog.tsx
@@ -30,7 +30,6 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutlined';
 import SailingOutlinedIcon from '@mui/icons-material/SailingOutlined';
 import SearchIcon from '@mui/icons-material/Search';
 import TravelExploreIcon from '@mui/icons-material/TravelExplore';
-import Editor from '@monaco-editor/react';
 import { useTheme } from '@mui/material/styles';
 import { dump as dumpYaml } from 'js-yaml';
 import type { HelmChartSourceRef, HelmChartSummary, HelmDryRunResult, HelmHubChart } from '@kubus/shared';
@@ -57,6 +56,7 @@ import { showToast } from '../state/toast.js';
 import { ConfirmDialog } from './ConfirmDialog.js';
 import { ChartMarkdown } from './ChartMarkdown.js';
 import { ChartSourceLink, preferredChartSource } from './ChartSourceLink.js';
+import { MonacoEditor } from './MonacoEditor.js';
 
 interface Props {
   /** Candidate target clusters (the ones selected in the sidebar). */
@@ -503,7 +503,7 @@ function ConfigureStep({ contexts, pick, onBack, onClose }: { contexts: string[]
                 <CircularProgress size={24} />
               </Box>
             ) : (
-              <Editor
+              <MonacoEditor
                 language="yaml"
                 value={valuesText ?? ''}
                 onChange={(v) => setValuesText(v ?? '')}
@@ -568,7 +568,7 @@ function ConfigureStep({ contexts, pick, onBack, onClose }: { contexts: string[]
               </Alert>
             )}
             <Box sx={{ flex: 1, minHeight: 0, border: 1, borderColor: 'divider' }}>
-              <Editor
+              <MonacoEditor
                 language="yaml"
                 value={previewTab === 'manifest' ? preview.manifest : dumpYaml(preview.computedValues, { noRefs: true })}
                 theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'light'}

--- a/client/src/components/HelmUpgradeDialog.tsx
+++ b/client/src/components/HelmUpgradeDialog.tsx
@@ -17,7 +17,6 @@ import Tabs from '@mui/material/Tabs';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
-import Editor from '@monaco-editor/react';
 import { useTheme } from '@mui/material/styles';
 import { dump as dumpYaml } from 'js-yaml';
 import type { HelmChartSourceRef, HelmDryRunResult, HelmReleaseDetail } from '@kubus/shared';
@@ -32,6 +31,7 @@ import { compareHelmVersions } from './helm-version.js';
 import { ChartMarkdown } from './ChartMarkdown.js';
 import { ChartSourceLink, preferredChartSource } from './ChartSourceLink.js';
 import { HelmOperationErrorAlert } from './HelmOperationErrorAlert.js';
+import { MonacoEditor } from './MonacoEditor.js';
 
 interface Props {
   ctx: string;
@@ -376,7 +376,7 @@ export default function HelmUpgradeDialog({ ctx, ns, name, release, isProtected,
         ) : null}
         <Box sx={{ flex: 1, minHeight: 0, border: 1, borderColor: 'divider' }}>
           {editTab === 'values' ? (
-            <Editor
+            <MonacoEditor
               language="yaml"
               value={valuesText}
               onChange={(v) => setValuesText(v ?? '')}

--- a/client/src/components/MonacoEditor.tsx
+++ b/client/src/components/MonacoEditor.tsx
@@ -11,23 +11,41 @@ type MonacoEditorProps = Omit<EditorProps, 'keepCurrentModel'>;
  * model through the child cleanup, then release it once the widget is gone.
  */
 export function MonacoEditor({ onMount, ...props }: MonacoEditorProps) {
-  const model = useRef<editor.ITextModel | undefined>(undefined);
+  const editorRef = useRef<editor.IStandaloneCodeEditor | undefined>(undefined);
+  const models = useRef(new Set<editor.ITextModel>());
+  const modelListener = useRef<{ dispose: () => void } | undefined>(undefined);
   const onMountRef = useRef(onMount);
   onMountRef.current = onMount;
 
   const handleMount = useCallback<OnMount>((mountedEditor, monaco) => {
-    model.current = mountedEditor.getModel() ?? undefined;
+    editorRef.current = mountedEditor;
+    const trackModel = () => {
+      const current = mountedEditor.getModel();
+      if (current) models.current.add(current);
+    };
+    trackModel();
+    modelListener.current = mountedEditor.onDidChangeModel(trackModel);
     onMountRef.current?.(mountedEditor, monaco);
   }, []);
 
   useEffect(
     () => () => {
-      const current = model.current;
-      model.current = undefined;
+      modelListener.current?.dispose();
+      modelListener.current = undefined;
+      // onMount only runs once, but changing `path` swaps the editor's model.
+      // Include the live model as a final guard in case teardown overlaps a
+      // switch before Monaco's model-change event has been delivered.
+      const current = editorRef.current?.getModel() ?? undefined;
+      if (current) models.current.add(current);
+      const ownedModels = [...models.current];
+      models.current.clear();
+      editorRef.current = undefined;
       // Parent effect cleanup runs before the wrapped editor's cleanup. Defer
       // model disposal until the child has synchronously disposed its widget.
       queueMicrotask(() => {
-        if (!current?.isDisposed()) current?.dispose();
+        for (const model of ownedModels) {
+          if (!model.isDisposed()) model.dispose();
+        }
       });
     },
     [],

--- a/client/src/components/MonacoEditor.tsx
+++ b/client/src/components/MonacoEditor.tsx
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef } from 'react';
+import Editor, { type EditorProps, type OnMount } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+
+type MonacoEditorProps = Omit<EditorProps, 'keepCurrentModel'>;
+
+/**
+ * Monaco's React wrapper disposes the text model before the editor widget.
+ * Monaco 0.55 can still consult editor-scoped services while reacting to that
+ * model disposal, after those services have begun shutting down. Keep the
+ * model through the child cleanup, then release it once the widget is gone.
+ */
+export function MonacoEditor({ onMount, ...props }: MonacoEditorProps) {
+  const model = useRef<editor.ITextModel | undefined>(undefined);
+  const onMountRef = useRef(onMount);
+  onMountRef.current = onMount;
+
+  const handleMount = useCallback<OnMount>((mountedEditor, monaco) => {
+    model.current = mountedEditor.getModel() ?? undefined;
+    onMountRef.current?.(mountedEditor, monaco);
+  }, []);
+
+  useEffect(
+    () => () => {
+      const current = model.current;
+      model.current = undefined;
+      // Parent effect cleanup runs before the wrapped editor's cleanup. Defer
+      // model disposal until the child has synchronously disposed its widget.
+      queueMicrotask(() => {
+        if (!current?.isDisposed()) current?.dispose();
+      });
+    },
+    [],
+  );
+
+  return <Editor {...props} keepCurrentModel onMount={handleMount} />;
+}

--- a/client/src/components/YamlEditorImpl.tsx
+++ b/client/src/components/YamlEditorImpl.tsx
@@ -5,13 +5,13 @@ import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import Editor from '@monaco-editor/react';
 import { useTheme } from '@mui/material/styles';
 import type { ResourceDryRunResponse } from '@kubus/shared';
 import { copyToClipboard } from '../clipboard.js';
 import { newYamlModelPath } from '../monaco-setup.js';
 import { useUiPrefsStore } from '../state/prefs.js';
 import { useYamlSchema, type YamlEditorProps } from './YamlEditor.js';
+import { MonacoEditor } from './MonacoEditor.js';
 
 export default function YamlEditorImpl({ value, readOnly, onApply, onDryRun, applyLabel = 'Apply', applyUnchanged, onChange, toolbar, schema }: YamlEditorProps) {
   const theme = useTheme();
@@ -207,7 +207,7 @@ export default function YamlEditorImpl({ value, readOnly, onApply, onDryRun, app
             </Typography>
           </Box>
         )}
-        <Editor
+        <MonacoEditor
           language="yaml"
           path={modelPath}
           value={text}

--- a/server/src/kube/portforward-manager.ts
+++ b/server/src/kube/portforward-manager.ts
@@ -1,6 +1,6 @@
 import net from 'node:net';
 import { EventEmitter } from 'node:events';
-import { PassThrough } from 'node:stream';
+import { PassThrough, Writable } from 'node:stream';
 import { nanoid } from 'nanoid';
 import type { FastifyBaseLogger } from 'fastify';
 import type { KubeObject, LogTargetKind, PortForwardInfo, PortForwardPreflightResponse, PortForwardRequest } from '@kubus/shared';
@@ -107,6 +107,28 @@ export class PortForwardManager extends EventEmitter {
   }
 
   private async handleConnection(ctx: string, req: PortForwardRequest, info: PortForwardInfo, socket: net.Socket): Promise<void> {
+    let upstream: { close: () => void } | undefined;
+    let localClosed = false;
+    let output: Writable | undefined;
+    const closeUpstream = () => {
+      if (localClosed) return;
+      localClosed = true;
+      output?.destroy();
+      try {
+        upstream?.close();
+      } catch {
+        /* already closed */
+      }
+    };
+
+    // A peer FIN ends both halves of a net.Socket by default. Kubernetes can
+    // still deliver a WebSocket frame before the subsequent close event; a
+    // direct socket.write in that window emits an unhandled EPIPE. Start the
+    // teardown on end/error as well as close, before awaiting the upstream WS.
+    socket.once('end', closeUpstream);
+    socket.once('error', closeUpstream);
+    socket.once('close', closeUpstream);
+
     try {
       const handle = this.clusters.get(ctx);
       // Re-resolve per connection so service forwards survive pod churn.
@@ -125,25 +147,47 @@ export class PortForwardManager extends EventEmitter {
         socket.destroy();
         this.emitUpdate();
       });
-      const ws = await handle.makePortForward().portForward(req.namespace, target.pod, [target.port], socket, errStream, socket);
+      // Keep the dependency from writing directly to the net.Socket. The
+      // guarded destination quietly drops frames once local teardown starts
+      // and absorbs the asynchronous write error if FIN races a final frame.
+      output = new Writable({
+        write: (chunk, _encoding, done) => {
+          if (localClosed || socket.destroyed || socket.writableEnded || !socket.writable) {
+            done();
+            return;
+          }
+          socket.write(chunk, (err) => {
+            if (err) closeUpstream();
+            done();
+          });
+        },
+      });
+      const connection = await handle.makePortForward().portForward(req.namespace, target.pod, [target.port], output, errStream, socket);
+      upstream = connection && typeof connection === 'object' && 'close' in connection
+        ? (connection as { close: () => void })
+        : undefined;
+      // The local peer may have gone away while the Kubernetes WebSocket was
+      // connecting. In that case close it now; its close event was already
+      // observed and will not fire a second time for a late listener.
+      if (localClosed) {
+        try {
+          upstream?.close();
+        } catch {
+          /* already closed */
+        }
+        return;
+      }
       info.state = 'active';
       info.error = undefined;
       this.emitUpdate();
-      socket.on('close', () => {
-        if (ws && typeof ws === 'object' && 'close' in ws) {
-          try {
-            (ws as { close: () => void }).close();
-          } catch {
-            /* already closed */
-          }
-        }
-        if (errText.trim()) {
-          info.state = 'error';
-          info.error = errText.trim();
-          this.emitUpdate();
-        }
+      socket.once('close', () => {
+        if (!errText.trim()) return;
+        info.state = 'error';
+        info.error = errText.trim();
+        this.emitUpdate();
       });
     } catch (err) {
+      if (localClosed) return;
       info.state = 'error';
       info.error = err instanceof Error ? err.message : String(err);
       this.log.warn({ id: info.id, err: info.error }, 'port-forward connection failed');

--- a/tests/unit/client/monaco-editor.test.tsx
+++ b/tests/unit/client/monaco-editor.test.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MonacoEditor } from '../../../client/src/components/MonacoEditor.js';
+
+const lifecycle = vi.hoisted(() => ({
+  events: [] as string[],
+  keepCurrentModel: false,
+  model: {
+    disposed: false,
+    isDisposed() {
+      return this.disposed;
+    },
+    dispose() {
+      this.disposed = true;
+      lifecycle.events.push('model');
+    },
+  },
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  default: function MockEditor({
+    keepCurrentModel,
+    onMount,
+  }: {
+    keepCurrentModel?: boolean;
+    onMount?: (editor: { getModel: () => typeof lifecycle.model }, monaco: object) => void;
+  }) {
+    useEffect(() => {
+      lifecycle.keepCurrentModel = !!keepCurrentModel;
+      onMount?.({ getModel: () => lifecycle.model }, {});
+      return () => {
+        lifecycle.events.push('editor');
+      };
+    }, [keepCurrentModel, onMount]);
+    return <textarea aria-label="Monaco mock" />;
+  },
+}));
+
+describe('MonacoEditor', () => {
+  it('disposes the model only after the editor widget has been disposed', async () => {
+    lifecycle.events = [];
+    lifecycle.keepCurrentModel = false;
+    lifecycle.model.disposed = false;
+    const view = render(<MonacoEditor value="kind: Pod\n" />);
+
+    await act(async () => {
+      view.unmount();
+      await Promise.resolve();
+    });
+
+    expect(lifecycle.keepCurrentModel).toBe(true);
+    expect(lifecycle.events).toEqual(['editor', 'model']);
+  });
+});

--- a/tests/unit/client/monaco-editor.test.tsx
+++ b/tests/unit/client/monaco-editor.test.tsx
@@ -6,14 +6,38 @@ import { MonacoEditor } from '../../../client/src/components/MonacoEditor.js';
 const lifecycle = vi.hoisted(() => ({
   events: [] as string[],
   keepCurrentModel: false,
-  model: {
+  modelChangeListener: undefined as (() => void) | undefined,
+  notifyModelChange() {
+    this.modelChangeListener?.();
+  },
+  currentModel: undefined as
+    | {
+        name: string;
+        disposed: boolean;
+        isDisposed: () => boolean;
+        dispose: () => void;
+      }
+    | undefined,
+  firstModel: {
+    name: 'first',
     disposed: false,
     isDisposed() {
       return this.disposed;
     },
     dispose() {
       this.disposed = true;
-      lifecycle.events.push('model');
+      lifecycle.events.push('first model');
+    },
+  },
+  secondModel: {
+    name: 'second',
+    disposed: false,
+    isDisposed() {
+      return this.disposed;
+    },
+    dispose() {
+      this.disposed = true;
+      lifecycle.events.push('second model');
     },
   },
 }));
@@ -24,11 +48,30 @@ vi.mock('@monaco-editor/react', () => ({
     onMount,
   }: {
     keepCurrentModel?: boolean;
-    onMount?: (editor: { getModel: () => typeof lifecycle.model }, monaco: object) => void;
+    onMount?: (
+      editor: {
+        getModel: () => typeof lifecycle.currentModel;
+        onDidChangeModel: (listener: () => void) => { dispose: () => void };
+      },
+      monaco: object,
+    ) => void;
   }) {
     useEffect(() => {
       lifecycle.keepCurrentModel = !!keepCurrentModel;
-      onMount?.({ getModel: () => lifecycle.model }, {});
+      onMount?.(
+        {
+          getModel: () => lifecycle.currentModel,
+          onDidChangeModel: (listener) => {
+            lifecycle.modelChangeListener = listener;
+            return {
+              dispose: () => {
+                if (lifecycle.modelChangeListener === listener) lifecycle.modelChangeListener = undefined;
+              },
+            };
+          },
+        },
+        {},
+      );
       return () => {
         lifecycle.events.push('editor');
       };
@@ -41,7 +84,9 @@ describe('MonacoEditor', () => {
   it('disposes the model only after the editor widget has been disposed', async () => {
     lifecycle.events = [];
     lifecycle.keepCurrentModel = false;
-    lifecycle.model.disposed = false;
+    lifecycle.modelChangeListener = undefined;
+    lifecycle.firstModel.disposed = false;
+    lifecycle.currentModel = lifecycle.firstModel;
     const view = render(<MonacoEditor value="kind: Pod\n" />);
 
     await act(async () => {
@@ -50,6 +95,27 @@ describe('MonacoEditor', () => {
     });
 
     expect(lifecycle.keepCurrentModel).toBe(true);
-    expect(lifecycle.events).toEqual(['editor', 'model']);
+    expect(lifecycle.events).toEqual(['editor', 'first model']);
+  });
+
+  it('disposes the current model after the editor switches paths', async () => {
+    lifecycle.events = [];
+    lifecycle.modelChangeListener = undefined;
+    lifecycle.firstModel.disposed = false;
+    lifecycle.secondModel.disposed = false;
+    lifecycle.currentModel = lifecycle.firstModel;
+    const view = render(<MonacoEditor path="first.yaml" value="kind: Pod\n" />);
+
+    lifecycle.currentModel = lifecycle.secondModel;
+    lifecycle.notifyModelChange();
+    view.rerender(<MonacoEditor path="second.yaml" value="kind: Service\n" />);
+    await act(async () => {
+      view.unmount();
+      await Promise.resolve();
+    });
+
+    expect(lifecycle.firstModel.disposed).toBe(true);
+    expect(lifecycle.secondModel.disposed).toBe(true);
+    expect(lifecycle.events).toEqual(['editor', 'first model', 'second model']);
   });
 });

--- a/tests/unit/server/portforward-manager.test.ts
+++ b/tests/unit/server/portforward-manager.test.ts
@@ -1,0 +1,77 @@
+import net from 'node:net';
+import { once } from 'node:events';
+import type { Writable } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PortForwardManager } from '../../../server/src/kube/portforward-manager.js';
+
+const managers: PortForwardManager[] = [];
+
+afterEach(() => {
+  for (const manager of managers.splice(0)) manager.stopAll();
+});
+
+describe('PortForwardManager connection lifecycle', () => {
+  it('drops late Kubernetes frames and closes an upstream that connects after the local peer ends', async () => {
+    let acceptConnection!: () => void;
+    const connectionAccepted = new Promise<void>((resolve) => {
+      acceptConnection = resolve;
+    });
+    let resolveUpstream!: (value: { close: () => void }) => void;
+    const upstreamConnected = new Promise<{ close: () => void }>((resolve) => {
+      resolveUpstream = resolve;
+    });
+    let output!: Writable;
+    let input!: net.Socket;
+    const portForward = vi.fn(
+      async (
+        _namespace: string,
+        _pod: string,
+        _ports: number[],
+        forwardOutput: Writable,
+        _error: Writable,
+        forwardInput: net.Socket,
+      ) => {
+        output = forwardOutput;
+        input = forwardInput;
+        acceptConnection();
+        return upstreamConnected;
+      },
+    );
+    const handle = {
+      raw: { json: vi.fn(async () => ({ status: { allowed: true } })) },
+      makePortForward: () => ({ portForward }),
+    };
+    const manager = new PortForwardManager(
+      { get: vi.fn(() => handle) } as never,
+      { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } as never,
+    );
+    managers.push(manager);
+
+    const forward = await manager.start('dev', {
+      namespace: 'default',
+      kind: 'pod',
+      name: 'web-0',
+      remotePort: 8080,
+    });
+    const client = net.connect(forward.localPort, '127.0.0.1');
+    await once(client, 'connect');
+    await connectionAccepted;
+
+    const socketErrors: Error[] = [];
+    input.on('error', (err) => socketErrors.push(err));
+    input.once('end', () => {
+      // Reproduce a WebSocket message delivered after FIN but before close.
+      queueMicrotask(() => output.write(Buffer.from('late frame')));
+    });
+    client.end();
+    await once(client, 'close');
+
+    const upstream = { close: vi.fn() };
+    resolveUpstream(upstream);
+    await vi.waitFor(() => expect(upstream.close).toHaveBeenCalledOnce());
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(output).not.toBe(input);
+    expect(socketErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- guard local port-forward sockets from Kubernetes frames that arrive after the peer has ended the connection
- close upstream port-forward WebSockets even when local teardown happens while they are still connecting
- dispose Monaco editor widgets before their text models across YAML and Helm editor surfaces
- add regression tests for both teardown races

## Root cause

The Kubernetes client wrote port-forward output directly to a local `net.Socket`. A frame delivered between the peer's FIN and the socket's close event emitted an unhandled `EPIPE`, which reached the Electron main process.

The Monaco React wrapper disposed text models before their editor widgets. Monaco could still consult editor-scoped services while reacting to model disposal, after those services had begun shutting down.

## Impact

Normal client disconnects no longer crash the desktop main process, and closing or switching YAML/Helm editor surfaces no longer trips the tab error boundary with `InstantiationService has been disposed`.

## Validation

- `pnpm --filter @kubus/tests test` — 964 tests across 85 files
- `pnpm lint`
- client, server, and tests typechecks
- shared, client, server, and Electron builds
- repeated Monaco mount/unmount cycles against the built client
- real kind-cluster port-forward stressed with 40 immediately half-closed HTTP clients