### PR TITLE
Fix/macos namespace dropdown click

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,24 @@ jobs:
       # test step so OS-specific behavior is visible without misleading skips.
       - name: Unit tests
         run: pnpm ${{ runner.os == 'Linux' && 'test:coverage' || 'test' }}
+      # The namespace selector lives inside a native draggable title bar. Run
+      # the real Electron renderer on every supported desktop OS so platform
+      # hit-testing differences cannot regress unnoticed.
+      - name: Electron end-to-end tests (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run --auto-servernum pnpm test:electron
+      - name: Electron end-to-end tests (macOS and Windows)
+        if: runner.os != 'Linux'
+        run: pnpm test:electron
+      - name: Upload Electron diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: electron-report-${{ runner.os }}
+          path: |
+            tests/electron-report
+            tests/electron/.results
+          retention-days: 7
       - name: Upload coverage report
         if: runner.os == 'Linux' && always()
         uses: actions/upload-artifact@v7
@@ -88,11 +106,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @kubus/shared --filter @kubus/server --filter @kubus/client --filter @kubus/electron build
-      # Launches the actual Electron main/preload/renderer stack with isolated
-      # user data and an empty kubeconfig. Electron 44's Chromium can crash in
-      # native headless mode on hosted runners, so exercise its X11 path.
-      - name: Electron end-to-end tests
-        run: xvfb-run --auto-servernum pnpm test:electron
       # Cluster name kubus-a matches the local dev clusters, so the suite
       # runs unchanged in both places (context kind-kubus-a).
       - name: Create kind cluster
@@ -109,6 +122,4 @@ jobs:
           path: |
             tests/playwright-report
             tests/e2e/.results
-            tests/electron-report
-            tests/electron/.results
           retention-days: 7

--- a/client/src/layout/NamespaceFilter.tsx
+++ b/client/src/layout/NamespaceFilter.tsx
@@ -7,6 +7,12 @@ import Typography from '@mui/material/Typography';
 import { useNamespaces } from '../api/queries.js';
 import { useClustersStore } from '../state/clusters.js';
 
+export const namespaceFilterSx = {
+  minWidth: 260,
+  maxWidth: 480,
+  WebkitAppRegion: 'no-drag',
+} as const;
+
 export function NamespaceFilter() {
   const selected = useClustersStore((s) => s.selected);
   const namespaces = useClustersStore((s) => s.namespaces);
@@ -36,7 +42,10 @@ export function NamespaceFilter() {
         value.map((option, index) => <Chip {...getItemProps({ index })} key={option} label={option} size="small" />)
       }
       renderInput={(params) => <TextField {...params} placeholder={namespaces.length ? '' : 'All namespaces'} variant="outlined" />}
-      sx={{ minWidth: 260, maxWidth: 480 }}
+      // Electron/macOS computes native title-bar hit regions from the painted
+      // Autocomplete root. Marking only its input as no-drag leaves the root
+      // draggable and swallows physical pointer clicks.
+      sx={namespaceFilterSx}
     />
   );
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -106,15 +106,18 @@ pnpm test:electron     # no cluster or display server required on Linux
 Each spec launches the real Electron executable against a temporary user-data
 directory, temporary `XDG_CONFIG_HOME`, and empty kubeconfig. The suite checks
 the context-isolated preload surface, renderer-to-main state persistence,
-native accelerator IPC, and cold-start `kubus://` routing. Linux uses Chromium's
-headless Ozone platform; macOS and Windows launch through Electron normally.
-All temporary desktop state is removed after each test.
+native accelerator IPC, cold-start `kubus://` routing, and physical pointer
+interaction with controls inside the draggable title bar. The title-bar test
+stubs only its context and namespace HTTP responses; the Electron main,
+preload, renderer, CSS hit regions, and pointer input remain real. Linux uses
+Chromium's headless Ozone platform locally; CI exercises its X11 path under
+Xvfb. macOS and Windows launch through Electron normally. All temporary desktop
+state is removed after each test.
 
 ## CI
 
-The `build` matrix job runs the unit suites on every OS. Linux runs the
-repository-wide coverage command, enforces its thresholds, and uploads the
-HTML report; macOS and Windows run the faster unit command. The Linux `e2e` job
-first launches the Electron suite, then creates a kind cluster named `kubus-a`
-via `helm/kind-action` and runs the browser suite, uploading diagnostics on
-failure.
+The `build` matrix job runs both the unit and Electron suites on Ubuntu, macOS,
+and Windows. Linux runs the repository-wide coverage command, enforces its
+thresholds, and uploads the HTML report; macOS and Windows run the faster unit
+command. The Linux `e2e` job creates a kind cluster named `kubus-a` via
+`helm/kind-action` and runs the browser suite, uploading diagnostics on failure.

--- a/tests/electron/specs/titlebar-controls.spec.ts
+++ b/tests/electron/specs/titlebar-controls.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Locator } from '@playwright/test';
+import { launchElectron } from '../helpers/app.js';
+
+const contextName = 'electron-titlebar-test';
+const namespaceName = 'pointer-click-verified';
+
+interface HitRegionDiagnostics {
+  appRegion: string;
+  className: string;
+  platform: string;
+  tagName: string;
+}
+
+async function hitRegionDiagnostics(root: Locator): Promise<HitRegionDiagnostics> {
+  return root.evaluate((element) => {
+    const style = getComputedStyle(element) as CSSStyleDeclaration & { webkitAppRegion?: string };
+    return {
+      appRegion: (style.webkitAppRegion ?? style.getPropertyValue('-webkit-app-region')) || '(unset)',
+      className: element.className,
+      platform: window.kubusDesktop?.platform ?? navigator.platform,
+      tagName: element.tagName,
+    };
+  });
+}
+
+function hitRegionFailure(diagnostics: HitRegionDiagnostics): Error {
+  return new Error(
+    [
+      `Namespace dropdown is part of Electron's draggable title-bar region on ${diagnostics.platform}.`,
+      `Expected the rendered .MuiAutocomplete-root to compute -webkit-app-region: no-drag, but received "${diagnostics.appRegion}".`,
+      'A draggable Autocomplete root causes the operating system to consume physical pointer clicks as window-drag gestures before MUI receives them.',
+      'Apply WebkitAppRegion: "no-drag" to the complete NamespaceFilter Autocomplete root; applying it only to the nested input or popup button is insufficient.',
+      `Rendered target: <${diagnostics.tagName.toLowerCase()} class="${diagnostics.className}">`,
+    ].join('\n'),
+  );
+}
+
+async function clickCenter(locator: Locator, description: string): Promise<void> {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error(
+      `Cannot send a physical pointer click to ${description}: Playwright could not obtain its on-screen bounds. ` +
+        'The control may be hidden, detached, or covered by the native title bar.',
+    );
+  }
+  await locator.page().mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+}
+
+test('namespace dropdown receives pointer clicks inside the native title bar', async () => {
+  const launched = await launchElectron();
+  const { page } = launched;
+
+  try {
+    // Keep this test hermetic: the actual Electron server and renderer run, but
+    // deterministic API responses avoid requiring a developer kubeconfig or a
+    // reachable Kubernetes cluster on any CI operating system.
+    await page.route(/\/api\/contexts$/, async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            name: contextName,
+            cluster: 'titlebar-test-cluster',
+            user: 'titlebar-test-user',
+            current: true,
+            health: 'connected',
+            active: true,
+          },
+        ]),
+      });
+    });
+    await page.route(`**/api/contexts/${contextName}/namespaces`, async (route) => {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify([namespaceName, 'default']) });
+    });
+    await page.reload();
+
+    const input = page.getByPlaceholder('All namespaces');
+    await expect(input, 'The current context should render the namespace filter before hit-region testing').toBeVisible();
+    const root = input.locator('xpath=ancestor::*[contains(@class, "MuiAutocomplete-root")]').first();
+    await expect(root, 'The namespace input must remain inside the MUI Autocomplete root that owns the native hit region').toBeVisible();
+
+    const diagnostics = await hitRegionDiagnostics(root);
+    if (diagnostics.appRegion !== 'no-drag') throw hitRegionFailure(diagnostics);
+
+    const openButton = root.getByRole('button', { name: 'Open' });
+    await expect(openButton, 'The namespace popup indicator should be available for a pointer click').toBeVisible();
+    await clickCenter(openButton, 'the namespace dropdown popup indicator');
+
+    const listbox = page.getByRole('listbox');
+    try {
+      await expect(listbox).toBeVisible({ timeout: 5_000 });
+    } catch (cause) {
+      const latest = await hitRegionDiagnostics(root);
+      throw new Error(
+        [
+          `A pointer click did not open the namespace dropdown on ${latest.platform}.`,
+          `The Autocomplete root currently computes -webkit-app-region: "${latest.appRegion}".`,
+          'This usually means the operating system intercepted the click as a title-bar drag, or another native overlay covers the popup indicator.',
+          'Inspect TopBar and NamespaceFilter draggable-region styles before debugging namespace API data or MUI selection state.',
+        ].join('\n'),
+        { cause },
+      );
+    }
+
+    const option = listbox.getByRole('option', { name: namespaceName });
+    await expect(option, 'The deterministic namespace response should appear in the opened dropdown').toBeVisible();
+    await clickCenter(option, `the "${namespaceName}" namespace option`);
+    await expect(
+      page.locator('.MuiAutocomplete-root').filter({ hasText: namespaceName }),
+      'The pointer-selected namespace should be rendered as a chip in the Autocomplete root',
+    ).toBeVisible();
+  } finally {
+    await launched.close();
+  }
+});

--- a/tests/unit/client/namespace-filter.test.tsx
+++ b/tests/unit/client/namespace-filter.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NamespaceFilter, namespaceFilterSx } from '../../../client/src/layout/NamespaceFilter';
+import { useClustersStore } from '../../../client/src/state/clusters';
+
+const queryMocks = vi.hoisted(() => ({ namespaces: ['default', 'kube-system'] }));
+
+vi.mock('../../../client/src/api/queries.js', () => ({
+  useNamespaces: () => ({ data: queryMocks.namespaces }),
+}));
+
+beforeEach(() => {
+  useClustersStore.setState({ selected: ['test'], namespaces: [] });
+});
+
+describe('NamespaceFilter', () => {
+  it('makes the complete autocomplete a non-draggable title-bar region', () => {
+    render(<NamespaceFilter />);
+
+    const input = screen.getByPlaceholderText('All namespaces');
+    const root = input.closest('.MuiAutocomplete-root');
+    expect(root).not.toBeNull();
+    expect(namespaceFilterSx.WebkitAppRegion).toBe('no-drag');
+  });
+
+  it('does not render without a selected cluster', () => {
+    useClustersStore.setState({ selected: [] });
+    const { container } = render(<NamespaceFilter />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
### AI usage disclosure

This change was diagnosed, implemented, and tested with assistance from an LLM. The LLM was used to inspect the running application and source code, identify the Electron draggable-region interaction, implement the fix, create component and cross-platform Electron regression tests, improve failure diagnostics, and run local validation.

The generated changes and reported test results were reviewed before submission.

## Fix namespace dropdown clicks inside the native title bar

### Summary

Fixes an issue where the namespace dropdown in the top toolbar could become unclickable in the desktop application.

### Root cause

The toolbar is configured as an Electron draggable title-bar region. Although nested input and button elements were marked as non-draggable, the surrounding Material UI `Autocomplete` root still inherited the draggable region.

Electron and the operating system calculate native hit-testing from the painted root element. As a result, pointer events could be interpreted as window-drag interactions before Material UI received them.

### Code changes

- Mark the complete namespace `Autocomplete` root with `WebkitAppRegion: 'no-drag'`.
- Preserve the existing width constraints in the same shared style definition.
- Document why applying `no-drag` only to nested controls is insufficient.

The change affects only native title-bar hit-testing. Namespace selection, API requests, and filtering logic remain unchanged.

### Regression tests

Added component coverage that verifies:

- The namespace filter uses a non-draggable root style.
- The filter renders when a context is selected.
- The filter remains hidden when no context is selected.

Added an Electron end-to-end test that:

1. Launches the actual Electron main process, preload bridge, and renderer.
2. Supplies deterministic context and namespace API responses without using a developer kubeconfig.
3. Verifies that the rendered `Autocomplete` root computes `-webkit-app-region: no-drag`.
4. Sends coordinate-based pointer clicks to the popup indicator.
5. Confirms that the namespace list opens.
6. Selects a namespace through pointer input.
7. Confirms that the selected namespace appears in the control.

The Electron suite now runs in CI on:

- Ubuntu under Xvfb
- macOS
- Windows

Each operating system uploads its Electron report, traces, and screenshots if the test fails.

### Failure diagnostics

The test produces a targeted troubleshooting error that includes:

- The affected operating system.
- The actual and expected `-webkit-app-region` values.
- The rendered element and class name.
- An explanation that the operating system may be consuming clicks as title-bar drag gestures.
- Guidance to apply `no-drag` to the complete `NamespaceFilter` Autocomplete root rather than only its nested input or button.

The test was also validated against a deliberately restored `drag` regression. It failed with the expected root-cause diagnosis and passed again after the fix was restored.

Ubuntu and Windows execute the same Electron test through the pull request CI matrix.