### PR TITLE
fix: bound Kubernetes search watches

### DIFF
--- a/client/src/pages/OverviewPage.tsx
+++ b/client/src/pages/OverviewPage.tsx
@@ -20,7 +20,6 @@ import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined';
 import ExtensionOutlinedIcon from '@mui/icons-material/ExtensionOutlined';
-import Inventory2OutlinedIcon from '@mui/icons-material/Inventory2Outlined';
 import VerifiedUserOutlinedIcon from '@mui/icons-material/VerifiedUserOutlined';
 import AddIcon from '@mui/icons-material/Add';
 import { useNavigate } from 'react-router';
@@ -202,12 +201,6 @@ function WholeClusterSection({ ctx }: { ctx: string }) {
               warn={!data.counts.crdsUnavailable && data.counts.crdsEstablished < data.counts.crds}
               icon={<ExtensionOutlinedIcon />}
               onClick={() => navigate('/r/apiextensions.k8s.io/v1/customresourcedefinitions')}
-            />
-            <StatCard
-              label="Custom Resources"
-              value={data.counts.customResources}
-              sub={data.counts.customResourcesIndexed ? 'instances' : 'indexing'}
-              icon={<Inventory2OutlinedIcon />}
             />
             <StatCard
               label="TLS certificates"

--- a/server/src/kube/cluster-manager.ts
+++ b/server/src/kube/cluster-manager.ts
@@ -55,8 +55,6 @@ export class ClusterHandle {
   onDiscoveryChanged?: () => void;
 
   private clients = new Map<string, unknown>();
-  private searchIndexWarmup?: NodeJS.Timeout;
-
   constructor(
     baseConfig: KubeConfig,
     public readonly contextName: string,
@@ -146,12 +144,9 @@ export class ClusterHandle {
     this.watchers.acquire('', 'v1', 'events');
     this.watchers.acquire('', 'v1', 'nodes');
     this.watchers.acquire('', 'v1', 'namespaces');
-    this.searchIndexWarmup = setTimeout(() => this.searchIndex.warm(), 1_000);
-    this.searchIndexWarmup.unref();
   }
 
   dispose(): void {
-    if (this.searchIndexWarmup) clearTimeout(this.searchIndexWarmup);
     this.metricsPoller.stop();
     this.networkPoller.stop();
     this.crdTracker.stop();

--- a/server/src/kube/overview.ts
+++ b/server/src/kube/overview.ts
@@ -58,9 +58,6 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
     const events = eventsWatcher.watcher.items();
     const persistentVolumes = persistentVolumesResult.items;
     const crds = crdsResult.items;
-    const customResourceEntries = await handle.searchIndex.entries();
-    const customResourcesIndexed = !handle.searchIndex.isReconciling();
-
     const overview: ClusterOverview = {
       counts: {
         nodes: nodesWatcher.watcher.items().length,
@@ -74,8 +71,6 @@ export async function computeOverview(handle: ClusterHandle): Promise<ClusterOve
         crds: crds.length,
         crdsEstablished: crds.filter(isEstablishedCrd).length,
         crdsUnavailable: crdsResult.unavailable,
-        customResources: customResourceEntries.reduce((n, entry) => (entry.kind.custom ? n + 1 : n), 0),
-        customResourcesIndexed,
       },
       failingPods: [],
       unavailableWorkloads: [],

--- a/server/src/kube/raw-client.ts
+++ b/server/src/kube/raw-client.ts
@@ -4,9 +4,18 @@ import fetch, { type RequestInit, type Response } from 'node-fetch';
 import { ApiException, type KubeConfig } from '@kubernetes/client-node';
 
 type FetchAgent = Agent & { options: Record<string, unknown> };
+type RawRequestInit = { method?: string; body?: string; headers?: Record<string, string>; signal?: AbortSignal };
 
 const TRAILING_SLASH_RE = /\/$/;
 const RETRYABLE_GET_ERROR_CODES = new Set(['ECONNABORTED', 'ECONNRESET', 'ENETRESET', 'EPIPE', 'ETIMEDOUT']);
+export const KUBE_REQUEST_DEADLINE_MS = 15_000;
+
+class RequestDeadlineError extends Error {
+  constructor(path: string) {
+    super(`Kubernetes API request timed out after ${KUBE_REQUEST_DEADLINE_MS / 1000}s: ${path}`);
+    this.name = 'RequestDeadlineError';
+  }
+}
 
 /**
  * Authenticated HTTP access to arbitrary API server paths for the things the
@@ -66,7 +75,7 @@ export class RawClient {
     return agent;
   }
 
-  private async requestOnce(path: string, init?: { method?: string; body?: string; headers?: Record<string, string>; signal?: AbortSignal }): Promise<Response> {
+  private async requestOnce(path: string, init?: RawRequestInit): Promise<Response> {
     const requestInit = (await this.kc.applyToFetchOptions({})) as RequestInit;
     requestInit.agent = this.pooledAgent(requestInit.agent) as RequestInit['agent'];
     requestInit.method = init?.method ?? 'GET';
@@ -103,17 +112,50 @@ export class RawClient {
     }
   }
 
-  async request(path: string, init?: { method?: string; body?: string; headers?: Record<string, string>; signal?: AbortSignal }): Promise<Response> {
-    return this.safeGet(init, () => this.requestOnce(path, init));
+  /**
+   * Give the supplied operation one deadline, including authentication and a
+   * possible safe-GET retry. JSON operations include the response-body read;
+   * streaming operations include watch establishment. This prevents a
+   * saturated API server from parking requests through successive OS-level
+   * TCP timeouts. A caller-provided abort signal remains authoritative.
+   */
+  private async withDeadline<T>(path: string, init: RawRequestInit | undefined, run: (timedInit: RawRequestInit) => Promise<T>): Promise<T> {
+    const deadlineController = new AbortController();
+    const signal = init?.signal ? AbortSignal.any([init.signal, deadlineController.signal]) : deadlineController.signal;
+    const timedInit: RawRequestInit = { ...init, signal };
+    const deadlineError = new RequestDeadlineError(path);
+    let timedOut = false;
+    let timer: NodeJS.Timeout;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        deadlineController.abort(deadlineError);
+        reject(deadlineError);
+      }, KUBE_REQUEST_DEADLINE_MS);
+      timer.unref();
+    });
+
+    try {
+      return await Promise.race([run(timedInit), deadline]);
+    } catch (err) {
+      if (timedOut) throw deadlineError;
+      throw err;
+    } finally {
+      clearTimeout(timer!);
+    }
+  }
+
+  async request(path: string, init?: RawRequestInit): Promise<Response> {
+    return this.withDeadline(path, init, (timedInit) => this.safeGet(timedInit, () => this.requestOnce(path, timedInit)));
   }
 
   /** GET/mutate a JSON API path; throws ApiException on non-2xx. */
-  async json<T = unknown>(path: string, init?: { method?: string; body?: string; headers?: Record<string, string>; signal?: AbortSignal }): Promise<T> {
-    return this.safeGet(init, async () => {
+  async json<T = unknown>(path: string, init?: RawRequestInit): Promise<T> {
+    return this.withDeadline(path, init, (timedInit) => this.safeGet(timedInit, async () => {
       // Keep the response-body read inside the retry boundary: an API server
       // can reset a pooled connection after sending headers but before the
       // complete JSON list has arrived.
-      const res = await this.requestOnce(path, init);
+      const res = await this.requestOnce(path, timedInit);
       const text = await res.text();
       if (!res.ok) {
         let body: unknown = text;
@@ -129,7 +171,7 @@ export class RawClient {
         throw new ApiException(res.status, message, body, {});
       }
       return (text ? JSON.parse(text) : undefined) as T;
-    });
+    }));
   }
 
   /**

--- a/server/src/kube/search-index.ts
+++ b/server/src/kube/search-index.ts
@@ -11,7 +11,6 @@ const START_CONCURRENCY = 16;
 const MIN_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
 const WATCH_FORBIDDEN_RELIST_MS = 60_000;
-const CRD_RECONCILE_DEBOUNCE_MS = 1_000;
 const DISCOVERY_SAFETY_RECONCILE_MS = 5 * 60_000;
 const METADATA_LIST_ACCEPT = 'application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json';
 const METADATA_WATCH_ACCEPT = 'application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json';
@@ -88,7 +87,11 @@ function labelsText(labels: Record<string, string> | undefined): string | undefi
 
 function shouldIndexKind(kind: ResourceKindInfo): boolean {
   if (!kind.verbs.includes('list') || !kind.verbs.includes('watch')) return false;
-  return !!kind.custom || BUILTIN_RESOURCE_SEARCH_KINDS.has(gvrKey(kind));
+  // Custom-resource cardinality is unbounded. Watching every served CRD made
+  // each Kubus session consume hundreds of persistent API-server connections.
+  // Custom kinds remain searchable through discovery; only instance-name
+  // search is restricted to this fixed built-in set.
+  return BUILTIN_RESOURCE_SEARCH_KINDS.has(gvrKey(kind));
 }
 
 function apiStatusCode(err: unknown): number | undefined {
@@ -135,12 +138,10 @@ async function mapWithConcurrency<T>(items: T[], concurrency: number, fn: (item:
 }
 
 /**
- * Live, names-only search index.
- *
- * The index does one metadata-only LIST per searchable GVR, then keeps that
- * GVR current with a metadata watch. Search reads the in-memory entries and
- * never triggers full scans. If a watch expires with 410, only that GVR is
- * relisted. CRD changes invalidate discovery and reconcile the watched GVR set.
+ * Bounded live, names-only search index for a fixed set of built-in kinds.
+ * It starts lazily when global search is first used, does one metadata-only
+ * LIST per GVR, then keeps that GVR current with a metadata watch. Custom kinds
+ * remain discoverable by kind but their instances are deliberately not watched.
  */
 export class ResourceSearchIndex {
   private entriesById = new Map<string, IndexedResourceSearchEntry>();
@@ -151,9 +152,7 @@ export class ResourceSearchIndex {
   private started = false;
   private disposed = false;
   private reconcileInFlight?: Promise<void>;
-  private reconcileTimer?: NodeJS.Timeout;
   private safetyReconcileTimer?: NodeJS.Timeout;
-  private crdAbort?: AbortController;
   private readonly lifecycleAbort = new AbortController();
 
   constructor(
@@ -166,17 +165,17 @@ export class ResourceSearchIndex {
     if (this.started || this.disposed) return;
     this.started = true;
     void this.reconcileKinds();
-    this.startCrdWatch();
-    this.safetyReconcileTimer = setInterval(() => this.scheduleReconcile(true), DISCOVERY_SAFETY_RECONCILE_MS);
+    this.safetyReconcileTimer = setInterval(() => {
+      this.discovery.invalidate();
+      void this.reconcileKinds();
+    }, DISCOVERY_SAFETY_RECONCILE_MS);
     this.safetyReconcileTimer.unref();
   }
 
   dispose(): void {
     this.disposed = true;
     this.lifecycleAbort.abort();
-    if (this.reconcileTimer) clearTimeout(this.reconcileTimer);
     if (this.safetyReconcileTimer) clearInterval(this.safetyReconcileTimer);
-    this.crdAbort?.abort();
     for (const state of this.kinds.values()) this.stopKind(state);
     this.kinds.clear();
     this.entriesById.clear();
@@ -187,6 +186,10 @@ export class ResourceSearchIndex {
   /** Shared snapshot — callers must not mutate the returned array. */
   async entries(): Promise<IndexedResourceSearchEntry[]> {
     this.warm();
+    // With lazy startup, the first search request owns the initial warmup.
+    // Wait for the bounded built-in lists so that request returns real results
+    // instead of an empty transient snapshot.
+    await this.reconcileInFlight;
     this.entriesSnapshot ??= [...this.entriesById.values()];
     return this.entriesSnapshot;
   }
@@ -194,17 +197,6 @@ export class ResourceSearchIndex {
   isReconciling(): boolean {
     this.warm();
     return !!this.reconcileInFlight;
-  }
-
-  private scheduleReconcile(invalidateDiscovery: boolean): void {
-    if (this.disposed) return;
-    if (invalidateDiscovery) this.discovery.invalidate();
-    if (this.reconcileTimer) return;
-    this.reconcileTimer = setTimeout(() => {
-      this.reconcileTimer = undefined;
-      void this.reconcileKinds();
-    }, CRD_RECONCILE_DEBOUNCE_MS);
-    this.reconcileTimer.unref();
   }
 
   private async reconcileKinds(): Promise<void> {
@@ -513,65 +505,4 @@ export class ResourceSearchIndex {
     else this.upsertEntry(state, metadata);
   }
 
-  private startCrdWatch(): void {
-    void this.crdWatchLoop();
-  }
-
-  private async listCrdResourceVersion(): Promise<string> {
-    const query = new URLSearchParams({ limit: '1' });
-    const list = await this.metadataJson<MetadataList>(resourcePath('apiextensions.k8s.io', 'v1', 'customresourcedefinitions', { query }));
-    return list.metadata?.resourceVersion ?? '';
-  }
-
-  private async crdWatchLoop(): Promise<void> {
-    let rv = '';
-    let backoff = MIN_BACKOFF_MS;
-    while (!this.disposed) {
-      try {
-        if (!rv) rv = await this.listCrdResourceVersion();
-        this.crdAbort = new AbortController();
-        const query = new URLSearchParams({
-          watch: '1',
-          resourceVersion: rv,
-          allowWatchBookmarks: 'true',
-          timeoutSeconds: '300',
-        });
-        const path = resourcePath('apiextensions.k8s.io', 'v1', 'customresourcedefinitions', { query });
-        const res = await this.metadataStream(path, this.crdAbort.signal);
-        const body = res.body;
-        if (!body) throw new Error('CRD watch response had no body');
-        backoff = MIN_BACKOFF_MS;
-
-        let buffer = '';
-        for await (const chunk of body) {
-          buffer += chunk.toString('utf8');
-          let nl: number;
-          while ((nl = buffer.indexOf('\n')) >= 0) {
-            const line = buffer.slice(0, nl).trim();
-            buffer = buffer.slice(nl + 1);
-            if (!line) continue;
-            const event = JSON.parse(line) as WatchLine;
-            if (event.type === 'ERROR') {
-              if (event.object?.code === 410) throw apiException(410, event.object?.message ?? '410 Gone', event.object);
-              throw new Error(`CRD watch error: ${event.object?.message ?? 'unknown'}`);
-            }
-            const nextRv = event.object?.metadata?.resourceVersion;
-            if (nextRv) rv = nextRv;
-            if (event.type !== 'BOOKMARK') this.scheduleReconcile(true);
-          }
-        }
-      } catch (err) {
-        if (this.disposed) return;
-        if (isGone(err)) {
-          rv = '';
-          this.scheduleReconcile(true);
-          continue;
-        }
-        if (isUnavailable(err)) return;
-        this.log.debug({ err: String(err) }, 'search index CRD watch failed');
-        if (!(await this.waitForRetry(backoff))) return;
-        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
-      }
-    }
-  }
 }

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -915,8 +915,6 @@ export interface ClusterOverview {
     crds: number;
     crdsEstablished: number;
     crdsUnavailable: boolean;
-    customResources: number;
-    customResourcesIndexed: boolean;
   };
   failingPods: OverviewProblemPod[];
   unavailableWorkloads: OverviewWorkloadIssue[];

--- a/tests/unit/client/overview-page.test.tsx
+++ b/tests/unit/client/overview-page.test.tsx
@@ -44,8 +44,6 @@ beforeEach(() => {
       crds: 0,
       crdsEstablished: 0,
       crdsUnavailable: false,
-      customResources: 0,
-      customResourcesIndexed: true,
     },
     failingPods: [],
     unavailableWorkloads: [],

--- a/tests/unit/server/cluster-manager.test.ts
+++ b/tests/unit/server/cluster-manager.test.ts
@@ -242,7 +242,7 @@ describe('ClusterHandle', () => {
       ['', 'v1', 'namespaces'],
     ]);
     await vi.advanceTimersByTimeAsync(1000);
-    expect(warm).toHaveBeenCalledTimes(1);
+    expect(warm).not.toHaveBeenCalled();
 
     handle.dispose();
     expect(metricsStop).toHaveBeenCalled();

--- a/tests/unit/server/raw-client.test.ts
+++ b/tests/unit/server/raw-client.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { isRetryableTransportError, resourcePath } from '../../../server/src/kube/raw-client.js';
+import type { KubeConfig } from '@kubernetes/client-node';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { KUBE_REQUEST_DEADLINE_MS, RawClient, isRetryableTransportError, resourcePath } from '../../../server/src/kube/raw-client.js';
+
+interface RawClientInternals {
+  withDeadline<T>(
+    path: string,
+    init: { method?: string; signal?: AbortSignal } | undefined,
+    run: (init: { method?: string; signal?: AbortSignal }) => Promise<T>,
+  ): Promise<T>;
+  safeGet<T>(init: { method?: string; signal?: AbortSignal } | undefined, run: () => Promise<T>): Promise<T>;
+}
+
+afterEach(() => vi.useRealTimers());
 
 describe('resourcePath', () => {
   it('uses /api for the core group and /apis otherwise', () => {
@@ -64,5 +76,40 @@ describe('isRetryableTransportError', () => {
     expect(isRetryableTransportError(wrap(wrap(wrap(reset))))).toBe(true);
     // Depth cap: the fifth object in the chain is never inspected.
     expect(isRetryableTransportError(wrap(wrap(wrap(wrap(reset)))))).toBe(false);
+  });
+});
+
+describe('RawClient request deadline', () => {
+  it('bounds the whole operation and does not retry after the deadline aborts', async () => {
+    vi.useFakeTimers();
+    const raw = new RawClient({} as KubeConfig) as unknown as RawClientInternals;
+    let attempts = 0;
+    const request = raw.withDeadline('/api/v1/pods', undefined, (init) =>
+      raw.safeGet(init, async () => {
+        attempts += 1;
+        await new Promise<never>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { code: 'ETIMEDOUT' })), { once: true });
+        });
+      }),
+    );
+
+    const rejection = expect(request).rejects.toThrow('Kubernetes API request timed out after 15s: /api/v1/pods');
+    await vi.advanceTimersByTimeAsync(KUBE_REQUEST_DEADLINE_MS);
+    await rejection;
+    expect(attempts).toBe(1);
+  });
+
+  it('preserves a caller abort instead of reporting a deadline', async () => {
+    vi.useFakeTimers();
+    const raw = new RawClient({} as KubeConfig) as unknown as RawClientInternals;
+    const caller = new AbortController();
+    const request = raw.withDeadline('/version', { signal: caller.signal }, async (init) => {
+      await new Promise<never>((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new Error('caller stopped')), { once: true });
+      });
+    });
+
+    caller.abort();
+    await expect(request).rejects.toThrow('caller stopped');
   });
 });

--- a/tests/unit/server/search-index.test.ts
+++ b/tests/unit/server/search-index.test.ts
@@ -33,11 +33,8 @@ interface SearchIndexInternals {
   started: boolean;
   disposed: boolean;
   reconcileInFlight?: Promise<void>;
-  reconcileTimer?: NodeJS.Timeout;
   safetyReconcileTimer?: NodeJS.Timeout;
-  crdAbort?: AbortController;
   warm(): void;
-  scheduleReconcile(invalidateDiscovery: boolean): void;
   reconcileKinds(): Promise<void>;
   reconcileKindsNow(): Promise<void>;
   startKind(kind: ResourceKindInfo): Promise<void>;
@@ -56,9 +53,6 @@ interface SearchIndexInternals {
   waitForRetry(ms: number): Promise<boolean>;
   watchKindOnce(state: KindState): Promise<void>;
   processKindWatchLine(state: KindState, event: { type: string; object?: { metadata?: Metadata; code?: number; message?: string } }): void;
-  startCrdWatch(): void;
-  listCrdResourceVersion(): Promise<string>;
-  crdWatchLoop(): Promise<void>;
 }
 
 function kind(overrides: Partial<ResourceKindInfo> = {}): ResourceKindInfo {
@@ -254,13 +248,15 @@ describe('ResourceSearchIndex reconciliation and lifecycle', () => {
     vi.restoreAllMocks();
   });
 
-  it('selects watchable built-ins/custom kinds, deduplicates versions, and removes obsolete kinds', async () => {
+  it('bounds indexing to watchable built-ins, deduplicates versions, and removes obsolete kinds', async () => {
     const podV1 = kind();
     const podOld = kind({ version: 'v1beta1' });
-    const custom = kind({ group: 'example.com', kind: 'Widget', plural: 'widgets', custom: true });
+    const customResources = Array.from({ length: 200 }, (_, i) =>
+      kind({ group: `example-${i}.com`, kind: `Widget${i}`, plural: `widgets${i}`, custom: true }),
+    );
     const ignoredCustom = kind({ group: 'example.com', kind: 'Ignored', plural: 'ignoreds', custom: true, verbs: ['list'] });
     const ignoredBuiltIn = kind({ group: '', kind: 'Event', plural: 'events' });
-    const { internals } = createHarness({ resources: [podV1, podOld, custom, ignoredCustom, ignoredBuiltIn] });
+    const { internals } = createHarness({ resources: [podV1, podOld, ...customResources, ignoredCustom, ignoredBuiltIn] });
 
     const obsolete = state(kind({ group: 'apps', kind: 'Deployment', plural: 'deployments' }));
     internals.upsertEntry(obsolete, { name: 'old', uid: 'old' });
@@ -271,33 +267,23 @@ describe('ResourceSearchIndex reconciliation and lifecycle', () => {
     });
 
     await internals.reconcileKindsNow();
-    expect(starts).toEqual([podV1, custom]);
+    expect(starts).toEqual([podV1]);
     expect(obsolete.running).toBe(false);
     expect(internals.entriesById.size).toBe(0);
 
     internals.disposed = true;
     await internals.reconcileKindsNow();
-    expect(starts).toHaveLength(2);
+    expect(starts).toHaveLength(1);
   });
 
-  it('coalesces scheduled and in-flight reconciliation and handles discovery failure', async () => {
+  it('handles discovery failure without disturbing the existing index', async () => {
     const { internals, discovery, log } = createHarness();
-    const reconcile = vi.fn(async () => {});
-    internals.reconcileKinds = reconcile;
-
-    internals.scheduleReconcile(true);
-    internals.scheduleReconcile(false);
-    expect(discovery.invalidate).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(reconcile).toHaveBeenCalledTimes(1);
-
+    const existing = state();
+    internals.kinds.set(existing.key, existing);
     discovery.getResources.mockRejectedValueOnce(new Error('discovery down'));
     await internals.reconcileKindsNow();
     expect(log.debug).toHaveBeenCalledWith(expect.objectContaining({ err: 'Error: discovery down' }), 'search index discovery failed');
-
-    internals.disposed = true;
-    internals.scheduleReconcile(true);
-    expect(discovery.invalidate).toHaveBeenCalledTimes(1);
+    expect(internals.kinds.get(existing.key)).toBe(existing);
   });
 
   it('starts kinds successfully and classifies unavailable and transient list failures', async () => {
@@ -406,79 +392,27 @@ describe('ResourceSearchIndex reconciliation and lifecycle', () => {
   it('warms once, exposes reconciliation state, and disposes timers, watches, and data', async () => {
     const { index, internals } = createHarness();
     const reconcile = vi.fn(async () => {});
-    const crd = vi.fn();
     internals.reconcileKinds = reconcile;
-    internals.startCrdWatch = crd;
 
     index.warm();
     index.warm();
     expect(reconcile).toHaveBeenCalledTimes(1);
-    expect(crd).toHaveBeenCalledTimes(1);
     expect(index.isReconciling()).toBe(false);
 
     const pending = Promise.resolve();
     internals.reconcileInFlight = pending;
     expect(index.isReconciling()).toBe(true);
-    internals.reconcileTimer = setTimeout(() => {}, 1000);
     internals.safetyReconcileTimer = setInterval(() => {}, 1000);
-    internals.crdAbort = new AbortController();
-    const abortSpy = vi.spyOn(internals.crdAbort, 'abort');
     const podState = state();
     podState.abort = new AbortController();
     internals.kinds.set(podState.key, podState);
     internals.upsertEntry(podState, { name: 'a', uid: 'a' });
 
     index.dispose();
-    expect(abortSpy).toHaveBeenCalled();
     expect(podState.running).toBe(false);
     expect(internals.kinds.size).toBe(0);
     expect(internals.entriesById.size).toBe(0);
     index.warm();
     expect(reconcile).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('ResourceSearchIndex CRD watch', () => {
-  it('reads the CRD resource version and schedules discovery reconciliation for changes', async () => {
-    const events = [
-      JSON.stringify({ type: 'BOOKMARK', object: { metadata: { resourceVersion: '2' } } }),
-      JSON.stringify({ type: 'MODIFIED', object: { metadata: { resourceVersion: '3' } } }),
-      '',
-    ].join('\n');
-    const { internals, raw } = createHarness({
-      json: async () => ({ metadata: { resourceVersion: '1' } }),
-      request: async () => streamResponse(events),
-    });
-    expect(await internals.listCrdResourceVersion()).toBe('1');
-    expect(raw.json.mock.calls[0]![0]).toContain('customresourcedefinitions?limit=1');
-
-    internals.scheduleReconcile = vi.fn(() => {
-      internals.disposed = true;
-    });
-    await internals.crdWatchLoop();
-    expect(internals.scheduleReconcile).toHaveBeenCalledWith(true);
-  });
-
-  it('handles missing bodies, expired watches, forbidden access, and retry exhaustion', async () => {
-    const missing = createHarness({ request: async () => ({ ok: true, body: null }) as unknown as Response });
-    missing.internals.waitForRetry = vi.fn(async () => false);
-    await missing.internals.crdWatchLoop();
-    expect(missing.log.debug).toHaveBeenCalledWith(expect.anything(), 'search index CRD watch failed');
-
-    const gone = createHarness({ request: async () => streamResponse(`${JSON.stringify({ type: 'ERROR', object: { code: 410 } })}\n`) });
-    gone.internals.scheduleReconcile = vi.fn(() => {
-      gone.internals.disposed = true;
-    });
-    await gone.internals.crdWatchLoop();
-    expect(gone.internals.scheduleReconcile).toHaveBeenCalledWith(true);
-
-    const forbidden = createHarness({ request: async () => streamResponse('denied', 403) });
-    await forbidden.internals.crdWatchLoop();
-    expect(forbidden.log.debug).not.toHaveBeenCalled();
-
-    const failed = createHarness({ request: async () => streamResponse(`${JSON.stringify({ type: 'ERROR', object: { code: 500 } })}\n`) });
-    failed.internals.waitForRetry = vi.fn(async () => false);
-    await failed.internals.crdWatchLoop();
-    expect(failed.log.debug).toHaveBeenCalledWith(expect.anything(), 'search index CRD watch failed');
   });
 });


### PR DESCRIPTION
## AI assistance disclosure

This PR was generated with assistance from an LLM. The LLM helped investigate the issue, instrument and run the controlled load tests, implement the fix, and create the regression tests.

## Issue

After my colleagues started using Kubus, the k8s API endpoint became unresponsive because of the connection exhaustion.

You can simulate the same error by running multiple instances at a time sending requests.

## Summary

Prevent Kubus instances from exhausting Kubernetes API server connections by making the global resource search index lazy and bounding it to a fixed set of built-in resource kinds.

## Root cause

Each connected Kubus instance eagerly started a search index that opened a persistent watch for every watchable resource type, including every custom resource definition.

## Changes

- Do not start the global search index when a cluster connects
- Start indexing lazily when global search is first used
- Restrict instance-name indexing to 13 built-in resource kinds
- Stop watching every custom resource type
- Remove the redundant CRD reconciliation watch
- Remove the overview custom-resource instance count that implicitly activated the index
- Add a shared 15-second Kubernetes API request deadline
  - Covers authentication, JSON response bodies, retries, and watch establishment
  - Prevents a retry from starting a second full timeout period
  - Preserves caller cancellation
  - Never retries mutating requests

Custom resource kinds remain searchable through discovery. Only custom-resource instance-name search is no longer globally indexed.

## Impact

A normal cluster connection now creates zero global-search watches instead of approximately 150–180.

Using global search creates at most 13 bounded watches, independent of the number of installed CRDs.

## Testing

- Production build passed
- Typecheck passed
- Lint passed
- Targeted regression tests: 42/42 passed
- Full unit suite: 970/970 passed
- Regression test supplies 200 custom resource kinds and verifies that only the permitted built-in watcher is started
- Request deadline tests verify timeout behavior, retry bounds, and caller cancellation