### PR TITLE
Add context menu for Helm releases

### DIFF
--- a/client/src/components/ConfirmDialog.tsx
+++ b/client/src/components/ConfirmDialog.tsx
@@ -15,13 +15,15 @@ interface Props {
   confirmLabel?: string;
   danger?: boolean;
   busy?: boolean;
+  /** Disable confirmation for a live precondition without presenting it as in-progress work. */
+  disabled?: boolean;
   /** When set, the user must type this exact text before the confirm button enables (protected clusters). */
   confirmText?: string;
   onConfirm: () => void;
   onClose: () => void;
 }
 
-export function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', danger, busy, confirmText, onConfirm, onClose }: Props) {
+export function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', danger, busy, disabled, confirmText, onConfirm, onClose }: Props) {
   const [typed, setTyped] = useState('');
   const [prevOpen, setPrevOpen] = useState(open);
   if (open !== prevOpen) {
@@ -47,7 +49,7 @@ export function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', 
               value={typed}
               onChange={(e) => setTyped(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !blocked && !busy) onConfirm();
+                if (e.key === 'Enter' && !blocked && !busy && !disabled) onConfirm();
               }}
             />
           </>
@@ -55,7 +57,7 @@ export function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', 
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button variant="contained" color={danger ? 'error' : 'primary'} onClick={onConfirm} disabled={busy || blocked}>
+        <Button variant="contained" color={danger ? 'error' : 'primary'} onClick={onConfirm} disabled={busy || blocked || disabled}>
           {busy ? 'Working…' : confirmLabel}
         </Button>
       </DialogActions>

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useCallback, useMemo, useRef, useState } from 'react';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
@@ -116,6 +117,10 @@ export function HelmPage() {
     }),
     [openContextMenu, rowsById],
   );
+  const uninstallTargetOperation = uninstallTarget
+    ? latestOperationByRelease.get(`${uninstallTarget.ctx}/${uninstallTarget.release.namespace}/${uninstallTarget.release.name}`)
+    : undefined;
+  const uninstallBlockedByOperation = uninstallTargetOperation?.status === 'running';
 
   const columns: GridColDef<Row>[] = useMemo(() => {
     const defs: GridColDef<Row>[] = [
@@ -301,18 +306,24 @@ export function HelmPage() {
         danger
         confirmLabel="Uninstall"
         busy={uninstall.isPending}
+        disabled={uninstallBlockedByOperation}
         confirmText={uninstallTargetProtected ? uninstallTarget?.release.name : undefined}
         message={
           uninstallTarget ? (
             <>
               Uninstall <b>{uninstallTarget.release.namespace}/{uninstallTarget.release.name}</b> from cluster <b>{uninstallTarget.ctx}</b>? This deletes every
               resource in the release manifest, then removes the release records only after cleanup succeeds. Stored pre-delete and post-delete hooks are executed.
+              {uninstallBlockedByOperation ? (
+                <Alert severity="warning" sx={{ mt: 1.5 }}>
+                  Cannot uninstall while the {uninstallTargetOperation.kind} operation is running.
+                </Alert>
+              ) : null}
             </>
           ) : null
         }
         onClose={() => setUninstallTarget(null)}
         onConfirm={() => {
-          if (!uninstallTarget) return;
+          if (!uninstallTarget || uninstallBlockedByOperation) return;
           const target = uninstallTarget;
           uninstall.mutate(
             { ctx: target.ctx, ns: target.release.namespace, name: target.release.name },

--- a/client/src/pages/HelmPage.tsx
+++ b/client/src/pages/HelmPage.tsx
@@ -1,21 +1,28 @@
-import { Suspense, lazy, useMemo, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useMemo, useRef, useState } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import Tooltip from '@mui/material/Tooltip';
 import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SailingOutlinedIcon from '@mui/icons-material/SailingOutlined';
 import { useNavigate } from 'react-router';
 import type { GridColDef } from '@mui/x-data-grid';
 import { DataGrid } from '@mui/x-data-grid';
 import type { HelmReleaseSummary } from '@kubus/shared';
-import { useAppInfo, useHelmOperations, useHelmReleases, useHelmUpdates } from '../api/queries.js';
-import { namespaceVisible, useClustersStore } from '../state/clusters.js';
+import { useAppInfo, useHelmOperations, useHelmReleases, useHelmUninstall, useHelmUpdates } from '../api/queries.js';
+import { namespaceVisible, useClustersStore, useIsProtected } from '../state/clusters.js';
 import { CellCopyOverlay, copyCellGridSx, handleCopyCellKeyDown, withCellCopy } from '../components/CellCopy.js';
 import { useGridPrefs } from '../components/grid-prefs.js';
 import { StatusChip } from '../components/StatusChip.js';
@@ -25,12 +32,20 @@ import { PageHeader } from '../components/PageHeader.js';
 import { helmOperationPhaseLabel, helmOperationReleaseKey } from '../components/HelmOperationStatus.js';
 import { HelmOperationsOverview } from '../components/HelmOperationsOverview.js';
 import { countLabel } from '../components/format.js';
+import { ConfirmDialog } from '../components/ConfirmDialog.js';
+import { showToast } from '../state/toast.js';
 
 const HelmInstallDialog = lazy(() => import('../components/HelmInstallDialog.js'));
 
 interface Row {
   ctx: string;
   release: HelmReleaseSummary;
+}
+
+interface ReleaseContextMenu {
+  row: Row;
+  mouseX: number;
+  mouseY: number;
 }
 
 const releasesGridSx = { flex: 1, minHeight: 0, border: 0, '& .MuiDataGrid-row': { cursor: 'pointer' }, ...copyCellGridSx };
@@ -41,9 +56,13 @@ export function HelmPage() {
   const { data, isLoading } = useHelmReleases(selected);
   const navigate = useNavigate();
   const [installOpen, setInstallOpen] = useState(false);
+  const [contextMenu, setContextMenu] = useState<ReleaseContextMenu | null>(null);
+  const [uninstallTarget, setUninstallTarget] = useState<Row | null>(null);
   const gridRootRef = useRef<HTMLDivElement>(null);
   const helmEngine = useAppInfo().data?.helmEngine ?? false;
   const operations = useHelmOperations();
+  const uninstall = useHelmUninstall();
+  const uninstallTargetProtected = useIsProtected(uninstallTarget?.ctx ?? '');
 
   const rows = useMemo(() => {
     const all = data ?? [];
@@ -74,6 +93,29 @@ export function HelmPage() {
     }
     return byRelease;
   }, [visibleOperations]);
+  const rowsById = useMemo(() => new Map(rows.map((row) => [`${row.ctx}/${row.release.namespace}/${row.release.name}`, row])), [rows]);
+  const releasePath = useCallback(
+    (row: Row) => `/helm/${encodeURIComponent(row.ctx)}/${encodeURIComponent(row.release.namespace)}/${encodeURIComponent(row.release.name)}`,
+    [],
+  );
+  const openRelease = useCallback((row: Row) => void navigate(releasePath(row)), [navigate, releasePath]);
+  const openContextMenu = useCallback((row: Row, clientX: number, clientY: number) => {
+    setContextMenu({ row, mouseX: clientX + 2, mouseY: clientY - 6 });
+  }, []);
+  const rowSlotProps = useMemo(
+    () => ({
+      row: {
+        onContextMenu: (event: React.MouseEvent<HTMLElement>) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const id = event.currentTarget.getAttribute('data-id');
+          const row = id ? rowsById.get(id) : undefined;
+          if (row) openContextMenu(row, event.clientX, event.clientY);
+        },
+      },
+    }),
+    [openContextMenu, rowsById],
+  );
 
   const columns: GridColDef<Row>[] = useMemo(() => {
     const defs: GridColDef<Row>[] = [
@@ -196,21 +238,111 @@ export function HelmPage() {
         getRowId={(r) => `${r.ctx}/${r.release.namespace}/${r.release.name}`}
         density={grid.density}
         onColumnWidthChange={grid.onColumnWidthChange}
-        onRowClick={(p) => navigate(`/helm/${encodeURIComponent(p.row.ctx)}/${encodeURIComponent(p.row.release.namespace)}/${encodeURIComponent(p.row.release.name)}`)}
+        onRowClick={(p) => openRelease(p.row)}
+        slotProps={rowSlotProps}
         onCellKeyDown={(params, event, details) => {
           handleCopyCellKeyDown(params, event, details);
           // Keyboard equivalent of clicking the row.
           if (event.key === 'Enter') {
             event.preventDefault();
-            void navigate(
-              `/helm/${encodeURIComponent(params.row.ctx)}/${encodeURIComponent(params.row.release.namespace)}/${encodeURIComponent(params.row.release.name)}`,
-            );
+            openRelease(params.row);
+          } else if (event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10')) {
+            event.preventDefault();
+            const cell = (event.target as HTMLElement | null)?.closest?.('.MuiDataGrid-cell');
+            const rect = (cell ?? (event.target as HTMLElement)).getBoundingClientRect();
+            openContextMenu(params.row, rect.left + 8, rect.bottom - 4);
           }
         }}
         sx={releasesGridSx}
         initialState={{ sorting: { sortModel: [{ field: 'name', sort: 'asc' }] } }}
       />
       <CellCopyOverlay rootRef={gridRootRef} />
+      <Menu
+        open={contextMenu !== null}
+        onClose={() => setContextMenu(null)}
+        anchorReference="anchorPosition"
+        anchorPosition={contextMenu ? { top: contextMenu.mouseY, left: contextMenu.mouseX } : undefined}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <MenuItem
+          onClick={() => {
+            if (!contextMenu) return;
+            openRelease(contextMenu.row);
+            setContextMenu(null);
+          }}
+        >
+          <ListItemIcon>
+            <OpenInNewIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Open release</ListItemText>
+        </MenuItem>
+        <Divider />
+        <MenuItem
+          disabled={
+            !!contextMenu &&
+            latestOperationByRelease.get(`${contextMenu.row.ctx}/${contextMenu.row.release.namespace}/${contextMenu.row.release.name}`)?.status === 'running'
+          }
+          onClick={() => {
+            if (!contextMenu) return;
+            setUninstallTarget(contextMenu.row);
+            setContextMenu(null);
+          }}
+          sx={{ color: 'error.main' }}
+        >
+          <ListItemIcon>
+            <DeleteIcon fontSize="small" color="error" />
+          </ListItemIcon>
+          <ListItemText>Uninstall…</ListItemText>
+        </MenuItem>
+      </Menu>
+      <ConfirmDialog
+        open={uninstallTarget !== null}
+        title={`Uninstall ${uninstallTarget?.release.name ?? ''}`}
+        danger
+        confirmLabel="Uninstall"
+        busy={uninstall.isPending}
+        confirmText={uninstallTargetProtected ? uninstallTarget?.release.name : undefined}
+        message={
+          uninstallTarget ? (
+            <>
+              Uninstall <b>{uninstallTarget.release.namespace}/{uninstallTarget.release.name}</b> from cluster <b>{uninstallTarget.ctx}</b>? This deletes every
+              resource in the release manifest, then removes the release records only after cleanup succeeds. Stored pre-delete and post-delete hooks are executed.
+            </>
+          ) : null
+        }
+        onClose={() => setUninstallTarget(null)}
+        onConfirm={() => {
+          if (!uninstallTarget) return;
+          const target = uninstallTarget;
+          uninstall.mutate(
+            { ctx: target.ctx, ns: target.release.namespace, name: target.release.name },
+            {
+              onSuccess: (result) => {
+                setUninstallTarget(null);
+                if (result.failed.length) {
+                  showToast(
+                    'error',
+                    `Uninstall incomplete: ${result.failed.length} item${result.failed.length === 1 ? '' : 's'} failed${
+                      result.recordsRetained ? '; release history was retained for inspection and retry' : ''
+                    }`,
+                  );
+                  return;
+                }
+                showToast(
+                  'success',
+                  `Uninstalled ${target.release.name}: ${result.deleted.length} resources deleted${
+                    result.crdsDeleted.length ? `, ${result.crdsDeleted.length} CRDs` : ''
+                  }`,
+                );
+              },
+              onError: (error) => {
+                setUninstallTarget(null);
+                showToast('error', `Uninstall failed: ${error.message}`);
+              },
+            },
+          );
+        }}
+      />
       {installOpen && (
         <Suspense fallback={null}>
           <HelmInstallDialog contexts={selected} onClose={() => setInstallOpen(false)} />

--- a/tests/unit/client/helm-page.test.tsx
+++ b/tests/unit/client/helm-page.test.tsx
@@ -140,7 +140,7 @@ describe('HelmPage release context menu', () => {
     expect(effects.toast).toHaveBeenCalledWith('success', 'Uninstalled web: 1 resources deleted');
   });
 
-  it('keeps protected-cluster confirmation and blocks uninstall during an active operation', () => {
+  it('disables an open confirmation when an operation starts in another window', () => {
     useClustersStore.setState({ contextSettings: { dev: { protected: true } } });
     const view = renderPage();
 
@@ -151,17 +151,27 @@ describe('HelmPage release context menu', () => {
     fireEvent.change(screen.getByPlaceholderText('web'), { target: { value: 'web' } });
     expect(confirm).toBeEnabled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     fixtures.operations = [operation('running')];
     view.rerender(
       <MemoryRouter initialEntries={['/helm']}>
         <Routes>
-          <Route path="*" element={<HelmPage />} />
+          <Route
+            path="*"
+            element={
+              <>
+                <HelmPage />
+                <LocationProbe />
+              </>
+            }
+          />
         </Routes>
       </MemoryRouter>,
     );
-    fireEvent.contextMenu(releaseRow(), { clientX: 24, clientY: 36 });
-    expect(screen.getByRole('menuitem', { name: 'Uninstall…' })).toHaveAttribute('aria-disabled', 'true');
+
+    expect(confirm).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Cannot uninstall while the upgrade operation is running.');
+    fireEvent.click(confirm);
+    expect(fixtures.uninstall.mutate).not.toHaveBeenCalled();
   });
 
   it('opens the context menu from Shift+F10', () => {

--- a/tests/unit/client/helm-page.test.tsx
+++ b/tests/unit/client/helm-page.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HelmOperation, HelmReleaseSummary } from '@kubus/shared';
+import { HelmPage } from '../../../client/src/pages/HelmPage';
+import { useClustersStore } from '../../../client/src/state/clusters';
+import { useUiPrefsStore } from '../../../client/src/state/prefs';
+
+interface ReleaseRow {
+  ctx: string;
+  release: HelmReleaseSummary;
+}
+
+const fixtures = vi.hoisted(() => ({
+  releases: [] as ReleaseRow[],
+  operations: [] as HelmOperation[],
+  uninstall: {
+    isPending: false,
+    mutate: vi.fn(),
+  },
+  refetchUpdates: vi.fn(),
+}));
+
+const effects = vi.hoisted(() => ({ toast: vi.fn() }));
+
+vi.mock('../../../client/src/api/queries.js', () => ({
+  useAppInfo: () => ({ data: { helmEngine: true } }),
+  useHelmOperations: () => ({ data: fixtures.operations, error: null, isLoading: false, isFetching: false, refetch: vi.fn() }),
+  useHelmReleases: () => ({ data: fixtures.releases, isLoading: false }),
+  useHelmUninstall: () => fixtures.uninstall,
+  useHelmUpdates: () => ({ data: [], isFetching: false, refetch: fixtures.refetchUpdates }),
+}));
+
+vi.mock('../../../client/src/components/CellCopy.js', () => ({
+  CellCopyOverlay: () => null,
+  copyCellGridSx: {},
+  handleCopyCellKeyDown: vi.fn(),
+  withCellCopy: (column: unknown) => column,
+}));
+vi.mock('../../../client/src/components/HelmOperationsOverview.js', () => ({ HelmOperationsOverview: () => null }));
+vi.mock('../../../client/src/components/grid-prefs.js', () => ({
+  useGridPrefs: (_id: string, columns: unknown[]) => ({ columns, density: 'compact', onColumnWidthChange: vi.fn() }),
+}));
+vi.mock('../../../client/src/state/toast.js', () => ({ showToast: effects.toast }));
+
+function release(name = 'web'): ReleaseRow {
+  return {
+    ctx: 'dev',
+    release: {
+      name,
+      namespace: 'team-a',
+      revision: 3,
+      status: 'deployed',
+      chart: 'nginx',
+      chartVersion: '1.2.3',
+      appVersion: '1.25.0',
+    },
+  };
+}
+
+function operation(status: HelmOperation['status']): HelmOperation {
+  return {
+    id: 'op-1',
+    kind: 'upgrade',
+    ctx: 'dev',
+    namespace: 'team-a',
+    releaseName: 'web',
+    status,
+    phase: 'applying',
+    message: 'Applying resources',
+    startedAt: '2026-08-28T10:00:00Z',
+    updatedAt: '2026-08-28T10:00:01Z',
+  };
+}
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}</output>;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/helm']}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <HelmPage />
+              <LocationProbe />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function releaseRow() {
+  return screen.getByText('web').closest('.MuiDataGrid-row')!;
+}
+
+beforeEach(() => {
+  fixtures.releases = [release()];
+  fixtures.operations = [];
+  fixtures.uninstall.isPending = false;
+  fixtures.uninstall.mutate.mockReset();
+  fixtures.uninstall.mutate.mockImplementation((_variables, options) =>
+    options.onSuccess({ deleted: ['Deployment/team-a/web'], failed: [], hooksRan: [], crdsDeleted: [], recordsRetained: false }),
+  );
+  fixtures.refetchUpdates.mockReset();
+  effects.toast.mockReset();
+  useClustersStore.setState({ selected: ['dev'], namespaces: [], contextSettings: {} });
+  useUiPrefsStore.setState({ protectByDefault: false });
+});
+
+describe('HelmPage release context menu', () => {
+  it('opens release details from a right-click menu', () => {
+    renderPage();
+
+    fireEvent.contextMenu(releaseRow(), { clientX: 24, clientY: 36 });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open release' }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/helm/dev/team-a/web');
+  });
+
+  it('confirms and uninstalls the selected release', async () => {
+    renderPage();
+
+    fireEvent.contextMenu(releaseRow(), { clientX: 24, clientY: 36 });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Uninstall…' }));
+    expect(screen.getByRole('dialog')).toHaveTextContent('Uninstall team-a/web from cluster dev');
+    fireEvent.click(screen.getByRole('button', { name: 'Uninstall' }));
+
+    expect(fixtures.uninstall.mutate).toHaveBeenCalledWith(
+      { ctx: 'dev', ns: 'team-a', name: 'web' },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(effects.toast).toHaveBeenCalledWith('success', 'Uninstalled web: 1 resources deleted');
+  });
+
+  it('keeps protected-cluster confirmation and blocks uninstall during an active operation', () => {
+    useClustersStore.setState({ contextSettings: { dev: { protected: true } } });
+    const view = renderPage();
+
+    fireEvent.contextMenu(releaseRow(), { clientX: 24, clientY: 36 });
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Uninstall…' }));
+    const confirm = screen.getByRole('button', { name: 'Uninstall' });
+    expect(confirm).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('web'), { target: { value: 'web' } });
+    expect(confirm).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fixtures.operations = [operation('running')];
+    view.rerender(
+      <MemoryRouter initialEntries={['/helm']}>
+        <Routes>
+          <Route path="*" element={<HelmPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    fireEvent.contextMenu(releaseRow(), { clientX: 24, clientY: 36 });
+    expect(screen.getByRole('menuitem', { name: 'Uninstall…' })).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('opens the context menu from Shift+F10', () => {
+    renderPage();
+
+    const cell = screen.getByText('web').closest('.MuiDataGrid-cell')!;
+    fireEvent.keyDown(cell, { key: 'F10', shiftKey: true });
+
+    expect(screen.getByRole('menuitem', { name: 'Open release' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- add a right-click menu to Helm release rows with open and uninstall actions
- support the Context Menu key and Shift+F10 for keyboard access
- preserve protected-cluster confirmation and block uninstall during active Helm operations
- add unit coverage for navigation, uninstall, protection, active operations, and keyboard access

## Testing

- `pnpm lint`
- `pnpm lint:perf`
- `pnpm typecheck`
- `pnpm --filter @kubus/shared --filter @kubus/client --filter @kubus/server build`
- `pnpm --filter @kubus/tests test` (1,005 tests)
- built-client Playwright verification of the right-click uninstall flow

Closes #144