### PR TITLE
docs: add release notes

### DIFF
--- a/docs/release-notes/0.1.md
+++ b/docs/release-notes/0.1.md
@@ -1,0 +1,44 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.1
+
+:material-calendar: 11 June 2026 · [View release](https://github.com/FloSch62/Kubus/releases/tag/v0.1.0)
+
+Release 0.1 is the first public version of Kubus: a local Kubernetes GUI that uses the
+clusters and credentials already present in your kubeconfig.
+
+## The first Kubus workspace
+
+The initial release can connect several contexts at once, browse built-in resources and
+CRDs, inspect and edit YAML, stream logs, open container shells and watch a cluster from a
+single desktop interface. The overview pulls workload health and warning events together,
+while the navigation tree and global search make large API surfaces manageable.
+
+Kubus runs locally and binds its server to the loopback interface. It uses the same access
+your kubeconfig grants and does not require an in-cluster dashboard deployment.
+
+## Patches
+
+### 0.1.1
+
+:material-calendar: 12 June 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.1.0...v0.1.1)
+
+- Added the first Settings controls.
+- Fixed early desktop integration issues.
+
+### 0.1.2
+
+:material-calendar: 12 June 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.1.1...v0.1.2)
+
+- Prepared corrected desktop artifacts for the initial release line.
+
+### 0.1.3
+
+:material-calendar: 23 June 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.1.2...v0.1.3)
+
+- Renamed the project to Kubus and introduced its current icon.
+- Added the first documentation site with light and dark screenshots.
+
+[View the 0.1 releases on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.1.3)

--- a/docs/release-notes/0.2.md
+++ b/docs/release-notes/0.2.md
@@ -1,0 +1,71 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.2
+
+:material-calendar: 23 June 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.1.3...v0.2.0)
+
+Release 0.2 expands Kubus beyond direct kubeconfig connections. Cluster entries can carry
+proxy settings, connection problems are visible before a context is selected and custom
+resources gain first-class schema and search support.
+
+## Editable cluster connections
+
+Cluster targets can be edited from Settings, including the proxy information needed for
+proxied environments. Changes work with split kubeconfig files instead of assuming that every
+context, cluster and user lives in one document.
+
+The cluster switcher checks connection status up front, so unreachable or misconfigured
+contexts are visible before they are added to the active workspace.
+
+## Custom resources become easier to explore
+
+CRD details include the published OpenAPI schema, and custom resources participate in fast
+fuzzy search. Their counts appear on the overview, while managed fields stay out of the YAML
+view unless they are needed.
+
+## Update notifications
+
+The desktop app checks the published release manifest and lets you know when a newer Kubus
+version is available. The notification links to the matching release downloads rather than
+updating the application behind your back.
+
+## Patches
+
+### 0.2.1
+
+:material-calendar: 23 June 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.2.0...v0.2.1)
+
+- Custom resource search is faster and the overview includes custom resource counts.
+- Favourites move into the navigation tree and can include whole categories.
+- SOCKS tunnel handling is more reliable.
+
+### 0.2.2
+
+:material-calendar: 1 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.2.1...v0.2.2)
+
+- Kubus can follow the operating-system light or dark theme automatically.
+- Favourites persist reliably between sessions.
+- Resource rows gain context menus, table-search shortcuts and clear-filter controls.
+- YAML and individual table values can be copied directly.
+- The overview shows cumulative node CPU and memory usage.
+- Resources link back to the CRD that defines them.
+
+### 0.2.3
+
+:material-calendar: 2 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.2.2...v0.2.3)
+
+- SSH jump-host connections avoid startup races.
+- CRD indexing is faster and more stable.
+- Resource watching and application startup receive a broader performance and stability pass.
+- Update checks no longer use a stale release manifest.
+
+### 0.2.4
+
+:material-calendar: 3 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.2.3...v0.2.4)
+
+- Raw Kubernetes requests retain the configured authentication headers.
+- Connection errors distinguish credential failures from anonymous authorization failures and include practical diagnostics.
+
+[View the 0.2 releases on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.2.4)

--- a/docs/release-notes/0.3.md
+++ b/docs/release-notes/0.3.md
@@ -1,0 +1,59 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.3
+
+:material-calendar: 12 July 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.2.4...v0.3.0)
+
+Release 0.3 makes Kubus a workspace rather than a sequence of pages. Tabs keep resources and
+tools close at hand, smart filters turn list searches into structured queries and the YAML
+editor understands the schema of the resource being edited.
+
+## Smart filters and saved table layout
+
+Start a resource search with `/` to filter on fields such as namespace, labels, images,
+readiness, age or CPU and memory values. Clauses can be combined, negated and compared without
+giving up the quick text search used for simple queries.
+
+Column widths are now remembered, so carefully arranged resource tables stay useful when you
+return to them.
+
+## Security audit and Helm revision diffs
+
+The new Security Audit page checks workloads, RBAC, network policy and sensitive configuration
+for common risks, then links each finding back to the affected resource.
+
+Helm release history can compare revisions side by side, making it easier to understand the
+manifest changes behind an upgrade or rollback.
+
+## Schema-aware YAML editing
+
+The YAML editor loads the Kubernetes OpenAPI schema for the current resource, including CRDs.
+That adds completion and validation while you edit. Saving follows `kubectl replace` semantics,
+which protects resource identity and reports update conflicts instead of merging hidden fields.
+
+## Faster navigation
+
+Client code is split into smaller bundles and expensive views do less work in the background.
+The detail drawer opens faster, shell and log panels render more efficiently and ++ctrl+w++
+closes the active dock tab.
+
+## Patches
+
+### 0.3.1
+
+:material-calendar: 13 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.3.0...v0.3.1)
+
+- Hover any resource-table cell to copy its complete value, including text shortened for display.
+
+### 0.3.2
+
+:material-calendar: 14 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.3.1...v0.3.2)
+
+- Pages and bottom-dock tools can be kept in tabs and switched without discarding their state.
+- Topology navigation is faster and supports opening resources with the middle mouse button.
+- Resource discovery consistently uses full group, version and kind identities.
+- CRD status, schema access, favourites and column sizing are clearer and more consistent.
+
+[View the 0.3 releases on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.3.2)

--- a/docs/release-notes/0.4.md
+++ b/docs/release-notes/0.4.md
@@ -1,0 +1,33 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.4
+
+:material-calendar: 15 July 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.3.2...v0.4.0)
+
+Release 0.4 is a speed and reliability pass across the parts of Kubus that stay open all day:
+resource details, topology, logs and shells. Installed desktop builds also get more reliable
+startup and recovery behaviour.
+
+## Faster topology and detail views
+
+Topology data loads with less delay and now shows when a refresh is in progress. Full-screen
+topology returns, CRD sections collapse correctly and semantic status colours make object
+health easier to scan.
+
+Detail drawers open and resize more smoothly, preserve their state while switching tabs and
+avoid unnecessary work in log and shell views.
+
+## A steadier terminal
+
+Shell sessions now report the correct terminal size and send keepalives so quiet sessions are
+less likely to be dropped by an intermediate connection.
+
+## Desktop startup and recovery
+
+Packaged desktop builds handle startup paths more consistently, and the recovery flow no
+longer leaves Kubus unable to relaunch after a failure. Permanent Kubernetes watch-list errors
+are surfaced instead of leaving a resource view silently stuck.
+
+[View the v0.4.0 release on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.4.0)

--- a/docs/release-notes/0.5.md
+++ b/docs/release-notes/0.5.md
@@ -1,0 +1,39 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.5
+
+:material-calendar: 16 July 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.4.0...v0.5.0)
+
+Release 0.5 adds two complementary views of cluster activity: Kubernetes resource usage
+from metrics-server and pod-to-pod traffic from Microsoft Retina. Together they make it
+possible to move from “what is unhealthy?” to “what is consuming resources or talking on
+the network?” without leaving Kubus.
+
+## Cluster and workload metrics
+
+The Metrics page charts CPU and memory for the cluster and highlights the busiest nodes,
+namespaces and pods. Resource lists and detail views use the same samples to show live usage
+beside requests and limits, so pressure is visible in the context where you are already
+working.
+
+Metrics come from the Kubernetes Metrics API. Kubus detects whether metrics-server is
+available and keeps the rest of the application usable when it is not.
+
+## Network visibility with Retina
+
+The Network Metrics page shows traffic between workloads, namespaces, Services and external
+addresses. Charts summarize transmitted bytes and packets, while the connection table lets
+you filter down to individual flows.
+
+Kubus can install a pinned Microsoft Retina deployment into `kube-system`, configure the
+namespaces it observes and remove that installation later. Existing Retina installations
+are detected and left under their current owner's control.
+
+## Interface polish
+
+Tab controls remain visible across light and dark themes, and the documentation screenshots
+were refreshed for the new metrics views.
+
+[View the v0.5.0 release on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.5.0)

--- a/docs/release-notes/0.6.md
+++ b/docs/release-notes/0.6.md
@@ -1,0 +1,116 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.6
+
+:material-calendar: 21 July 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.5.0...v0.6.0)
+
+Release 0.6 turns many everyday Kubernetes jobs into complete workflows. Helm releases can
+be managed from install through rollback, port forwards have a dedicated home and resource
+lists gain saved views, bulk actions and deeper keyboard support. The overview becomes a
+namespace-aware health dashboard instead of a collection of counters.
+
+## Full Helm lifecycle management
+
+Kubus can now install and upgrade charts, inspect values and rendered manifests, follow an
+operation's progress, roll back to an earlier revision and uninstall a release. Readiness
+checks explain which workload is holding an operation up, and safety checks cover common
+failure and recovery cases.
+
+All of this runs through the built-in Helm engine; a separate Helm binary is not required.
+
+## An overview built around health
+
+The overview follows the active namespace scope and combines workload readiness, unhealthy
+pods, warnings and expiring certificates into one picture. It also highlights why pods are
+not ready and keeps operator and certificate data isolated between namespace scopes.
+
+## Resource workflows that stay in context
+
+Resource lists now support saved views that restore filters, sorting, columns and other grid
+state. You can delete or restart a selection in bulk, toggle favourites from a row or detail
+view and open the active resource directly in the navigation drawer.
+
+Scaling respects HPA and KEDA ownership, DaemonSets join Deployments in rollout history and
+rollback, and CronJob and Job actions include schedule validation and more useful operations.
+
+## Port forwarding from start to finish
+
+Start a port forward from an eligible workload or Service, choose the target and ports, then
+monitor or stop it from the Port Forwards page. Kubus checks access before starting and keeps
+the forward's status and errors visible for its lifetime.
+
+## ConfigMap and Secret data editor
+
+ConfigMaps and Secrets gain a per-key editor alongside YAML. Add, edit, copy or remove
+individual values without manually handling encoded Secret data, with conflict checks before
+concurrent changes are overwritten.
+
+## Keyboard-first navigation
+
+Resource tables, row actions, details, filters and the navigation drawer are now reachable
+from the keyboard. A shortcut reference makes the available commands discoverable, while
+the first-run welcome screen and collapsible navigation improve narrow-window use.
+
+## Logs and terminals
+
+The log viewer has bounded history, stronger reconnect behaviour and clearer stream controls.
+The embedded terminal gains right-click copy and paste, while pod debug sessions can use
+`kubectl`-style profiles.
+
+## Performance and desktop reliability
+
+Shared watches and context state reduce background polling, table updates keep stable inputs
+and desktop preferences are persisted without blocking the renderer. Deep links wait for the
+window to be ready, and state writes fall back safely if the desktop store is unavailable.
+
+## Patches
+
+### 0.6.1
+
+:material-calendar: 21 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.6.0...v0.6.1)
+
+- Topology selection stays above surrounding edges and focused graphs no longer fan out through shared infrastructure.
+- Warning events link to their resources, including cluster-scoped objects.
+- CRDs are grouped more clearly in resource navigation.
+- Usage bars mark values that exceed their requests or capacity.
+
+### 0.6.2
+
+:material-calendar: 22 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.6.1...v0.6.2)
+
+- Detail drawers use a more consistent layout with clearer environment values and real truncation.
+- Unreachable clusters no longer crash overview warm-up.
+- The false metrics-server prompt at startup is fixed, and overview sections stream in as they become available.
+- Empty lists distinguish a filter with no matches from a resource kind with no objects.
+
+### 0.6.3
+
+:material-calendar: 27 July 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.6.2...v0.6.3)
+
+- Pod debug sessions offer reusable image presets and configured shells run as login shells.
+- Topology discovers typed cross-namespace references more accurately.
+- The detail drawer can be resized by dragging its handle.
+- SSH jump-host settings survive kubeconfig imports and remain isolated between clusters.
+- Favourites are scoped to the clusters where they were created.
+
+### 0.6.4
+
+:material-calendar: 8 August 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.6.3...v0.6.4)
+
+- Pod details gain a quick-action bar, concise fact rows and per-container log and shell actions.
+- Terminal shortcuts focus the dock reliably and repeated shortcuts cycle through sessions.
+- The overview shows total CPU and memory capacity across all nodes.
+
+### 0.6.5
+
+:material-calendar: 10 August 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.6.4...v0.6.5)
+
+- Terminal settings can automatically copy selected text and configure right-click behaviour.
+- The command-palette search field stays put while results change.
+- Favourite navigation remains selected through URL updates.
+- Connectivity errors appear with the affected cluster, including contexts with special characters.
+- Bulk-delete counts stay synchronized with the current grid selection.
+
+[View the 0.6 releases on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.6.5)

--- a/docs/release-notes/0.7.md
+++ b/docs/release-notes/0.7.md
@@ -1,0 +1,57 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.7
+
+:material-calendar: 14 August 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.6.5...v0.7.0)
+
+Release 0.7 makes Kubus feel more at home as a desktop tool. Tabs can move between
+windows, terminals can reconnect in place and useful diagnostics are available without
+starting Kubus from a console. Resource browsing also gets a substantial performance and
+reliability pass.
+
+## Tabs and focused windows
+
+Tabs are no longer tied to the window in which they were opened. Use a tab's menu to open
+or move it into a new window, or drag it outside the current Kubus window to detach it.
+Tabs can move between existing windows too, without losing their page state.
+
+Logs and shells can open as focused utility windows. These compact windows give the active
+session the full canvas and stay independent of the main resource browser. Closing a moved
+window returns its tab safely instead of silently discarding the session.
+
+## Reconnect a terminal
+
+A dropped shell or node-shell session no longer means closing the tab and starting over.
+Choose **Reconnect** from the terminal tab menu to create a fresh exec session for the same
+container while keeping the tab in place.
+
+## Diagnostics you can take with you
+
+The new **Diagnostic logging** section in Settings captures Kubus server and desktop events
+in an in-memory log. Turn on verbose capture while reproducing a problem, inspect the log
+inside Kubus and export it as a text file when you need to share the details.
+
+Routine request noise is left out, and the session token is redacted from captured startup
+messages.
+
+## Copy the matching `kubectl get` command
+
+Resource context menus can now copy the `kubectl get` command for the selected object. The
+command includes its namespace, context and non-default kubeconfig path, so it is ready to
+paste into a terminal even when several clusters are connected.
+
+## Capacity where you need it
+
+Node rows now show CPU and memory usage against that node's capacity. This makes saturation
+visible directly in the resource list and keeps percentage-based smart filters meaningful
+for node resources.
+
+## Smoother and more reliable resource browsing
+
+Large resource tables do less work while scrolling, and their copy controls no longer leave
+overlays behind as cells are recycled. This release also fixes stale watch data after normal
+Kubernetes watch timeouts and closes races when sockets or YAML editor models are replaced.
+
+[View the v0.7.0 release on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.7.0)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,12 @@
+---
+icon: lucide/scroll-text
+hide:
+  - navigation
+  - toc
+---
+
+<meta http-equiv="refresh" content="0; url=0.7/">
+
+# Latest release
+
+[Continue to release 0.7](0.7.md)

--- a/zensical.toml
+++ b/zensical.toml
@@ -60,6 +60,15 @@ nav = [
     { "Architecture" = "reference/architecture.md" },
     { "Security model" = "reference/security.md" },
   ] },
+  { "Release notes" = [
+    { "0.7" = "release-notes/0.7.md" },
+    { "0.6" = "release-notes/0.6.md" },
+    { "0.5" = "release-notes/0.5.md" },
+    { "0.4" = "release-notes/0.4.md" },
+    { "0.3" = "release-notes/0.3.md" },
+    { "0.2" = "release-notes/0.2.md" },
+    { "0.1" = "release-notes/0.1.md" },
+  ] },
   { "Community" = [
     "community/index.md",
     { "Contributing" = "community/contributing.md" },


### PR DESCRIPTION
## Summary

- add editorial release notes for every release line from 0.1 through 0.7
- group patch releases with their corresponding minor release
- add a top-level Release notes section to the documentation navigation
- route `/release-notes/` to the latest version while keeping `0.7` highlighted in the sidebar

## Why

Users can now understand the important features, workflow changes, and fixes in each Kubus release without reconstructing them from commit or pull request lists.

## Impact

The documentation gains versioned release-note pages and a stable latest-release entry point. Application behavior is unchanged.

## Validation

- `uvx --native-tls zensical build --strict`
