### PR TITLE
Improve resource table scrolling performance

### DIFF
--- a/client/src/components/CellCopy.tsx
+++ b/client/src/components/CellCopy.tsx
@@ -74,7 +74,7 @@ const cellCopyIcons = (
   </>
 );
 
-const CellCopyButton = memo(function CellCopyButton({ text }: { text: string }) {
+const CellCopyButton = memo(function CellCopyButton({ cell }: { cell: HTMLElement }) {
   return (
     <button
       type="button"
@@ -85,6 +85,10 @@ const CellCopyButton = memo(function CellCopyButton({ text }: { text: string }) 
       onClick={(event) => {
         event.stopPropagation();
         const button = event.currentTarget;
+        // Watches can update a cell while the pointer remains stationary.
+        // Read at click time so the copied value always matches the cell.
+        const text = cell.querySelector<HTMLElement>('[data-copy-text]')?.dataset.copyText ?? '';
+        if (!text) return;
         void copyToClipboard(text).then((ok) => {
           if (!ok) return;
           button.classList.add('kubus-cell-copied');
@@ -103,24 +107,18 @@ const CellCopyButton = memo(function CellCopyButton({ text }: { text: string }) 
   );
 });
 
-interface ActiveCopyCell {
-  cell: HTMLElement;
-  text: string;
-}
-
 /**
  * One hover copy button shared by the whole grid. Virtualized scrolling used
  * to mount a button (and two SVGs) in every non-empty visible cell; moving a
  * single portal between cells keeps that DOM out of the row recycle path.
  */
 export function CellCopyOverlay({ rootRef }: { rootRef: RefObject<HTMLElement | null> }) {
-  const [active, setActive] = useState<ActiveCopyCell | null>(null);
+  const [activeCell, setActiveCell] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
-    const scroller = root.querySelector<HTMLElement>('.MuiDataGrid-virtualScroller');
-    const hide = () => setActive(null);
+    const hide = () => setActiveCell(null);
     const showForPointer = (event: PointerEvent) => {
       const target = event.target instanceof Element ? event.target : null;
       const cell = target?.closest<HTMLElement>('.MuiDataGrid-cell');
@@ -130,7 +128,7 @@ export function CellCopyOverlay({ rootRef }: { rootRef: RefObject<HTMLElement | 
         hide();
         return;
       }
-      setActive((current) => (current?.cell === cell && current.text === text ? current : { cell, text }));
+      setActiveCell((current) => (current === cell ? current : cell));
     };
 
     root.addEventListener('pointerover', showForPointer);
@@ -138,15 +136,17 @@ export function CellCopyOverlay({ rootRef }: { rootRef: RefObject<HTMLElement | 
     // A stationary pointer does not reliably emit enter/leave events while
     // virtualization replaces the row beneath it. Hide immediately; the next
     // pointer movement reveals the button for the new cell.
-    scroller?.addEventListener('scroll', hide, { passive: true });
+    // Capture scroll from a virtual scroller even if it mounts after this
+    // effect (for example when an empty grid receives its first row).
+    root.addEventListener('scroll', hide, { capture: true, passive: true });
     return () => {
       root.removeEventListener('pointerover', showForPointer);
       root.removeEventListener('pointerleave', hide);
-      scroller?.removeEventListener('scroll', hide);
+      root.removeEventListener('scroll', hide, true);
     };
   }, [rootRef]);
 
-  return active && active.cell.isConnected ? createPortal(<CellCopyButton text={active.text} />, active.cell) : null;
+  return activeCell?.isConnected ? createPortal(<CellCopyButton cell={activeCell} />, activeCell) : null;
 }
 
 function updateTruncationTitle(event: ReactMouseEvent<HTMLSpanElement>) {

--- a/client/src/components/CellCopy.tsx
+++ b/client/src/components/CellCopy.tsx
@@ -1,10 +1,10 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState, type MouseEvent as ReactMouseEvent, type RefObject } from 'react';
+import { createPortal } from 'react-dom';
 import IconButton from '@mui/material/IconButton';
 import CheckIcon from '@mui/icons-material/Check';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import type { GridColDef, GridEventListener, GridValidRowModel } from '@mui/x-data-grid';
 import { copyToClipboard } from '../clipboard.js';
-import { TruncationTooltip } from './truncation.js';
 
 /** The text a cell copies: the raw (unformatted) value the grid computed. */
 export function cellCopyText(value: unknown): string {
@@ -103,6 +103,58 @@ const CellCopyButton = memo(function CellCopyButton({ text }: { text: string }) 
   );
 });
 
+interface ActiveCopyCell {
+  cell: HTMLElement;
+  text: string;
+}
+
+/**
+ * One hover copy button shared by the whole grid. Virtualized scrolling used
+ * to mount a button (and two SVGs) in every non-empty visible cell; moving a
+ * single portal between cells keeps that DOM out of the row recycle path.
+ */
+export function CellCopyOverlay({ rootRef }: { rootRef: RefObject<HTMLElement | null> }) {
+  const [active, setActive] = useState<ActiveCopyCell | null>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const scroller = root.querySelector<HTMLElement>('.MuiDataGrid-virtualScroller');
+    const hide = () => setActive(null);
+    const showForPointer = (event: PointerEvent) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const cell = target?.closest<HTMLElement>('.MuiDataGrid-cell');
+      const value = cell?.querySelector<HTMLElement>('[data-copy-text]');
+      const text = value?.dataset.copyText ?? '';
+      if (!cell || !text) {
+        hide();
+        return;
+      }
+      setActive((current) => (current?.cell === cell && current.text === text ? current : { cell, text }));
+    };
+
+    root.addEventListener('pointerover', showForPointer);
+    root.addEventListener('pointerleave', hide);
+    // A stationary pointer does not reliably emit enter/leave events while
+    // virtualization replaces the row beneath it. Hide immediately; the next
+    // pointer movement reveals the button for the new cell.
+    scroller?.addEventListener('scroll', hide, { passive: true });
+    return () => {
+      root.removeEventListener('pointerover', showForPointer);
+      root.removeEventListener('pointerleave', hide);
+      scroller?.removeEventListener('scroll', hide);
+    };
+  }, [rootRef]);
+
+  return active && active.cell.isConnected ? createPortal(<CellCopyButton text={active.text} />, active.cell) : null;
+}
+
+function updateTruncationTitle(event: ReactMouseEvent<HTMLSpanElement>) {
+  const element = event.currentTarget;
+  if (element.scrollWidth > element.clientWidth) element.title = element.textContent ?? '';
+  else element.removeAttribute('title');
+}
+
 /**
  * Wrap a column so every non-empty cell gets a hover copy button overlaid at
  * its right edge. Columns without a custom renderCell keep their default
@@ -118,19 +170,19 @@ export function withCellCopy<R extends GridValidRowModel>(column: GridColDef<R>)
     renderCell: (params) => {
       const text = cellCopyText(params.value);
       const display = String(params.formattedValue ?? params.value ?? '');
-      return (
-        <>
-          {original ? (
-            original(params)
-          ) : (
-            <TruncationTooltip text={display}>
-              <span className="kubus-cell-text" style={{ textAlign: align }}>
-                {display}
-              </span>
-            </TruncationTooltip>
-          )}
-          {text ? <CellCopyButton text={text} /> : null}
-        </>
+      return original ? (
+        <div className="kubus-cell-copy-value" data-copy-text={text || undefined}>
+          {original(params)}
+        </div>
+      ) : (
+        <span
+          className="kubus-cell-text"
+          data-copy-text={text || undefined}
+          style={{ textAlign: align }}
+          onMouseEnter={updateTruncationTitle}
+        >
+          {display}
+        </span>
       );
     },
   };
@@ -157,6 +209,7 @@ export const handleCopyCellKeyDown: GridEventListener<'cellKeyDown'> = (params, 
 /** Grid `sx` styles required by withCellCopy / handleCopyCellKeyDown. */
 export const copyCellGridSx = {
   '& .MuiDataGrid-cell': { position: 'relative' },
+  '& .kubus-cell-copy-value': { display: 'contents' },
   '& .kubus-cell-copy': {
     position: 'absolute',
     top: '50%',
@@ -170,9 +223,6 @@ export const copyCellGridSx = {
     border: 0,
     borderRadius: 1,
     cursor: 'pointer',
-    opacity: 0,
-    pointerEvents: 'none',
-    transition: 'opacity 120ms',
     bgcolor: 'background.paper',
     boxShadow: 1,
     color: 'action.active',
@@ -181,7 +231,6 @@ export const copyCellGridSx = {
     '&.kubus-cell-copied .kubus-cell-copy-icon': { display: 'none' },
     '&.kubus-cell-copied .kubus-cell-copy-check': { display: 'block' },
   },
-  '& .MuiDataGrid-cell:hover .kubus-cell-copy': { opacity: 1, pointerEvents: 'auto' },
   '& .kubus-cell-text': {
     flex: 1,
     minWidth: 0,

--- a/client/src/components/ResourceTable.tsx
+++ b/client/src/components/ResourceTable.tsx
@@ -12,7 +12,7 @@ import type { ClusterRow } from '../api/queries.js';
 import { matchesPlainText, matchesSmartFilter, parseSmartFilter } from '../smart-filter.js';
 import { joinLabelSelector, splitLabelSelector } from '../label-selector.js';
 import { SmartFilterInput } from './SmartFilterInput.js';
-import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from './CellCopy.js';
+import { CellCopyOverlay, copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from './CellCopy.js';
 import type { MetricsLookup } from './columns.js';
 import { podSummary } from '../kube-display.js';
 import { useUiPrefsStore } from '../state/prefs.js';
@@ -59,6 +59,10 @@ const DEFAULT_SORT: GridSortModel = [{ field: 'name', sort: 'asc' }];
 
 const EMPTY_LABEL_OPTIONS: { terms: string[]; keys: Set<string> } = { terms: [], keys: new Set() };
 
+const getResourceRowId = (row: ClusterRow) => row.obj.metadata.uid;
+
+const SCROLL_SETTLE_MS = 120;
+
 /** All `key` and `key=value` selector terms present in the rows. */
 function labelSelectorOptions(rows: ClusterRow[]): { terms: string[]; keys: Set<string> } {
   const keys = new Set<string>();
@@ -94,6 +98,7 @@ export function ResourceTable({
   tableId,
   activeRowId,
 }: Props) {
+  const tableRef = useRef<HTMLDivElement>(null);
   const [localFilter, setLocalFilter] = useState('');
   // The committed value lives in the URL (or localFilter); the input itself is
   // local state so typing never waits on a router round-trip, and the commit
@@ -198,7 +203,42 @@ export function ResourceTable({
     return rows.filter((r) => matchesPlainText(r, words ?? [], resourceKind));
   }, [rows, parsedFilter, kind, metricsForFilter]);
 
+  // Kubernetes watches can replace the rows prop every 100 ms. Let those
+  // updates accumulate while the virtual scroller is moving so the grid does
+  // not re-sort and recycle its visible rows in the middle of a scroll frame.
+  // The newest snapshot is committed shortly after scrolling settles.
+  const scrollingRef = useRef(false);
+  const scrollTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const [, commitPendingRows] = useState(0);
+  const gridRowsRef = useRef(filtered);
+  if (!scrollingRef.current) gridRowsRef.current = filtered;
+  const gridRows = gridRowsRef.current;
+  useEffect(() => {
+    const scroller = tableRef.current?.querySelector<HTMLElement>('.MuiDataGrid-virtualScroller');
+    if (!scroller) return;
+    const handleScroll = () => {
+      scrollingRef.current = true;
+      clearTimeout(scrollTimerRef.current);
+      scrollTimerRef.current = setTimeout(() => {
+        scrollingRef.current = false;
+        commitPendingRows((epoch) => epoch + 1);
+      }, SCROLL_SETTLE_MS);
+    };
+    scroller.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener('scroll', handleScroll);
+      clearTimeout(scrollTimerRef.current);
+      scrollingRef.current = false;
+    };
+  }, []);
+
   const rowsById = useMemo(() => new Map(filtered.map((row) => [row.obj.metadata.uid, row])), [filtered]);
+  const rowsByIdRef = useRef(rowsById);
+  rowsByIdRef.current = rowsById;
+  const filteredRef = useRef(filtered);
+  filteredRef.current = filtered;
+  const callbacksRef = useRef({ onRowClick, onRowActivate, onRowContextMenu, onSelectionChange });
+  callbacksRef.current = { onRowClick, onRowActivate, onRowContextMenu, onSelectionChange };
   const rowSelectionModel = useMemo<GridRowSelectionModel | undefined>(
     () => selectedRows && { type: 'include', ids: new Set(selectedRows.map((row) => row.obj.metadata.uid)) },
     [selectedRows],
@@ -265,9 +305,80 @@ export function ResourceTable({
     ),
     [filteredOut, labelFiltered, kind],
   );
+  const slots = useMemo(() => ({ noRowsOverlay: NoRowsOverlay }), [NoRowsOverlay]);
+  const getRowClassName = useCallback(
+    (params: GridRowParams<ClusterRow>) => {
+      const classes: string[] = [];
+      if (params.id === activeRowId) classes.push('kubus-active-resource-row');
+      // Finished pods stay listed (and filterable) but recede visually so
+      // the running set stands out; hover restores full contrast.
+      if (kind === 'Pod') {
+        const status = podSummary(params.row.obj).status;
+        if (status === 'Succeeded' || status === 'Completed') classes.push('kubus-muted-row');
+      }
+      return classes.join(' ');
+    },
+    [activeRowId, kind],
+  );
+  const handleRowSelectionChange = useCallback<NonNullable<React.ComponentProps<typeof DataGrid<ClusterRow>>['onRowSelectionModelChange']>>(
+    (model) => {
+      const onChange = callbacksRef.current.onSelectionChange;
+      if (!onChange) return;
+      const currentRows = filteredRef.current;
+      // The header "select all" checkbox reports an exclude-type model whose
+      // ids are the deselected rows.
+      const ids = model.ids instanceof Set ? model.ids : new Set();
+      const selected =
+        model.type === 'exclude'
+          ? currentRows.filter((row) => !ids.has(row.obj.metadata.uid))
+          : currentRows.filter((row) => ids.has(row.obj.metadata.uid));
+      onChange(selected);
+    },
+    [],
+  );
+  const handleRowClick = useCallback((params: GridRowParams<ClusterRow>) => callbacksRef.current.onRowClick?.(params.row), []);
+  const rowSlotProps = useMemo(
+    () => ({
+      row: {
+        onContextMenu: (event: React.MouseEvent<HTMLElement>) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const id = event.currentTarget.getAttribute('data-id');
+          const row = id ? rowsByIdRef.current.get(id) : undefined;
+          if (row) callbacksRef.current.onRowContextMenu?.(row, event);
+        },
+      },
+    }),
+    [],
+  );
+  const handleColumnWidthChange = useCallback(
+    (params: { colDef: GridColDef<ClusterRow>; width: number }) => {
+      if (tableId) setColumnWidth(tableId, params.colDef.field, params.width);
+    },
+    [tableId, setColumnWidth],
+  );
+  const handleCellKeyDown = useCallback<NonNullable<React.ComponentProps<typeof DataGrid<ClusterRow>>['onCellKeyDown']>>(
+    (params, event, details) => {
+      handleCopyCellKeyDown(params, event, details);
+      const row = rowsByIdRef.current.get(String(params.id));
+      if (!row) return;
+      const callbacks = callbacksRef.current;
+      // Keyboard equivalents of clicking and right-clicking a row.
+      if (event.key === 'Enter' && (callbacks.onRowActivate || callbacks.onRowClick)) {
+        event.preventDefault();
+        (callbacks.onRowActivate ?? callbacks.onRowClick)!(row);
+      } else if (callbacks.onRowContextMenu && (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10'))) {
+        event.preventDefault();
+        const cell = (event.target as HTMLElement | null)?.closest?.('.MuiDataGrid-cell');
+        const rect = (cell ?? (event.target as HTMLElement)).getBoundingClientRect();
+        callbacks.onRowContextMenu(row, { clientX: rect.left + 8, clientY: rect.bottom - 4 });
+      }
+    },
+    [],
+  );
 
   return (
-    <Box className="kubus-table" sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+    <Box ref={tableRef} className="kubus-table" sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Stack direction="row" spacing={1} useFlexGap sx={{ px: 1.5, py: 1, flexShrink: 0, alignItems: 'center', flexWrap: 'wrap' }}>
         <SmartFilterInput
           value={inputValue}
@@ -321,21 +432,11 @@ export function ResourceTable({
         {toolbar}
       </Stack>
       <DataGrid
-        rows={filtered}
+        rows={gridRows}
         columns={gridColumns}
         loading={loading}
-        getRowId={(r) => r.obj.metadata.uid}
-        getRowClassName={(params) => {
-          const classes: string[] = [];
-          if (params.id === activeRowId) classes.push('kubus-active-resource-row');
-          // Finished pods stay listed (and filterable) but recede visually so
-          // the running set stands out; hover restores full contrast.
-          if (kind === 'Pod') {
-            const status = podSummary(params.row.obj).status;
-            if (status === 'Succeeded' || status === 'Completed') classes.push('kubus-muted-row');
-          }
-          return classes.join(' ');
-        }}
+        getRowId={getResourceRowId}
+        getRowClassName={getRowClassName}
         density={tableDensity === 'comfortable' ? 'standard' : 'compact'}
         // On overlay-scrollbar platforms the grid measures the native
         // scrollbar as 0px and floats its own on top of the last column;
@@ -344,60 +445,20 @@ export function ResourceTable({
         scrollbarSize={layout.scrollbarSize}
         checkboxSelection={checkboxSelection}
         rowSelectionModel={rowSelectionModel}
-        slots={{ noRowsOverlay: NoRowsOverlay }}
-        onRowSelectionModelChange={
-          onSelectionChange
-            ? (model) => {
-                // The header "select all" checkbox reports an exclude-type
-                // model whose ids are the deselected rows.
-                const ids = model.ids instanceof Set ? model.ids : new Set();
-                const selected =
-                  model.type === 'exclude'
-                    ? filtered.filter((r) => !ids.has(r.obj.metadata.uid))
-                    : filtered.filter((r) => ids.has(r.obj.metadata.uid));
-                onSelectionChange(selected);
-              }
-            : undefined
-        }
+        slots={slots}
+        onRowSelectionModelChange={onSelectionChange ? handleRowSelectionChange : undefined}
         disableRowSelectionOnClick={!!checkboxSelection}
-        onRowClick={onRowClick ? (params: GridRowParams<ClusterRow>) => onRowClick(params.row) : undefined}
-        slotProps={
-          onRowContextMenu
-            ? {
-                row: {
-                  onContextMenu: (event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    const id = event.currentTarget.getAttribute('data-id');
-                    const row = id ? rowsById.get(id) : undefined;
-                    if (row) onRowContextMenu(row, event);
-                  },
-                },
-              }
-            : undefined
-        }
+        onRowClick={onRowClick ? handleRowClick : undefined}
+        slotProps={onRowContextMenu ? rowSlotProps : undefined}
         columnVisibilityModel={visibility}
         onColumnVisibilityModelChange={handleVisibilityChange}
-        onColumnWidthChange={tableId ? (params) => setColumnWidth(tableId, params.colDef.field, params.width) : undefined}
-        onCellKeyDown={(params, event, details) => {
-          handleCopyCellKeyDown(params, event, details);
-          const row = rowsById.get(String(params.id));
-          if (!row) return;
-          // Keyboard equivalents of clicking and right-clicking a row.
-          if (event.key === 'Enter' && (onRowActivate || onRowClick)) {
-            event.preventDefault();
-            (onRowActivate ?? onRowClick)!(row);
-          } else if (onRowContextMenu && (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10'))) {
-            event.preventDefault();
-            const cell = (event.target as HTMLElement | null)?.closest?.('.MuiDataGrid-cell');
-            const rect = (cell ?? (event.target as HTMLElement)).getBoundingClientRect();
-            onRowContextMenu(row, { clientX: rect.left + 8, clientY: rect.bottom - 4 });
-          }
-        }}
+        onColumnWidthChange={tableId ? handleColumnWidthChange : undefined}
+        onCellKeyDown={handleCellKeyDown}
         sortModel={sortModel}
         onSortModelChange={handleSortChange}
         sx={gridSx}
       />
+      <CellCopyOverlay rootRef={tableRef} />
     </Box>
   );
 }

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -17,7 +17,7 @@ import { matchesPlainText, matchesSmartFilter, parseSmartFilter } from '../smart
 import { namespaceVisible, useClustersStore } from '../state/clusters.js';
 import { useDetailStore } from '../state/detail.js';
 import { AgeCell } from '../components/AgeCell.js';
-import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
+import { CellCopyOverlay, copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
 import { useQuickSearchShortcut } from '../components/quick-search.js';
 import { SmartFilterInput } from '../components/SmartFilterInput.js';
@@ -110,6 +110,7 @@ export function EventsPage() {
   const [text, setText] = useState('');
   const deferredText = useDeferredValue(text);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const gridRootRef = useRef<HTMLDivElement>(null);
   useQuickSearchShortcut(searchInputRef);
 
   const kinds = useMemo(() => {
@@ -239,7 +240,7 @@ export function EventsPage() {
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+    <Box ref={gridRootRef} sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       <Box sx={{ px: 1.5, pt: 1.5 }}>
         <PageHeader title="Events" icon={<NotificationsNoneOutlinedIcon />}>
           <Chip label={countLabel(rows.length, 'event')} variant="outlined" />
@@ -275,6 +276,7 @@ export function EventsPage() {
         initialState={eventsGridInitialState}
         sx={eventsGridSx}
       />
+      <CellCopyOverlay rootRef={gridRootRef} />
     </Box>
   );
 }

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useMemo, useState } from 'react';
+import { Suspense, lazy, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -16,7 +16,7 @@ import { DataGrid } from '@mui/x-data-grid';
 import type { HelmReleaseSummary } from '@kubus/shared';
 import { useAppInfo, useHelmOperations, useHelmReleases, useHelmUpdates } from '../api/queries.js';
 import { namespaceVisible, useClustersStore } from '../state/clusters.js';
-import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
+import { CellCopyOverlay, copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { AgeCell } from '../components/AgeCell.js';
@@ -41,6 +41,7 @@ export function HelmPage() {
   const { data, isLoading } = useHelmReleases(selected);
   const navigate = useNavigate();
   const [installOpen, setInstallOpen] = useState(false);
+  const gridRootRef = useRef<HTMLDivElement>(null);
   const helmEngine = useAppInfo().data?.helmEngine ?? false;
   const operations = useHelmOperations();
 
@@ -161,7 +162,7 @@ export function HelmPage() {
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5, pt: 1.5 }}>
+    <Box ref={gridRootRef} sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5, pt: 1.5 }}>
       <PageHeader title="Helm Releases" icon={<SailingOutlinedIcon />}>
         <Chip label={countLabel(rows.length, 'release')} variant="outlined" />
         {availableUpdates > 0 ? <Chip label={`${availableUpdates} update${availableUpdates === 1 ? '' : 's'} available`} color="primary" /> : null}
@@ -209,6 +210,7 @@ export function HelmPage() {
         sx={releasesGridSx}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
       />
+      <CellCopyOverlay rootRef={gridRootRef} />
       {installOpen && (
         <Suspense fallback={null}>
           <HelmInstallDialog contexts={selected} onClose={() => setInstallOpen(false)} />

--- a/client/src/pages/PortForwardsPage.tsx
+++ b/client/src/pages/PortForwardsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -12,7 +12,7 @@ import type { GridColDef } from '@mui/x-data-grid';
 import { DataGrid } from '@mui/x-data-grid';
 import type { PortForwardInfo } from '@kubus/shared';
 import { usePortForwards, useStopAllPortForwards, useStopPortForward } from '../api/queries.js';
-import { copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
+import { CellCopyOverlay, copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
 import { EmptyState } from '../components/EmptyState.js';
@@ -25,6 +25,7 @@ export function PortForwardsPage() {
   const { mutate: stop } = useStopPortForward();
   const stopAll = useStopAllPortForwards();
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const gridRootRef = useRef<HTMLDivElement>(null);
 
   const columns: GridColDef<PortForwardInfo>[] = useMemo(() => {
     const defs: GridColDef<PortForwardInfo>[] = [
@@ -75,7 +76,7 @@ export function PortForwardsPage() {
   const grid = useGridPrefs('port-forwards', columns);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5 }}>
+    <Box ref={gridRootRef} sx={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, p: 1.5 }}>
       <PageHeader title="Port Forwards" icon={<CableOutlinedIcon />}>
         <Chip label={`${data?.length ?? 0} active`} variant="outlined" />
         <Box sx={{ flex: 1 }} />
@@ -138,6 +139,7 @@ export function PortForwardsPage() {
           sx={forwardsGridSx}
         />
       )}
+      <CellCopyOverlay rootRef={gridRootRef} />
     </Box>
   );
 }

--- a/tests/unit/client/cell-copy.test.tsx
+++ b/tests/unit/client/cell-copy.test.tsx
@@ -40,4 +40,15 @@ describe('CellCopyOverlay', () => {
     fireEvent.scroll(container.querySelector('.MuiDataGrid-virtualScroller')!);
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Copy value' })).not.toBeInTheDocument());
   });
+
+  it('copies the current value when a hovered cell updates', async () => {
+    render(<GridHarness />);
+
+    fireEvent.pointerOver(screen.getByText('First'));
+    const value = screen.getByText('First');
+    value.dataset.copyText = 'updated-raw';
+    fireEvent.click(await screen.findByRole('button', { name: 'Copy value' }));
+
+    expect(clipboard.copy).toHaveBeenLastCalledWith('updated-raw');
+  });
 });

--- a/tests/unit/client/cell-copy.test.tsx
+++ b/tests/unit/client/cell-copy.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { CellCopyOverlay } from '../../../client/src/components/CellCopy';
+
+const clipboard = vi.hoisted(() => ({ copy: vi.fn(async () => true) }));
+
+vi.mock('../../../client/src/clipboard.js', () => ({ copyToClipboard: clipboard.copy }));
+
+function GridHarness() {
+  const rootRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={rootRef}>
+      <div className="MuiDataGrid-virtualScroller">
+        <div className="MuiDataGrid-cell">
+          <span data-copy-text="first-raw">First</span>
+        </div>
+        <div className="MuiDataGrid-cell">
+          <span data-copy-text="second-raw">Second</span>
+        </div>
+      </div>
+      <CellCopyOverlay rootRef={rootRef} />
+    </div>
+  );
+}
+
+describe('CellCopyOverlay', () => {
+  it('mounts one button for the hovered cell and removes it while scrolling', async () => {
+    const { container } = render(<GridHarness />);
+
+    fireEvent.pointerOver(screen.getByText('First'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Copy value' }));
+    expect(clipboard.copy).toHaveBeenCalledWith('first-raw');
+
+    fireEvent.pointerOver(screen.getByText('Second'));
+    expect(screen.getAllByRole('button', { name: 'Copy value' })).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Copy value' }));
+    expect(clipboard.copy).toHaveBeenLastCalledWith('second-raw');
+
+    fireEvent.scroll(container.querySelector('.MuiDataGrid-virtualScroller')!);
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Copy value' })).not.toBeInTheDocument());
+  });
+});

--- a/tests/unit/client/resource-table.test.tsx
+++ b/tests/unit/client/resource-table.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ClusterRow } from '../../../client/src/api/queries';
 import { ResourceTable } from '../../../client/src/components/ResourceTable';
 
 vi.mock('../../../client/src/components/SmartFilterInput.js', () => ({ SmartFilterInput: () => null }));
 vi.mock('../../../client/src/components/CellCopy.js', () => ({
+  CellCopyOverlay: () => null,
   copyCellGridSx: {},
   handleCopyCellKeyDown: vi.fn(),
   withCellCopy: (column: unknown) => column,
@@ -36,5 +37,22 @@ describe('ResourceTable selection', () => {
 
     rerender(<ResourceTable rows={[first, second]} columns={columns} checkboxSelection selectedRows={[]} onSelectionChange={vi.fn()} />);
     return waitFor(() => expect(screen.getAllByRole('checkbox').every((checkbox) => !(checkbox as HTMLInputElement).checked)).toBe(true));
+  });
+
+  it('holds watch updates out of the grid until scrolling settles', async () => {
+    const first = row('first');
+    const second = row('second');
+    const columns = [{ field: 'name', valueGetter: (_value: unknown, current: ClusterRow) => current.obj.metadata.name }];
+    const { container, rerender } = render(<ResourceTable rows={[first]} columns={columns} />);
+    const scroller = container.querySelector('.MuiDataGrid-virtualScroller');
+    expect(scroller).not.toBeNull();
+
+    fireEvent.scroll(scroller!);
+    rerender(<ResourceTable rows={[second]} columns={columns} />);
+    expect(screen.getByText('first')).toBeInTheDocument();
+    expect(screen.queryByText('second')).not.toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText('second')).toBeInTheDocument());
+    expect(screen.queryByText('first')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- buffer Kubernetes watch-driven row updates until resource-table scrolling settles
- keep DataGrid callbacks and slot props stable across list refreshes
- replace per-cell hidden copy controls with one shared hover copy button
- add regression coverage for scroll buffering and cell copy behavior

## Why

Pod and workload watches can flush updates every 100 ms. Applying each snapshot while the virtual scroller is moving forces the grid to re-sort and recycle visible rows inside scroll frames. The table also mounted a hidden copy button and two SVGs in every non-empty cell, increasing the DOM work needed whenever virtualized rows changed.

## User impact

Pods, Deployments, and other resource tables remain responsive while live cluster updates arrive. The newest data appears shortly after scrolling stops, and existing mouse and keyboard copy behavior is preserved.

## Validation

- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- `pnpm lint`
- `pnpm --filter @kubus/tests typecheck`
- full unit suite: 968 tests passed
- focused table regressions: 3 tests passed
- isolated browser verification against the local kind cluster
