### PR TITLE
feat: configurable debug container image catalog

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -50,6 +50,7 @@ import type {
   RolloutRevision,
   DebugPodRequest,
   DebugPodResponse,
+  DebugImagePreset,
   StopDebugRequest,
   HelmRepo,
   HelmChartSummary,
@@ -722,6 +723,34 @@ export function useStopDebug() {
     onSuccess: () => {
       setTimeout(() => void qc.invalidateQueries({ queryKey: ['resource'] }), 1500);
     },
+  });
+}
+
+// ---- Debug image presets (settings-backed, app-global) ----
+
+export function useDebugImages() {
+  return useQuery({
+    queryKey: ['debug-images'],
+    queryFn: () => apiFetch<DebugImagePreset[]>('/api/settings/debug-images'),
+  });
+}
+
+export function useAddDebugImage() {
+  const qc = useQueryClient();
+  return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
+    mutationFn: (preset: DebugImagePreset) =>
+      apiFetch<DebugImagePreset>('/api/settings/debug-images', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(preset) }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['debug-images'] }),
+  });
+}
+
+export function useRemoveDebugImage() {
+  const qc = useQueryClient();
+  return useMutation({
+    meta: LOCAL_ERROR_HANDLING_META,
+    mutationFn: (name: string) => apiFetch(`/api/settings/debug-images/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ['debug-images'] }),
   });
 }
 

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -17,6 +17,8 @@ import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import InputLabel from '@mui/material/InputLabel';
 import LinearProgress from '@mui/material/LinearProgress';
+import List from '@mui/material/List';
+import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
@@ -55,6 +57,7 @@ import { gvkForResource, type DebugProfile, type KubeObject, type LogTargetKind 
 import {
   resolveLogTargetPods,
   useCordon,
+  useDebugImages,
   useDebugPod,
   useDeleteResource,
   useDrain,
@@ -77,6 +80,7 @@ import { FileCopyDialog } from './FileCopyDialog.js';
 import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
 import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
 import { execTargetContainer, podContainerNames } from '../kube-display.js';
+import { isBuiltInDebugImage, mergeDebugPresets } from '../debug-presets.js';
 import { splitImageRef } from '../image-ref.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detailPathForRef, favoriteForRef, kindListPath, shareLinkForPath } from '../resource-links.js';
@@ -1144,20 +1148,6 @@ export function SetImageDialog({
   );
 }
 
-/**
- * Version-pinned so a preset never silently changes underneath a user; the
- * field stays free-text for anything else. `profile` marks presets whose
- * tooling is useless without extra capabilities — selecting one adjusts the
- * profile dropdown.
- */
-const DEBUG_IMAGE_PRESETS: Array<{ label: string; image: string; hint: string; profile?: DebugProfile }> = [
-  { label: 'busybox', image: 'busybox:1.36', hint: 'Minimal shell and coreutils (~2 MB).' },
-  { label: 'DebugBox lite', image: 'ghcr.io/ibtisam-iq/debugbox:lite-1.2.0', hint: 'curl, dig, jq, yq (~15 MB) — DNS and HTTP checks.' },
-  { label: 'DebugBox balanced', image: 'ghcr.io/ibtisam-iq/debugbox:1.2.0', hint: 'Adds bash, vim, tcpdump, strace, openssl (~47 MB).' },
-  { label: 'DebugBox power', image: 'ghcr.io/ibtisam-iq/debugbox:power-1.2.0', hint: 'tshark, nmap, iptables, nftables (~91 MB) — needs the network admin profile.', profile: 'netadmin' },
-  { label: 'netshoot', image: 'nicolaka/netshoot:v0.16', hint: 'The kitchen-sink network toolbox (~200 MB).' },
-];
-
 const DEBUG_PROFILES: Array<{ value: DebugProfile; label: string; hint: string }> = [
   { value: 'general', label: 'General', hint: 'No extra privileges — inherits the namespace defaults.' },
   { value: 'restricted', label: 'Restricted', hint: 'Non-root, all capabilities dropped — for PodSecurity-restricted namespaces (needs a non-root image).' },
@@ -1165,15 +1155,20 @@ const DEBUG_PROFILES: Array<{ value: DebugProfile; label: string; hint: string }
   { value: 'sysadmin', label: 'System admin', hint: 'Privileged container — full access, rejected in restricted namespaces.' },
 ];
 
+const CUSTOM_DEBUG_IMAGE = '__custom__';
+
 function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTarget; onClose: () => void; onDone: (t: string) => void; onError: (e: unknown) => void }) {
   const debug = useDebugPod();
   const addTab = useDockStore((s) => s.addTab);
   const containers = podContainerNames(target.obj);
-  const [image, setImage] = useState('busybox:1.36');
+  const presets = mergeDebugPresets(useDebugImages().data);
+  const [selection, setSelection] = useState('busybox');
+  const [customImage, setCustomImage] = useState('');
   const [targetContainer, setTargetContainer] = useState(containers[0] ?? '');
   const [profile, setProfile] = useState<DebugProfile>('general');
   const name = target.obj.metadata.name;
-  const imagePreset = DEBUG_IMAGE_PRESETS.find((p) => p.image === image);
+  const isCustom = selection === CUSTOM_DEBUG_IMAGE;
+  const image = isCustom ? customImage.trim() : (presets.find((p) => p.name === selection)?.image ?? '');
   return (
     <Dialog open onClose={debug.isPending ? undefined : onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Debug container — {name}</DialogTitle>
@@ -1182,25 +1177,54 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
           Attaches an ephemeral debug container to the running pod (like <code>kubectl debug</code>) and opens a shell into it. The
           container stays in the pod spec until the pod is recreated.
         </Typography>
-        <TextField autoFocus fullWidth label="Image" value={image} onChange={(e) => setImage(e.target.value)} />
-        <Stack direction="row" spacing={1} sx={{ mt: -1, flexWrap: 'wrap' }}>
-          {DEBUG_IMAGE_PRESETS.map((p) => (
-            <Chip
-              key={p.image}
-              label={p.label}
-              size="small"
-              variant={image === p.image ? 'filled' : 'outlined'}
+        <List dense sx={{ py: 0, maxHeight: 280, overflowY: 'auto', border: 1, borderColor: 'divider', borderRadius: 1 }}>
+          {presets.map((p) => (
+            <ListItemButton
+              key={p.name}
+              selected={!isCustom && selection === p.name}
               onClick={() => {
-                setImage(p.image);
+                setSelection(p.name);
                 if (p.profile) setProfile(p.profile);
               }}
-            />
+            >
+              <ListItemText
+                primary={
+                  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                    <Typography variant="body2">{p.name}</Typography>
+                    {!isBuiltInDebugImage(p.name) && <Chip size="small" variant="outlined" label="custom" sx={{ height: 18, fontSize: 10 }} />}
+                    {p.profile && p.profile !== 'general' && (
+                      <Chip
+                        size="small"
+                        variant="outlined"
+                        label={DEBUG_PROFILES.find((d) => d.value === p.profile)?.label ?? p.profile}
+                        sx={{ height: 18, fontSize: 10 }}
+                      />
+                    )}
+                  </Stack>
+                }
+                secondary={p.description ? `${p.image} — ${p.description}` : p.image}
+                slotProps={{ secondary: { sx: { fontSize: 11 } } }}
+              />
+            </ListItemButton>
           ))}
-        </Stack>
-        {imagePreset && (
-          <Typography variant="caption" color="text.secondary" sx={{ mt: -1 }}>
-            {imagePreset.hint}
-          </Typography>
+          <ListItemButton selected={isCustom} onClick={() => setSelection(CUSTOM_DEBUG_IMAGE)}>
+            <ListItemText
+              primary={<Typography variant="body2">Custom image…</Typography>}
+              secondary="Any image reference from any registry"
+              slotProps={{ secondary: { sx: { fontSize: 11 } } }}
+            />
+          </ListItemButton>
+        </List>
+        {isCustom && (
+          <TextField
+            autoFocus
+            fullWidth
+            size="small"
+            label="Image"
+            placeholder="registry.example.com/debug:tag"
+            value={customImage}
+            onChange={(e) => setCustomImage(e.target.value)}
+          />
         )}
         <FormControl size="small" fullWidth>
           <InputLabel id="debug-target">Target container (shared process namespace)</InputLabel>
@@ -1233,10 +1257,10 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
         </Button>
         <Button
           variant="contained"
-          disabled={debug.isPending || !image.trim()}
+          disabled={debug.isPending || !image}
           onClick={() =>
             debug.mutate(
-              { ctx: target.ctx, body: { namespace: target.obj.metadata.namespace ?? '', pod: name, image: image.trim(), target: targetContainer || undefined, profile } },
+              { ctx: target.ctx, body: { namespace: target.obj.metadata.namespace ?? '', pod: name, image, target: targetContainer || undefined, profile } },
               {
                 onSuccess: ({ containerName }) => {
                   onClose();

--- a/client/src/components/RowActions.tsx
+++ b/client/src/components/RowActions.tsx
@@ -80,7 +80,7 @@ import { FileCopyDialog } from './FileCopyDialog.js';
 import { TriggerCronJobDialog } from './TriggerCronJobDialog.js';
 import { PortForwardDialog, isForwardableKind } from './PortForwardDialog.js';
 import { execTargetContainer, podContainerNames } from '../kube-display.js';
-import { isBuiltInDebugImage, mergeDebugPresets } from '../debug-presets.js';
+import { isBuiltInDebugImage, mergeDebugPresets, normalizeDebugImageName } from '../debug-presets.js';
 import { splitImageRef } from '../image-ref.js';
 import { copyToClipboard } from '../clipboard.js';
 import { detailPathForRef, favoriteForRef, kindListPath, shareLinkForPath } from '../resource-links.js';
@@ -1155,20 +1155,22 @@ const DEBUG_PROFILES: Array<{ value: DebugProfile; label: string; hint: string }
   { value: 'sysadmin', label: 'System admin', hint: 'Privileged container — full access, rejected in restricted namespaces.' },
 ];
 
-const CUSTOM_DEBUG_IMAGE = '__custom__';
-
 function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTarget; onClose: () => void; onDone: (t: string) => void; onError: (e: unknown) => void }) {
   const debug = useDebugPod();
   const addTab = useDockStore((s) => s.addTab);
   const containers = podContainerNames(target.obj);
-  const presets = mergeDebugPresets(useDebugImages().data);
-  const [selection, setSelection] = useState('busybox');
+  const debugImages = useDebugImages();
+  const presets = mergeDebugPresets(debugImages.data);
+  const [selection, setSelection] = useState<string | null>('busybox');
   const [customImage, setCustomImage] = useState('');
   const [targetContainer, setTargetContainer] = useState(containers[0] ?? '');
-  const [profile, setProfile] = useState<DebugProfile>('general');
+  const [profileOverride, setProfileOverride] = useState<DebugProfile>();
   const name = target.obj.metadata.name;
-  const isCustom = selection === CUSTOM_DEBUG_IMAGE;
-  const image = isCustom ? customImage.trim() : (presets.find((p) => p.name === selection)?.image ?? '');
+  const isCustom = selection === null;
+  const normalizedSelection = selection === null ? null : normalizeDebugImageName(selection);
+  const selectedPreset = normalizedSelection === null ? undefined : presets.find((p) => normalizeDebugImageName(p.name) === normalizedSelection);
+  const image = isCustom ? customImage.trim() : (selectedPreset?.image ?? '');
+  const profile = profileOverride ?? selectedPreset?.profile ?? 'general';
   return (
     <Dialog open onClose={debug.isPending ? undefined : onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Debug container — {name}</DialogTitle>
@@ -1181,10 +1183,10 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
           {presets.map((p) => (
             <ListItemButton
               key={p.name}
-              selected={!isCustom && selection === p.name}
+              selected={!isCustom && normalizedSelection === normalizeDebugImageName(p.name)}
               onClick={() => {
                 setSelection(p.name);
-                if (p.profile) setProfile(p.profile);
+                setProfileOverride(undefined);
               }}
             >
               <ListItemText
@@ -1207,7 +1209,7 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
               />
             </ListItemButton>
           ))}
-          <ListItemButton selected={isCustom} onClick={() => setSelection(CUSTOM_DEBUG_IMAGE)}>
+          <ListItemButton selected={isCustom} onClick={() => setSelection(null)}>
             <ListItemText
               primary={<Typography variant="body2">Custom image…</Typography>}
               secondary="Any image reference from any registry"
@@ -1239,7 +1241,7 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
         </FormControl>
         <FormControl size="small" fullWidth>
           <InputLabel id="debug-profile">Profile</InputLabel>
-          <Select labelId="debug-profile" label="Profile" value={profile} onChange={(e) => setProfile(e.target.value as DebugProfile)}>
+          <Select labelId="debug-profile" label="Profile" value={profile} onChange={(e) => setProfileOverride(e.target.value as DebugProfile)}>
             {DEBUG_PROFILES.map((p) => (
               <MenuItem key={p.value} value={p.value}>
                 {p.label}
@@ -1257,7 +1259,7 @@ function DebugDialog({ target, onClose, onDone, onError }: { target: RowActionTa
         </Button>
         <Button
           variant="contained"
-          disabled={debug.isPending || !image}
+          disabled={debug.isPending || debugImages.data === undefined || !image}
           onClick={() =>
             debug.mutate(
               { ctx: target.ctx, body: { namespace: target.obj.metadata.namespace ?? '', pod: name, image, target: targetContainer || undefined, profile } },

--- a/client/src/components/settings/SettingsDialog.tsx
+++ b/client/src/components/settings/SettingsDialog.tsx
@@ -36,8 +36,8 @@ import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import AddIcon from '@mui/icons-material/Add';
-import type { AppInfo, ContextInfo, UpdateCheckResult } from '@kubus/shared';
-import { useContexts, useDeleteCluster, useKubeconfigSettings } from '../../api/queries.js';
+import type { AppInfo, ContextInfo, DebugProfile, UpdateCheckResult } from '@kubus/shared';
+import { useAddDebugImage, useContexts, useDebugImages, useDeleteCluster, useKubeconfigSettings, useRemoveDebugImage } from '../../api/queries.js';
 import { ConfirmDialog } from '../ConfirmDialog.js';
 import { checkForUpdate, getAppInfo } from '../../api/app.js';
 import { AddClusterDialog } from './AddClusterDialog.js';
@@ -46,6 +46,7 @@ import { useClustersStore } from '../../state/clusters.js';
 import { useLogPrefsStore, type TsMode } from '../../state/log-prefs.js';
 import { TAIL_LINE_OPTIONS, useUiPrefsStore, type RefreshRate, type RightClickAction, type TableDensity } from '../../state/prefs.js';
 import { KubeconfigSection } from './KubeconfigSection.js';
+import { isBuiltInDebugImage, mergeDebugPresets } from '../../debug-presets.js';
 import { fetchAppLogs, formatLogEntry } from '../../api/logs.js';
 import { exportFilename, saveTextFile } from '../../save-file.js';
 import { showErrorToast } from '../../state/toast.js';
@@ -425,6 +426,136 @@ function LogsTerminalSection() {
   );
 }
 
+const DEBUG_PROFILE_LABELS: Record<string, string> = { general: 'General', restricted: 'Restricted', netadmin: 'Network admin', sysadmin: 'System admin' };
+
+/** The debug-container image catalog: built-in presets plus user-defined images. */
+function DebugContainersSection() {
+  const { data: images } = useDebugImages();
+  const add = useAddDebugImage();
+  const remove = useRemoveDebugImage();
+  const [name, setName] = useState('');
+  const [image, setImage] = useState('');
+  const [profile, setProfile] = useState('');
+  const [description, setDescription] = useState('');
+  const error = add.error ?? remove.error;
+  const catalog = mergeDebugPresets(images);
+  const customNames = new Set((images ?? []).map((p) => p.name));
+
+  return (
+    <Stack spacing={3}>
+      <Section title="Image catalog">
+        <Stack spacing={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            The images offered when attaching a debug container to a pod (<b>Debug container…</b> in the pod menu). A profile on an entry is
+            pre-selected with it.
+          </Typography>
+          <List dense sx={{ border: 1, borderColor: 'divider', borderRadius: 1, py: 0 }}>
+            {catalog.map((p, i) => {
+              const custom = customNames.has(p.name);
+              return (
+                <ListItem
+                  key={p.name}
+                  divider={i < catalog.length - 1}
+                  secondaryAction={
+                    custom ? (
+                      <Tooltip title={isBuiltInDebugImage(p.name) ? 'Remove and restore the built-in entry' : 'Remove'}>
+                        <IconButton size="small" disabled={remove.isPending} onClick={() => remove.mutate(p.name)}>
+                          <DeleteOutlinedIcon sx={{ fontSize: 18 }} />
+                        </IconButton>
+                      </Tooltip>
+                    ) : undefined
+                  }
+                >
+                  <ListItemText
+                    primary={
+                      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+                        <Typography variant="body2">{p.name}</Typography>
+                        <Chip
+                          size="small"
+                          variant="outlined"
+                          label={custom ? (isBuiltInDebugImage(p.name) ? 'replaces built-in' : 'custom') : 'built-in'}
+                          color={custom ? 'info' : 'default'}
+                          sx={{ height: 18, fontSize: 10 }}
+                        />
+                        {p.profile && p.profile !== 'general' && (
+                          <Chip size="small" variant="outlined" label={DEBUG_PROFILE_LABELS[p.profile]} sx={{ height: 18, fontSize: 10 }} />
+                        )}
+                      </Stack>
+                    }
+                    secondary={p.description ? `${p.image} — ${p.description}` : p.image}
+                    slotProps={{ secondary: { sx: { fontSize: 11 } } }}
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        </Stack>
+      </Section>
+      <Section title="Add image">
+        <Stack spacing={1.5}>
+          <Typography variant="caption" color="text.secondary">
+            Add your own image — an internal toolbox, a different busybox tag, anything your registry serves. An entry named like a built-in
+            replaces it. Stored in the server-side <code>settings.json</code>, next to your Helm repositories.
+          </Typography>
+          <Stack direction="row" spacing={1}>
+            <TextField size="small" label="Name" value={name} onChange={(e) => setName(e.target.value)} sx={{ width: 170 }} />
+            <TextField
+              size="small"
+              label="Image"
+              placeholder="registry.example.com/debug:tag"
+              value={image}
+              onChange={(e) => setImage(e.target.value)}
+              sx={{ flex: 1 }}
+            />
+            <FormControl size="small" sx={{ width: 170, flexShrink: 0 }}>
+              <InputLabel id="settings-debug-image-profile">Profile</InputLabel>
+              <Select labelId="settings-debug-image-profile" label="Profile" value={profile} onChange={(e) => setProfile(e.target.value)}>
+                <MenuItem value="">General (default)</MenuItem>
+                <MenuItem value="restricted">Restricted</MenuItem>
+                <MenuItem value="netadmin">Network admin</MenuItem>
+                <MenuItem value="sysadmin">System admin</MenuItem>
+              </Select>
+            </FormControl>
+          </Stack>
+          <Stack direction="row" spacing={1}>
+            <TextField size="small" label="Description (optional)" value={description} onChange={(e) => setDescription(e.target.value)} sx={{ flex: 1 }} />
+            <Button
+              variant="outlined"
+              startIcon={<AddIcon />}
+              disabled={add.isPending || !name.trim() || !image.trim()}
+              onClick={() =>
+                add.mutate(
+                  {
+                    name: name.trim(),
+                    image: image.trim(),
+                    profile: (profile || undefined) as DebugProfile | undefined,
+                    description: description.trim() || undefined,
+                  },
+                  {
+                    onSuccess: () => {
+                      setName('');
+                      setImage('');
+                      setProfile('');
+                      setDescription('');
+                    },
+                  },
+                )
+              }
+            >
+              Add
+            </Button>
+          </Stack>
+          {error && (
+            <Alert severity="error" variant="outlined">
+              {error.message}
+            </Alert>
+          )}
+        </Stack>
+      </Section>
+    </Stack>
+  );
+}
+
 /** Diagnostic logging: verbose capture plus viewer and export controls. */
 function DebugSection() {
   const debugMode = useUiPrefsStore((state) => state.debugMode);
@@ -587,7 +718,7 @@ function AboutSection() {
   );
 }
 
-const TABS = ['Kubeconfig', 'Clusters', 'Appearance', 'Data & refresh', 'Logs & terminal', 'Debug', 'About'];
+const TABS = ['Kubeconfig', 'Clusters', 'Appearance', 'Data & refresh', 'Logs & terminal', 'Debug containers', 'Diagnostics', 'About'];
 
 export function SettingsDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [tab, setTab] = useState(0);
@@ -611,8 +742,9 @@ export function SettingsDialog({ open, onClose }: { open: boolean; onClose: () =
           {tab === 2 && <AppearanceSection />}
           {tab === 3 && <RefreshSection />}
           {tab === 4 && <LogsTerminalSection />}
-          {tab === 5 && <DebugSection />}
-          {tab === 6 && <AboutSection />}
+          {tab === 5 && <DebugContainersSection />}
+          {tab === 6 && <DebugSection />}
+          {tab === 7 && <AboutSection />}
         </Box>
       </DialogContent>
       <DialogActions>

--- a/client/src/debug-presets.ts
+++ b/client/src/debug-presets.ts
@@ -1,0 +1,33 @@
+import type { DebugImagePreset } from '@kubus/shared';
+
+/**
+ * Version-pinned so a preset never silently changes underneath a user. A
+ * `profile` marks images whose tooling is useless without extra capabilities —
+ * selecting one adjusts the profile dropdown in the debug dialog.
+ */
+export const BUILT_IN_DEBUG_IMAGES: DebugImagePreset[] = [
+  { name: 'busybox', image: 'busybox:1.36', description: 'Minimal shell and coreutils (~2 MB).' },
+  { name: 'DebugBox lite', image: 'ghcr.io/ibtisam-iq/debugbox:lite-1.2.0', description: 'curl, dig, jq, yq (~15 MB) — DNS and HTTP checks.' },
+  { name: 'DebugBox balanced', image: 'ghcr.io/ibtisam-iq/debugbox:1.2.0', description: 'Adds bash, vim, tcpdump, strace, openssl (~47 MB).' },
+  { name: 'DebugBox power', image: 'ghcr.io/ibtisam-iq/debugbox:power-1.2.0', description: 'tshark, nmap, iptables, nftables (~91 MB) — needs the network admin profile.', profile: 'netadmin' },
+  { name: 'netshoot', image: 'nicolaka/netshoot:v0.16', description: 'The kitchen-sink network toolbox (~200 MB).' },
+];
+
+export function isBuiltInDebugImage(name: string): boolean {
+  return BUILT_IN_DEBUG_IMAGES.some((p) => p.name === name);
+}
+
+/**
+ * The effective catalog: user-defined images (Settings → Debug containers)
+ * extend the built-ins; one named like a built-in replaces it in place, so
+ * users can e.g. pin a different busybox tag without growing the list.
+ */
+export function mergeDebugPresets(custom: DebugImagePreset[] | undefined): DebugImagePreset[] {
+  if (!custom?.length) return BUILT_IN_DEBUG_IMAGES;
+  const byName = new Map(custom.map((c) => [c.name, c]));
+  const merged = BUILT_IN_DEBUG_IMAGES.map((p) => byName.get(p.name) ?? p);
+  for (const c of custom) {
+    if (!isBuiltInDebugImage(c.name)) merged.push(c);
+  }
+  return merged;
+}

--- a/client/src/debug-presets.ts
+++ b/client/src/debug-presets.ts
@@ -13,8 +13,13 @@ export const BUILT_IN_DEBUG_IMAGES: DebugImagePreset[] = [
   { name: 'netshoot', image: 'nicolaka/netshoot:v0.16', description: 'The kitchen-sink network toolbox (~200 MB).' },
 ];
 
+export function normalizeDebugImageName(name: string): string {
+  return name.toLowerCase();
+}
+
 export function isBuiltInDebugImage(name: string): boolean {
-  return BUILT_IN_DEBUG_IMAGES.some((p) => p.name === name);
+  const normalizedName = normalizeDebugImageName(name);
+  return BUILT_IN_DEBUG_IMAGES.some((p) => normalizeDebugImageName(p.name) === normalizedName);
 }
 
 /**
@@ -24,8 +29,8 @@ export function isBuiltInDebugImage(name: string): boolean {
  */
 export function mergeDebugPresets(custom: DebugImagePreset[] | undefined): DebugImagePreset[] {
   if (!custom?.length) return BUILT_IN_DEBUG_IMAGES;
-  const byName = new Map(custom.map((c) => [c.name, c]));
-  const merged = BUILT_IN_DEBUG_IMAGES.map((p) => byName.get(p.name) ?? p);
+  const byName = new Map(custom.map((c) => [normalizeDebugImageName(c.name), c]));
+  const merged = BUILT_IN_DEBUG_IMAGES.map((p) => byName.get(normalizeDebugImageName(p.name)) ?? p);
   for (const c of custom) {
     if (!isBuiltInDebugImage(c.name)) merged.push(c);
   }

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -70,6 +70,18 @@ Defaults for the [log viewer](logs.md) and [terminals](shell.md):
 | --- | --- | --- |
 | Default shell | Auto (`bash`→`sh`) / `sh` / `bash` / custom path | Auto |
 
+## Debug containers { #debug-containers }
+
+The image catalog offered by the [debug container](shell.md#debug-containers)
+dialog. The built-in presets (busybox, the DebugBox tiers, netshoot) are listed
+alongside your own entries — add an internal toolbox image, a different busybox
+tag, anything your registry serves. Each entry has a name, an image reference,
+an optional description and an optional security profile that is pre-selected
+with it. An entry named like a built-in preset replaces it.
+
+Your entries are stored server-side in `settings.json` (key `debugImages`),
+next to your Helm repositories.
+
 ## See also
 
 <div class="grid cards" markdown>

--- a/docs/guide/shell.md
+++ b/docs/guide/shell.md
@@ -35,14 +35,18 @@ attach an **ephemeral debug container**:
 
 - **Pod** ⋮ menu → **Debug container…**
 
-1. Choose a debug **image** (default `busybox:1.36`). Preset chips offer curated
-   images without having to remember registry paths: busybox, the three
-   [DebugBox](https://github.com/ibtisam-iq/debugbox) tiers (lite ~15 MB for
-   DNS/HTTP checks, balanced ~47 MB with tcpdump and strace, power ~91 MB with
-   tshark and nmap) and [netshoot](https://github.com/nicolaka/netshoot)
-   (~200 MB, everything). Picking **DebugBox power** switches the profile to
-   **Network admin** for you, since its tools need `NET_ADMIN`. The field stays
-   editable — any image reference works.
+1. Pick a debug **image** from the catalog (default `busybox:1.36`). The
+   built-in presets cover the common cases without having to remember registry
+   paths: busybox, the three [DebugBox](https://github.com/ibtisam-iq/debugbox)
+   tiers (lite ~15 MB for DNS/HTTP checks, balanced ~47 MB with tcpdump and
+   strace, power ~91 MB with tshark and nmap) and
+   [netshoot](https://github.com/nicolaka/netshoot) (~200 MB, everything).
+   Picking **DebugBox power** switches the profile to **Network admin** for
+   you, since its tools need `NET_ADMIN`. **Custom image…** takes any image
+   reference, and you can add your own catalog entries (an internal toolbox
+   image, a different busybox tag) in
+   [Settings → Debug containers](settings.md#debug-containers); one named like
+   a built-in preset replaces it.
 2. Optionally pick a **target container** to share a process namespace with, so you can
    see and poke at its processes.
 3. Kubus attaches the ephemeral container and drops you into a shell inside it — the same

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -104,6 +104,13 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
         return url.searchParams.get('token') === config.token;
       },
     },
+    // The renderer disappears with the desktop window and cannot always
+    // complete a WebSocket close handshake. Terminate sockets during server
+    // shutdown so app.close() cannot wait forever for an absent peer.
+    preClose(done) {
+      for (const client of this.websocketServer.clients) client.terminate();
+      this.websocketServer.close(done);
+    },
   });
 
   // Bearer-token auth for all /api routes.

--- a/server/src/debug-images.ts
+++ b/server/src/debug-images.ts
@@ -1,0 +1,50 @@
+import type { DebugImagePreset, DebugProfile } from '@kubus/shared';
+import type { SettingsStore } from './settings-store.js';
+import { HttpProblem } from './util/errors.js';
+
+/**
+ * User-defined debug container images (settings.json `debugImages`). The
+ * client offers them as preset chips next to the built-in catalog; an entry
+ * with the same name as a built-in preset replaces it, so users can e.g. pin
+ * a different busybox tag.
+ */
+
+const PROFILES = new Set<string>(['general', 'restricted', 'netadmin', 'sysadmin']);
+
+export function listDebugImages(settings: SettingsStore): DebugImagePreset[] {
+  const entries = settings.load().debugImages;
+  // settings.json is hand-editable; malformed entries must not break the debug dialog.
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .filter((e) => !!e && typeof e === 'object' && typeof e.name === 'string' && e.name.trim() !== '' && typeof e.image === 'string' && e.image.trim() !== '')
+    .map((e) => ({
+      name: e.name,
+      image: e.image,
+      description: typeof e.description === 'string' && e.description ? e.description : undefined,
+      profile: typeof e.profile === 'string' && PROFILES.has(e.profile) ? (e.profile as DebugProfile) : undefined,
+    }));
+}
+
+export function addDebugImage(settings: SettingsStore, preset: { name: string; image: string; description?: string; profile?: string }): DebugImagePreset {
+  const name = preset.name.trim();
+  const image = preset.image.trim();
+  if (!name || name.length > 40) throw new HttpProblem(422, 'name is required and may be at most 40 characters');
+  if (!image || image.length > 300) throw new HttpProblem(422, 'image is required and may be at most 300 characters');
+  if (/\s/.test(image)) throw new HttpProblem(422, 'image must be a reference without whitespace');
+  const description = preset.description?.trim() || undefined;
+  if (description && description.length > 200) throw new HttpProblem(422, 'description may be at most 200 characters');
+  const profile = preset.profile || undefined;
+  if (profile !== undefined && !PROFILES.has(profile)) throw new HttpProblem(422, `unknown debug profile ${profile}`);
+  const existing = listDebugImages(settings);
+  if (existing.some((e) => e.name.toLowerCase() === name.toLowerCase())) throw new HttpProblem(409, `debug image "${name}" already exists`);
+  const entry: DebugImagePreset = { name, image, description, profile: profile as DebugProfile | undefined };
+  settings.save({ debugImages: [...existing, entry] });
+  return entry;
+}
+
+export function removeDebugImage(settings: SettingsStore, name: string): void {
+  const entries = listDebugImages(settings);
+  const next = entries.filter((e) => e.name !== name);
+  if (next.length === entries.length) throw new HttpProblem(404, `debug image "${name}" not found`);
+  settings.save({ debugImages: next });
+}

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -9,6 +9,7 @@ import type { AppContext } from '../app.js';
 import { HttpProblem, sendError } from '../util/errors.js';
 import { mergeKubeconfig, writeKubeconfig } from '../kube/kubeconfig-file.js';
 import { authWarningForUser } from '../kube/auth-diagnostics.js';
+import { addDebugImage, listDebugImages, removeDebugImage } from '../debug-images.js';
 
 /** Credential problems (missing exec plugin, legacy auth-provider) in the users an import brings in. */
 function importAuthWarnings(incomingYaml: string, addedUsers: string[]): string[] {
@@ -86,6 +87,36 @@ export function registerSettingsRoutes(app: FastifyInstance, ctx: AppContext): v
       // the server was started with --kubeconfig; the flag wins on relaunch.
       if (p === null) ctx.cliKubeconfig = undefined;
       return kubeconfigSettings();
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  // ---- Debug container image presets (app-global, not per cluster) ----
+
+  app.get('/api/settings/debug-images', async () => listDebugImages(ctx.settings));
+
+  app.post<{ Body: { name?: unknown; image?: unknown; description?: unknown; profile?: unknown } }>('/api/settings/debug-images', async (req, reply) => {
+    try {
+      const { name, image, description, profile } = req.body ?? {};
+      if (typeof name !== 'string' || typeof image !== 'string' || !name || !image) throw new HttpProblem(422, 'name and image are required');
+      return addDebugImage(ctx.settings, {
+        name,
+        image,
+        description: typeof description === 'string' ? description : undefined,
+        profile: typeof profile === 'string' ? profile : undefined,
+      });
+    } catch (err) {
+      sendError(reply, err);
+      return reply;
+    }
+  });
+
+  app.delete<{ Params: { name: string } }>('/api/settings/debug-images/:name', async (req, reply) => {
+    try {
+      removeDebugImage(ctx.settings, req.params.name);
+      return { ok: true };
     } catch (err) {
       sendError(reply, err);
       return reply;

--- a/server/src/settings-store.ts
+++ b/server/src/settings-store.ts
@@ -10,6 +10,8 @@ export interface PersistedSettings {
   sshTunnels?: Record<string, string>;
   /** Configured Helm chart repositories (classic http(s) index.yaml repos). */
   helmRepos?: Array<{ name: string; url: string }>;
+  /** User-defined debug container images, offered alongside the built-in presets. */
+  debugImages?: Array<{ name: string; image: string; description?: string; profile?: string }>;
 }
 
 /**

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -534,6 +534,16 @@ export interface StopDebugRequest {
   container: string;
 }
 
+/** A debug-container image offered as a preset chip in the debug dialog. */
+export interface DebugImagePreset {
+  name: string;
+  image: string;
+  /** One-line hint shown while the preset is selected. */
+  description?: string;
+  /** Profile auto-selected with the image (e.g. netadmin for capture tools). */
+  profile?: DebugProfile;
+}
+
 export interface HelmRollbackResult {
   newRevision: number;
   applied: string[];

--- a/tests/unit/client/row-actions.test.tsx
+++ b/tests/unit/client/row-actions.test.tsx
@@ -40,7 +40,7 @@ const queryMocks = vi.hoisted(() => {
     scale: mutation(),
     setImage: mutation(),
     debug: mutation({ containerName: 'debugger-1' }),
-    debugImages: [] as DebugImagePreset[],
+    debugImages: [] as DebugImagePreset[] | undefined,
     drain: mutation({ drainId: 'drain-1' }),
     startPort: mutation({ localPort: 8080, remotePort: 80 }),
     create: mutation({ metadata: { name: 'manual-job' } }),
@@ -335,6 +335,14 @@ describe('pod actions', () => {
     view.unmount();
   });
 
+  it('waits for the configured debug image catalog before enabling Start', () => {
+    queryMocks.debugImages = undefined;
+    const view = clickMenuAction(pod, 'Debug container…');
+    expect(screen.getByRole('button', { name: 'Start' })).toBeDisabled();
+    expect(queryMocks.debug.mutate).not.toHaveBeenCalled();
+    view.unmount();
+  });
+
   it('accepts a free-text reference through the custom image entry', () => {
     const view = clickMenuAction(pod, 'Debug container…');
     expect(screen.queryByLabelText('Image')).not.toBeInTheDocument();
@@ -353,15 +361,17 @@ describe('pod actions', () => {
   it('offers user-defined debug images and lets one shadow a built-in preset', () => {
     queryMocks.debugImages = [
       { name: 'company toolbox', image: 'registry.acme.dev/debug:2', profile: 'sysadmin', description: 'Internal tooling.' },
-      { name: 'busybox', image: 'busybox:1.37' },
+      { name: 'Busybox', image: 'busybox:1.37', profile: 'netadmin' },
+      { name: '__custom__', image: 'registry.acme.dev/sentinel-safe:1' },
     ];
-    // The custom busybox replaces the built-in entry instead of duplicating it,
-    // and is preselected as the default — Start sends the pinned tag.
+    // Built-in shadowing follows the API's case-insensitive name rules. The
+    // replacement is selected by default together with its configured profile.
     let view = clickMenuAction(pod, 'Debug container…');
-    expect(screen.getAllByText('busybox')).toHaveLength(1);
+    expect(screen.getAllByText('Busybox')).toHaveLength(1);
+    expect(screen.queryByText('busybox')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     expect(queryMocks.debug.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ body: expect.objectContaining({ image: 'busybox:1.37' }) }),
+      expect.objectContaining({ body: expect.objectContaining({ image: 'busybox:1.37', profile: 'netadmin' }) }),
       expect.anything(),
     );
     view.unmount();
@@ -372,6 +382,18 @@ describe('pod actions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     expect(queryMocks.debug.mutate).toHaveBeenLastCalledWith(
       expect.objectContaining({ body: expect.objectContaining({ image: 'registry.acme.dev/debug:2', profile: 'sysadmin' }) }),
+      expect.anything(),
+    );
+    view.unmount();
+
+    // A saved preset can use the old sentinel string without being mistaken
+    // for the free-text custom-image choice.
+    view = clickMenuAction(pod, 'Debug container…');
+    fireEvent.click(screen.getByText('__custom__'));
+    expect(screen.queryByLabelText('Image')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    expect(queryMocks.debug.mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ image: 'registry.acme.dev/sentinel-safe:1' }) }),
       expect.anything(),
     );
     view.unmount();

--- a/tests/unit/client/row-actions.test.tsx
+++ b/tests/unit/client/row-actions.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { KubeconfigSettings, KubeObject } from '@kubus/shared';
+import type { DebugImagePreset, KubeconfigSettings, KubeObject } from '@kubus/shared';
 import {
   DetailQuickActions,
   isLogTargetKind,
@@ -40,6 +40,7 @@ const queryMocks = vi.hoisted(() => {
     scale: mutation(),
     setImage: mutation(),
     debug: mutation({ containerName: 'debugger-1' }),
+    debugImages: [] as DebugImagePreset[],
     drain: mutation({ drainId: 'drain-1' }),
     startPort: mutation({ localPort: 8080, remotePort: 80 }),
     create: mutation({ metadata: { name: 'manual-job' } }),
@@ -76,6 +77,7 @@ vi.mock('../../../client/src/api/queries.js', () => ({
   useScale: () => queryMocks.scale,
   useSetImage: () => queryMocks.setImage,
   useDebugPod: () => queryMocks.debug,
+  useDebugImages: () => ({ data: queryMocks.debugImages }),
   useDrain: () => queryMocks.drain,
   useStartPortForward: () => queryMocks.startPort,
   usePortForwardPreflight: () => ({ data: queryMocks.preflight }),
@@ -168,6 +170,7 @@ beforeEach(() => {
   queryMocks.resolveLogTargetPods.mockClear();
   queryMocks.hpas = [];
   queryMocks.services = [];
+  queryMocks.debugImages = [];
   queryMocks.preflight = { allowed: true };
   queryMocks.kubeconfig = {
     paths: ['/home/test/.kube/config'],
@@ -247,9 +250,11 @@ describe('pod actions', () => {
 
     view = clickMenuAction(pod, 'Debug container…');
     expect(screen.getByText('Debug container — pod-a')).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText('Image'), { target: { value: 'alpine:3.21' } });
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
-    expect(queryMocks.debug.mutate).toHaveBeenCalled();
+    expect(queryMocks.debug.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ image: 'busybox:1.36' }) }),
+      expect.anything(),
+    );
     expect(useDockStore.getState().tabs.at(-1)).toMatchObject({ kind: 'terminal', container: 'debugger-1' });
     view.unmount();
 
@@ -319,13 +324,54 @@ describe('pod actions', () => {
     view.unmount();
   });
 
-  it('debug image presets fill the field and pair the power tier with netadmin', () => {
+  it('debug image presets send the preset image and pair the power tier with netadmin', () => {
     const view = clickMenuAction(pod, 'Debug container…');
     fireEvent.click(screen.getByText('DebugBox power'));
-    expect(screen.getByLabelText('Image')).toHaveValue('ghcr.io/ibtisam-iq/debugbox:power-1.2.0');
     fireEvent.click(screen.getByRole('button', { name: 'Start' }));
     expect(queryMocks.debug.mutate).toHaveBeenCalledWith(
       expect.objectContaining({ body: expect.objectContaining({ image: 'ghcr.io/ibtisam-iq/debugbox:power-1.2.0', profile: 'netadmin' }) }),
+      expect.anything(),
+    );
+    view.unmount();
+  });
+
+  it('accepts a free-text reference through the custom image entry', () => {
+    const view = clickMenuAction(pod, 'Debug container…');
+    expect(screen.queryByLabelText('Image')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Custom image…'));
+    const startButton = screen.getByRole('button', { name: 'Start' });
+    expect(startButton).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Image'), { target: { value: ' my.registry/tools:3 ' } });
+    fireEvent.click(startButton);
+    expect(queryMocks.debug.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ image: 'my.registry/tools:3' }) }),
+      expect.anything(),
+    );
+    view.unmount();
+  });
+
+  it('offers user-defined debug images and lets one shadow a built-in preset', () => {
+    queryMocks.debugImages = [
+      { name: 'company toolbox', image: 'registry.acme.dev/debug:2', profile: 'sysadmin', description: 'Internal tooling.' },
+      { name: 'busybox', image: 'busybox:1.37' },
+    ];
+    // The custom busybox replaces the built-in entry instead of duplicating it,
+    // and is preselected as the default — Start sends the pinned tag.
+    let view = clickMenuAction(pod, 'Debug container…');
+    expect(screen.getAllByText('busybox')).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    expect(queryMocks.debug.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ image: 'busybox:1.37' }) }),
+      expect.anything(),
+    );
+    view.unmount();
+
+    view = clickMenuAction(pod, 'Debug container…');
+    fireEvent.click(screen.getByText('company toolbox'));
+    expect(screen.getByText('registry.acme.dev/debug:2 — Internal tooling.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Start' }));
+    expect(queryMocks.debug.mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ body: expect.objectContaining({ image: 'registry.acme.dev/debug:2', profile: 'sysadmin' }) }),
       expect.anything(),
     );
     view.unmount();

--- a/tests/unit/server/app-shutdown.test.ts
+++ b/tests/unit/server/app-shutdown.test.ts
@@ -1,0 +1,63 @@
+import { once } from 'node:events';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+import { startServer, type RunningServer } from '../../../server/src/server';
+
+let server: RunningServer | undefined;
+let socket: net.Socket | undefined;
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  socket?.destroy();
+  await server?.close().catch(() => undefined);
+  socket = undefined;
+  server = undefined;
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+it('closes promptly when a WebSocket peer does not answer the close handshake', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kubus-app-shutdown-'));
+  tempDirs.push(root);
+  const kubeconfig = path.join(root, 'kubeconfig');
+  fs.writeFileSync(kubeconfig, 'apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []\ncurrent-context: ""\n');
+  vi.stubEnv('XDG_CONFIG_HOME', path.join(root, 'config'));
+
+  server = await startServer({
+    host: '127.0.0.1',
+    port: 0,
+    token: 'test',
+    openBrowser: false,
+    prettyLogs: false,
+    staticRoot: path.join(root, 'missing-client'),
+    kubeconfigOverride: kubeconfig,
+  });
+  socket = net.createConnection({ host: '127.0.0.1', port: server.port });
+  await once(socket, 'connect');
+  socket.write(
+    [
+      'GET /ws/watch?token=test HTTP/1.1',
+      'Host: 127.0.0.1',
+      'Connection: Upgrade',
+      'Upgrade: websocket',
+      'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+      'Sec-WebSocket-Version: 13',
+      '',
+      '',
+    ].join('\r\n'),
+  );
+
+  let response = '';
+  while (!response.includes('\r\n\r\n')) {
+    const [chunk] = await once(socket, 'data');
+    response += String(chunk);
+  }
+  expect(response).toContain('101 Switching Protocols');
+
+  await expect(server.close()).resolves.toBeUndefined();
+  server = undefined;
+  await expect.poll(() => socket?.destroyed).toBe(true);
+});

--- a/tests/unit/server/misc-routes.test.ts
+++ b/tests/unit/server/misc-routes.test.ts
@@ -152,10 +152,10 @@ function createHarness() {
     setKubeconfigOverride: vi.fn(),
     reload: vi.fn(),
   };
-  const settingsState: { kubeconfigPath?: string } = {};
+  const settingsState: { kubeconfigPath?: string; debugImages?: unknown } = {};
   const settings = {
     load: vi.fn(() => settingsState),
-    save: vi.fn((next: { kubeconfigPath?: string }) => Object.assign(settingsState, next)),
+    save: vi.fn((next: Record<string, unknown>) => Object.assign(settingsState, next)),
   };
   const portForwards = {
     list: vi.fn(() => [{ id: 'pf-1' }]),
@@ -566,6 +566,55 @@ describe('settings routes', () => {
         })
       ).statusCode,
     ).toBe(400);
+  });
+});
+
+describe('debug image routes', () => {
+  it('lists, adds and removes user debug images', async () => {
+    const harness = createHarness();
+    const app = await buildApp(harness);
+    expect((await app.inject({ method: 'GET', url: '/api/settings/debug-images' })).json()).toEqual([]);
+
+    const added = await app.inject({
+      method: 'POST',
+      url: '/api/settings/debug-images',
+      payload: { name: 'toolbox', image: 'ghcr.io/acme/toolbox:1.0.0', profile: 'netadmin', description: 'Company debug image.' },
+    });
+    expect(added.statusCode).toBe(200);
+    expect(added.json()).toEqual({ name: 'toolbox', image: 'ghcr.io/acme/toolbox:1.0.0', profile: 'netadmin', description: 'Company debug image.' });
+    expect((await app.inject({ method: 'GET', url: '/api/settings/debug-images' })).json()).toHaveLength(1);
+
+    // Name uniqueness is case-insensitive so a chip can't show up twice.
+    expect((await app.inject({ method: 'POST', url: '/api/settings/debug-images', payload: { name: 'Toolbox', image: 'other:1' } })).statusCode).toBe(409);
+
+    expect((await app.inject({ method: 'DELETE', url: '/api/settings/debug-images/toolbox' })).statusCode).toBe(200);
+    expect((await app.inject({ method: 'GET', url: '/api/settings/debug-images' })).json()).toEqual([]);
+    expect((await app.inject({ method: 'DELETE', url: '/api/settings/debug-images/toolbox' })).statusCode).toBe(404);
+  });
+
+  it('validates names, image references and profiles', async () => {
+    const harness = createHarness();
+    const app = await buildApp(harness);
+    expect((await app.inject({ method: 'POST', url: '/api/settings/debug-images', payload: { name: 'x' } })).statusCode).toBe(422);
+    expect((await app.inject({ method: 'POST', url: '/api/settings/debug-images', payload: { image: 'busybox:1.37' } })).statusCode).toBe(422);
+    expect((await app.inject({ method: 'POST', url: '/api/settings/debug-images', payload: { name: 'x', image: 'has space' } })).statusCode).toBe(422);
+    expect((await app.inject({ method: 'POST', url: '/api/settings/debug-images', payload: { name: 'x', image: 'img:1', profile: 'root' } })).statusCode).toBe(422);
+    expect((await app.inject({ method: 'POST', url: '/api/settings/debug-images', payload: { name: 'y'.repeat(41), image: 'img:1' } })).statusCode).toBe(422);
+  });
+
+  it('filters malformed hand-edited settings entries instead of failing', async () => {
+    const harness = createHarness();
+    harness.settingsState.debugImages = [
+      { name: 'ok', image: 'busybox:1.37' },
+      { name: '', image: 'no-name:1' },
+      'junk',
+      { name: 'bad-profile', image: 'img:1', profile: 'root' },
+    ];
+    const app = await buildApp(harness);
+    expect((await app.inject({ method: 'GET', url: '/api/settings/debug-images' })).json()).toEqual([
+      { name: 'ok', image: 'busybox:1.37' },
+      { name: 'bad-profile', image: 'img:1' },
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #140.

Kubus already attaches ephemeral debug containers (`kubectl debug` style) with a curated image set; what was missing from #140 is the "optional setting for users to set their own debug containers config". This PR turns the hardcoded preset list into a configurable catalog.

## What's in here

**Server**
- `debugImages` in the persisted `settings.json` (next to `helmRepos`), managed through `GET`/`POST`/`DELETE /api/settings/debug-images` with validation (length caps, no whitespace in image refs, known profiles, case-insensitive duplicate rejection). Malformed hand-edited entries are filtered instead of breaking the dialog.

**Settings**
- New **Debug containers** tab showing the full effective catalog: built-ins (busybox, the three DebugBox tiers, netshoot) and user entries side by side with provenance chips (`built-in` / `custom` / `replaces built-in`) and per-entry profile chips, plus an add form (name, image, optional profile and description). Only custom entries can be deleted; deleting a shadowing entry restores the built-in.
- The app-diagnostics **Debug** tab is renamed **Diagnostics** to avoid the name clash.

**Debug dialog**
- The free-text field + preset chip row is replaced by a selectable catalog list — each row shows name, image reference, description and profile — with a **Custom image…** entry that reveals a free-text field. A user entry named like a built-in replaces it in place (e.g. pin `busybox:1.37`), and profile-tagged entries still pre-select their security profile.

## Testing

- Unit: route CRUD + validation + malformed-settings filtering, and dialog tests for preset selection, custom-image entry and built-in shadowing (full suite passes, 998 tests).
- Manual: exercised end to end against a kind cluster — catalog management in the new tab, shadowed busybox sent with the pinned tag, profile auto-switch, custom image gating Start.

Docs updated (`docs/guide/shell.md`, `docs/guide/settings.md`).