### PR TITLE
Fix stale watch caches after normal timeouts

### DIFF
--- a/server/src/kube/watcher.ts
+++ b/server/src/kube/watcher.ts
@@ -189,6 +189,10 @@ export class ResourceWatcher {
         this.setState('live');
         backoff = MIN_BACKOFF_MS;
         await this.watchOnce();
+        // A normal close is usually the API server's timeout. Re-list before
+        // opening the next watch so a missed event cannot leave the cache
+        // stale forever while every connection still appears healthy.
+        await this.relistWithRetry();
       } catch (err) {
         if (!this.running) break;
         if (isUnavailable(err)) {
@@ -208,6 +212,23 @@ export class ResourceWatcher {
         } else {
           this.setState('reconnecting', err instanceof Error ? err.message : String(err));
         }
+        await delay(backoff);
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+      }
+    }
+  }
+
+  /** Authoritative resync after a normal watch close, resilient to brief list failures. */
+  private async relistWithRetry(): Promise<void> {
+    let backoff = MIN_BACKOFF_MS;
+    while (this.running) {
+      try {
+        await this.relistAndDiff();
+        return;
+      } catch (err) {
+        if (!this.running) throw err;
+        if (!isRetryableListError(err)) throw err;
+        this.setState('reconnecting', err instanceof Error ? err.message : String(err));
         await delay(backoff);
         backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
       }

--- a/tests/unit/server/watcher.test.ts
+++ b/tests/unit/server/watcher.test.ts
@@ -259,11 +259,62 @@ describe('ResourceWatcher', () => {
     expect(batches).toEqual([]);
     expect(watcher.items()).toHaveLength(1);
 
-    // A benign stream end reconnects from the bookmarked rv without backoff.
+    // A benign stream end performs an authoritative relist before reconnecting.
+    raw.queueList({ metadata: { resourceVersion: '50' }, items: [obj('uid-a', '1', 'a')] });
     raw.streamAt(0).end();
     await until(() => raw.streams.length === 2, 'reconnect');
-    expect(raw.streamCalls[1]).toContain('resourceVersion=42');
+    expect(raw.jsonCalls).toHaveLength(2);
+    expect(raw.streamCalls[1]).toContain('resourceVersion=50');
     expect(delayMock).not.toHaveBeenCalled();
+  });
+
+  it('removes an externally deleted object when a timed-out watch closes without its event', async () => {
+    const raw = new FakeRaw();
+    raw.queueList({
+      metadata: { resourceVersion: '10' },
+      items: [obj('uid-a', '1', 'a'), obj('uid-b', '2', 'b')],
+    });
+    const watcher = makeWatcher(raw);
+    const { batches, sub } = collector();
+    watcher.subscribe(sub);
+    await watcher.ready();
+    await until(() => raw.streams.length === 1, 'watch stream');
+
+    // Simulate an upstream timeout after Kubernetes deleted a, but without the
+    // DELETED event reaching Kubus. The authoritative LIST only contains b.
+    raw.queueList({ metadata: { resourceVersion: '20' }, items: [obj('uid-b', '2', 'b')] });
+    raw.streamAt(0).end();
+
+    await until(() => batches.length === 1, 'synthetic deletion after timeout');
+    expect(batches[0]?.map((delta) => ({ type: delta.type, uid: delta.object.metadata.uid }))).toEqual([
+      { type: 'DELETED', uid: 'uid-a' },
+    ]);
+    expect(watcher.items().map((item) => item.metadata.uid)).toEqual(['uid-b']);
+    await until(() => raw.streams.length === 2, 'watch reconnect');
+    expect(raw.streamCalls[1]).toContain('resourceVersion=20');
+  });
+
+  it('retries timeout resyncs through transport and API-server flakiness', async () => {
+    const raw = new FakeRaw();
+    raw.queueList({ metadata: { resourceVersion: '10' }, items: [obj('uid-a', '1', 'a')] });
+    const watcher = makeWatcher(raw);
+    const { batches, statuses, sub } = collector();
+    watcher.subscribe(sub);
+    await watcher.ready();
+    await until(() => raw.streams.length === 1, 'watch stream');
+
+    raw.queueListError(Object.assign(new Error('socket reset'), { code: 'ECONNRESET' }));
+    raw.queueListError(Object.assign(new Error('API server overloaded'), { code: 503 }));
+    raw.queueList({ metadata: { resourceVersion: '30' }, items: [] });
+    raw.streamAt(0).end();
+
+    await until(() => raw.streams.length === 2, 'watch reconnect after flaky relist');
+    expect(delayMock.mock.calls.map((call) => call[0])).toEqual([1000, 2000]);
+    expect(statuses.map((status) => status.state)).toEqual(['live', 'reconnecting', 'live']);
+    expect(batches[0]?.map((delta) => ({ type: delta.type, uid: delta.object.metadata.uid }))).toEqual([
+      { type: 'DELETED', uid: 'uid-a' },
+    ]);
+    expect(raw.streamCalls[1]).toContain('resourceVersion=30');
   });
 
   it('recovers from a 410 ERROR event by relisting and synthesizing diff deltas', async () => {


### PR DESCRIPTION
## Summary

- reconcile each resource watcher with an authoritative LIST after a normal watch close
- synthesize deltas before opening the next watch so missed external deletions cannot remain cached
- retry transient resync failures with exponential backoff

## Root cause

Kubus already relisted after Kubernetes returned `410 Gone`, but a normally closed watch immediately reopened from the last resource version. If an external deletion event was missed without a `410`, the cached row could remain indefinitely until the cluster session was manually reconnected.

## User impact

Resource lists continue updating normally with no client or UI changes. Missed events now self-heal on the next watch timeout, normally within five minutes. The tradeoff is one authoritative LIST per active resource watcher after a normal watch completion.

## Validation

- production build for shared, client, and server packages
- full Vitest unit suite
- 23 focused watcher tests
- test package typecheck and focused lint
- real `kind-kubus-a` scenario with an externally deleted ConfigMap, a deliberately dropped watch event, and timeout-driven reconciliation
- isolated built Kubus server plus browser verification that an external `kubectl delete` removes the watched row