### PR TITLE
docs: fix macOS quarantine command

### DIFF
--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -45,7 +45,7 @@ name. It's a UI guard, not RBAC — see [Production guard](../guide/production-g
 ### Why does macOS say the app is damaged / unverified?
 
 The builds aren't notarised yet. Right-click → **Open**, or run
-`xattr -dr com.apple.quarantine /Applications/Kubus.app`. Details on the
+`xattr -d com.apple.quarantine /Applications/Kubus.app`. Details on the
 [Desktop app](../install/desktop.md) page.
 
 ### Can I run it on a remote/headless box?

--- a/docs/install/desktop.md
+++ b/docs/install/desktop.md
@@ -37,7 +37,7 @@ Grab the installer for your platform from the **[releases page](https://github.c
         - clear the quarantine flag from a terminal:
 
         ```bash
-        xattr -dr com.apple.quarantine /Applications/Kubus.app
+        xattr -d com.apple.quarantine /Applications/Kubus.app
         ```
 
     After the first launch you can open it normally from Spotlight or the Dock.


### PR DESCRIPTION
## Summary

- replace the unsupported `xattr -dr` invocation with `xattr -d` in the macOS installation instructions
- keep the FAQ command consistent with the installation page

## Why

The documented recursive flag is not supported by the macOS `xattr` command, so copying the command fails before clearing the quarantine attribute.

## Impact

macOS users can copy the documented command to clear the quarantine flag and launch Kubus.

## Validation

- `git diff HEAD^ --check`
- documentation-only change; no runtime tests required