### PR TITLE
Keep the detail drawer in sync with the watch stream

### DIFF
--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { keepPreviousData, queryOptions, useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { hashKey, keepPreviousData, queryOptions, useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePaneActive } from '../layout/pane-context.js';
 import type {
   ClusterMetricsSummary,
@@ -533,7 +533,12 @@ export function useResource(
   // wire sub an open list page already holds. Revealed secret reads stay on
   // the poll — the watch stream carries redacted objects.
   const watched = opts?.watch && sel && !sel.reveal ? sel : undefined;
-  const watchKey = watched ? `${watched.ctx}|${watched.group}/${watched.version}/${watched.plural}|${watched.namespace ?? ''}|${watched.name}` : '';
+  // Rebind on the full query-key hash, not just the resource identity: events
+  // are written to ['resource', watched], which must stay hash-identical to
+  // the ['resource', sel] key the query observes, and selections for the same
+  // resource can differ in extra fields (e.g. the list page sets `custom`,
+  // the topology map doesn't).
+  const watchKey = watched ? hashKey(['resource', watched]) : '';
   useEffect(() => {
     if (!watched) return;
     const queryKey = ['resource', watched];

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -536,20 +536,28 @@ export function useResource(
   const watchKey = watched ? `${watched.ctx}|${watched.group}/${watched.version}/${watched.plural}|${watched.namespace ?? ''}|${watched.name}` : '';
   useEffect(() => {
     if (!watched) return;
-    const apply = (objects: KubeObject[]) => {
-      for (const obj of objects) {
-        if (obj.metadata.name === watched.name && (obj.metadata.namespace ?? '') === (watched.namespace ?? '')) {
-          qc.setQueryData(['resource', watched], obj);
-        }
-      }
-    };
+    const queryKey = ['resource', watched];
+    const matches = (obj: KubeObject) => obj.metadata.name === watched.name && (obj.metadata.namespace ?? '') === (watched.namespace ?? '');
     return watchClient.subscribe(
       { ctx: watched.ctx, group: groupToPath(watched.group), version: watched.version, plural: watched.plural },
       {
-        onSnapshot: apply,
-        // DELETED keeps the last object on screen, matching the poll once the
-        // GET starts returning 404; a recreate under the same name re-matches.
-        onEvents: (events) => apply(events.filter((ev) => ev.type !== 'DELETED').map((ev) => ev.object)),
+        onSnapshot: (items) => {
+          const obj = items.find(matches);
+          if (obj) qc.setQueryData(queryKey, obj);
+          // Absent from a full snapshot (deleted while the watch was down):
+          // re-fetch so the 404 marks the query gone, keeping the data.
+          else if (qc.getQueryData(queryKey)) void qc.invalidateQueries({ queryKey });
+        },
+        onEvents: (events) => {
+          for (const ev of events) {
+            if (!matches(ev.object)) continue;
+            // DELETED keeps the terminal object on screen for post-mortem;
+            // the follow-up fetch's 404 tells views the resource is gone
+            // (an error a later setQueryData clears if the name comes back).
+            qc.setQueryData(queryKey, ev.object);
+            if (ev.type === 'DELETED') void qc.invalidateQueries({ queryKey });
+          }
+        },
         onStatus: () => {},
       },
     );
@@ -559,8 +567,15 @@ export function useResource(
     queryKey: ['resource', sel],
     queryFn: () => apiFetch<KubeObject>(resourceUrl(sel!.ctx, sel!.group, sel!.version, sel!.plural, sel!.name, sel!.namespace, sel!.reveal ? { reveal: 'true' } : undefined)),
     enabled: !!sel,
-    refetchInterval: opts?.liveMs ? interval : false,
+    // Once the object is gone, re-polling only repeats the 404; a watch event
+    // for a recreated name restores the data (and with it the interval).
+    refetchInterval: opts?.liveMs ? (query) => (isResourceGone(query.state.error) ? false : interval) : false,
   });
+}
+
+/** True when a resource read failed because the object no longer exists. */
+export function isResourceGone(error: unknown): boolean {
+  return (error as { status?: number } | null)?.status === 404;
 }
 
 /** JSON Schema for a kind, derived from the cluster's OpenAPI (covers CRDs). Best-effort: consumers degrade gracefully without it. */

--- a/client/src/api/queries.ts
+++ b/client/src/api/queries.ts
@@ -522,9 +522,39 @@ export function resourceUrl(ctx: string, group: string, version: string, plural:
 
 export function useResource(
   sel: { ctx: string; group: string; version: string; plural: string; name: string; namespace?: string; reveal?: boolean } | undefined,
-  opts?: { liveMs?: number },
+  opts?: { liveMs?: number; watch?: boolean },
 ) {
   const interval = useRefetchInterval(opts?.liveMs ?? 0);
+  const qc = useQueryClient();
+  // Watch-fed freshness: mirror the shared watch stream into the query so
+  // detail views track the tables within one event flush instead of waiting
+  // on the next poll (which the refresh-rate preference, an unfocused window
+  // or staleTime can defer indefinitely). Subscribing cluster-wide shares the
+  // wire sub an open list page already holds. Revealed secret reads stay on
+  // the poll — the watch stream carries redacted objects.
+  const watched = opts?.watch && sel && !sel.reveal ? sel : undefined;
+  const watchKey = watched ? `${watched.ctx}|${watched.group}/${watched.version}/${watched.plural}|${watched.namespace ?? ''}|${watched.name}` : '';
+  useEffect(() => {
+    if (!watched) return;
+    const apply = (objects: KubeObject[]) => {
+      for (const obj of objects) {
+        if (obj.metadata.name === watched.name && (obj.metadata.namespace ?? '') === (watched.namespace ?? '')) {
+          qc.setQueryData(['resource', watched], obj);
+        }
+      }
+    };
+    return watchClient.subscribe(
+      { ctx: watched.ctx, group: groupToPath(watched.group), version: watched.version, plural: watched.plural },
+      {
+        onSnapshot: apply,
+        // DELETED keeps the last object on screen, matching the poll once the
+        // GET starts returning 404; a recreate under the same name re-matches.
+        onEvents: (events) => apply(events.filter((ev) => ev.type !== 'DELETED').map((ev) => ev.object)),
+        onStatus: () => {},
+      },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchKey, qc]);
   return useQuery({
     queryKey: ['resource', sel],
     queryFn: () => apiFetch<KubeObject>(resourceUrl(sel!.ctx, sel!.group, sel!.version, sel!.plural, sel!.name, sel!.namespace, sel!.reveal ? { reveal: 'true' } : undefined)),

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { layout } from '../theme.js';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
 import FormControlLabel from '@mui/material/FormControlLabel';
@@ -18,7 +19,7 @@ import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { dump as dumpYaml } from 'js-yaml';
 import { gvkForResource, type KubeObject } from '@kubus/shared';
-import { useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
+import { isResourceGone, useApplyResource, useDryRunResource, useResource, useResourceEvents } from '../api/queries.js';
 import { jobPhase, nodeStatus, podSummary, withoutManagedFields } from '../kube-display.js';
 import { isTextEntryTarget } from '../text-entry.js';
 import { YamlEditor, useYamlSchema } from './YamlEditor.js';
@@ -109,10 +110,13 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   // and conditions update in place — fed by the watch stream so it keeps pace
   // with the tables, with the poll as fallback; other tabs (YAML editing!)
   // keep the snapshot they opened with.
-  const { data: obj, refetch } = useResource(sel ? { ...sel, reveal: isSecret && reveal } : undefined, {
+  const { data: obj, refetch, error } = useResource(sel ? { ...sel, reveal: isSecret && reveal } : undefined, {
     liveMs: tab === 'overview' ? 5000 : undefined,
     watch: tab === 'overview',
   });
+  // The last state stays on screen for post-mortem, but the drawer must say
+  // the object is gone instead of freezing on e.g. "Terminating" forever.
+  const objGone = !!obj && isResourceGone(error);
   const { data: backingCrd } = useResource(backingCrdSelection);
   const { data: events } = useResourceEvents(tab === 'events' && sel ? { ctx: sel.ctx, name: sel.name, kind: sel.kind, namespace: sel.namespace } : undefined);
   const apply = useApplyResource();
@@ -237,10 +241,10 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
                     <AgeCell timestamp={obj.metadata.creationTimestamp} variant="caption" /> old
                   </>
                 )}
-                {obj && headerStatus(behaviorKind, obj) && (
+                {obj && (objGone || headerStatus(behaviorKind, obj)) && (
                   <>
                     {' · '}
-                    <StatusChip status={headerStatus(behaviorKind, obj)!} />
+                    <StatusChip status={objGone ? 'Deleted' : headerStatus(behaviorKind, obj)!} />
                   </>
                 )}
               </Typography>
@@ -270,7 +274,12 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
               <CloseIcon />
             </IconButton>
           </Stack>
-          {obj && <DetailQuickActions target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
+          {objGone && (
+            <Alert severity="warning" sx={{ borderRadius: 0, py: 0 }}>
+              Deleted from the cluster — showing the last known state.
+            </Alert>
+          )}
+          {obj && !objGone && <DetailQuickActions target={{ ctx: sel.ctx, group: sel.group, version: sel.version, plural: sel.plural, kind: sel.kind, obj }} />}
           <Tabs
             value={tab}
             onChange={(_e, v) => guardLeave(() => setTab(v as string))}

--- a/client/src/components/ResourceDetailDrawer.tsx
+++ b/client/src/components/ResourceDetailDrawer.tsx
@@ -106,10 +106,12 @@ export function ResourceDetailDrawer({ sel, onClose, onBack, inline = false }: P
   }, [hasSel]);
 
   // Live-refresh the object while Overview is showing so stuck pods, rollouts
-  // and conditions update in place; other tabs (YAML editing!) keep the
-  // snapshot they opened with.
+  // and conditions update in place — fed by the watch stream so it keeps pace
+  // with the tables, with the poll as fallback; other tabs (YAML editing!)
+  // keep the snapshot they opened with.
   const { data: obj, refetch } = useResource(sel ? { ...sel, reveal: isSecret && reveal } : undefined, {
     liveMs: tab === 'overview' ? 5000 : undefined,
+    watch: tab === 'overview',
   });
   const { data: backingCrd } = useResource(backingCrdSelection);
   const { data: events } = useResourceEvents(tab === 'events' && sel ? { ctx: sel.ctx, name: sel.name, kind: sel.kind, namespace: sel.namespace } : undefined);

--- a/tests/setup/mock-react-query.tsx
+++ b/tests/setup/mock-react-query.tsx
@@ -16,6 +16,20 @@ function harness(): QueryHarness {
 
 export const keepPreviousData = Symbol('keep-previous-data');
 
+/** Mirrors query-core's stable hash: sorted object keys, JSON stringify. */
+export function hashKey(queryKey: readonly unknown[]): string {
+  return JSON.stringify(queryKey, (_, val: unknown) =>
+    val && typeof val === 'object' && !Array.isArray(val)
+      ? Object.keys(val)
+          .sort()
+          .reduce<Record<string, unknown>>((result, key) => {
+            result[key] = (val as Record<string, unknown>)[key];
+            return result;
+          }, {})
+      : val,
+  );
+}
+
 export function queryOptions<T>(config: T): T {
   return config;
 }

--- a/tests/unit/client/queries.test.tsx
+++ b/tests/unit/client/queries.test.tsx
@@ -12,6 +12,7 @@ const harness = vi.hoisted(() => {
       cache.set(cacheKey, next);
       return next;
     }),
+    getQueryData: (key: readonly unknown[]) => cache.get(JSON.stringify(key)),
   };
   const value = {
     apiFetch: vi.fn(),
@@ -453,10 +454,19 @@ describe('watched and filtered lists', () => {
       ]),
     );
     expect(harness.cache.get(cacheKey)).toEqual(updated);
+    expect(harness.queryClient.invalidateQueries).not.toHaveBeenCalled();
 
-    // DELETED keeps the last object, matching the poll's behavior on 404.
+    // DELETED keeps the terminal object for post-mortem but re-fetches so the
+    // 404 marks the query gone.
     act(() => sub.handlers.onEvents([{ type: 'DELETED', object: updated }]));
     expect(harness.cache.get(cacheKey)).toEqual(updated);
+    expect(harness.queryClient.invalidateQueries).toHaveBeenCalledExactlyOnceWith({ queryKey: ['resource', sel] });
+
+    // Absence from a later full snapshot (deletion missed while reconnecting)
+    // re-fetches too; a snapshot containing the object just updates it.
+    act(() => sub.handlers.onSnapshot([kubeObject('other')]));
+    expect(harness.cache.get(cacheKey)).toEqual(updated);
+    expect(harness.queryClient.invalidateQueries).toHaveBeenCalledTimes(2);
 
     unmount();
     expect(sub.unsubscribe).toHaveBeenCalledOnce();

--- a/tests/unit/client/queries.test.tsx
+++ b/tests/unit/client/queries.test.tsx
@@ -472,6 +472,27 @@ describe('watched and filtered lists', () => {
     expect(sub.unsubscribe).toHaveBeenCalledOnce();
   });
 
+  it('rebinds the resource watch when the selection changes beyond its identity', () => {
+    // Same resource, but the list page sets `custom` while the topology map
+    // doesn't — the bridge must follow the query key, not just the identity.
+    type Sel = Parameters<typeof queries.useResource>[0];
+    const fromList = { ctx: 'dev', group: 'apps', version: 'v1', plural: 'deployments', name: 'web', namespace: 'team-a', custom: true } as Sel;
+    const fromMap = { ctx: 'dev', group: 'apps', version: 'v1', plural: 'deployments', name: 'web', namespace: 'team-a' } as Sel;
+    const { rerender, unmount } = renderHook(({ sel }: { sel: Sel }) => queries.useResource(sel, { watch: true }), {
+      initialProps: { sel: fromList },
+    });
+    expect(harness.subscriptions).toHaveLength(1);
+
+    rerender({ sel: fromMap });
+    expect(harness.subscriptions).toHaveLength(2);
+    expect(harness.subscriptions[0]!.unsubscribe).toHaveBeenCalledOnce();
+
+    act(() => harness.subscriptions[1]!.handlers.onSnapshot([kubeObject('web')]));
+    expect(harness.cache.get(JSON.stringify(['resource', fromMap]))).toEqual(kubeObject('web'));
+    expect(harness.cache.has(JSON.stringify(['resource', fromList]))).toBe(false);
+    unmount();
+  });
+
   it('keeps unwatched and revealed-secret resource reads off the watch stream', () => {
     const plain = renderHook(() => queries.useResource({ ctx: 'dev', group: '', version: 'v1', plural: 'pods', name: 'p' }, { liveMs: 5000 }));
     const revealed = renderHook(() =>

--- a/tests/unit/client/queries.test.tsx
+++ b/tests/unit/client/queries.test.tsx
@@ -433,6 +433,48 @@ describe('watched and filtered lists', () => {
     expect(sub.unsubscribe).toHaveBeenCalledOnce();
   });
 
+  it('feeds a watched single-resource query from the shared watch stream', () => {
+    const sel = { ctx: 'dev', group: 'apps', version: 'v1', plural: 'deployments', name: 'web', namespace: 'team-a' };
+    const cacheKey = JSON.stringify(['resource', sel]);
+    const { unmount } = renderHook(() => queries.useResource(sel, { liveMs: 5000, watch: true }));
+    const sub = harness.subscriptions[0]!;
+    expect(sub.params).toEqual({ ctx: 'dev', group: 'apps', version: 'v1', plural: 'deployments' });
+
+    const fresh = kubeObject('web');
+    act(() => sub.handlers.onSnapshot([kubeObject('other'), fresh]));
+    expect(harness.cache.get(cacheKey)).toEqual(fresh);
+
+    const updated = { ...fresh, metadata: { ...fresh.metadata, resourceVersion: '2' } };
+    act(() =>
+      sub.handlers.onEvents([
+        { type: 'MODIFIED', object: kubeObject('other') },
+        { type: 'MODIFIED', object: kubeObject('web', 'team-b') },
+        { type: 'MODIFIED', object: updated },
+      ]),
+    );
+    expect(harness.cache.get(cacheKey)).toEqual(updated);
+
+    // DELETED keeps the last object, matching the poll's behavior on 404.
+    act(() => sub.handlers.onEvents([{ type: 'DELETED', object: updated }]));
+    expect(harness.cache.get(cacheKey)).toEqual(updated);
+
+    unmount();
+    expect(sub.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('keeps unwatched and revealed-secret resource reads off the watch stream', () => {
+    const plain = renderHook(() => queries.useResource({ ctx: 'dev', group: '', version: 'v1', plural: 'pods', name: 'p' }, { liveMs: 5000 }));
+    const revealed = renderHook(() =>
+      queries.useResource(
+        { ctx: 'dev', group: '', version: 'v1', plural: 'secrets', name: 's', namespace: 'team-a', reveal: true },
+        { liveMs: 5000, watch: true },
+      ),
+    );
+    expect(harness.subscriptions).toHaveLength(0);
+    plain.unmount();
+    revealed.unmount();
+  });
+
   it('filters watched rows by namespace and returns selector-query results', () => {
     useClustersStore.setState({ selected: ['dev'], namespaces: ['team-a'] });
     const plain = renderHook(() => queries.useFilteredList('', 'v1', 'pods', true));

--- a/tests/unit/client/resource-detail-drawer.test.tsx
+++ b/tests/unit/client/resource-detail-drawer.test.tsx
@@ -16,6 +16,7 @@ const queries = vi.hoisted(() => ({
   resourceCalls: [] as Array<{ selection: Record<string, unknown> | undefined; options?: Record<string, unknown> }>,
   eventsCalls: [] as Array<Record<string, unknown> | undefined>,
   refetch: vi.fn(),
+  resourceError: null as Error | null,
   applyMode: 'success' as 'success' | 'conflict' | 'error',
   applyMutateAsync: vi.fn(),
   dryRunMutateAsync: vi.fn(),
@@ -37,8 +38,9 @@ vi.mock('../../../client/src/api/queries.js', () => ({
         : selection.plural === 'customresourcedefinitions'
           ? queries.backing
           : queries.current;
-    return { data, refetch: queries.refetch };
+    return { data, refetch: queries.refetch, error: queries.resourceError };
   },
+  isResourceGone: (error: unknown) => (error as { status?: number } | null)?.status === 404,
   useResourceEvents: (selection: Record<string, unknown> | undefined) => {
     queries.eventsCalls.push(selection);
     return { data: { items: queries.events } };
@@ -170,6 +172,7 @@ beforeEach(() => {
   queries.resourceCalls = [];
   queries.eventsCalls = [];
   queries.refetch.mockReset();
+  queries.resourceError = null;
   queries.applyMode = 'success';
   queries.applyMutateAsync.mockReset();
   queries.applyMutateAsync.mockImplementation(async () => {
@@ -250,6 +253,18 @@ describe('ResourceDetailDrawer', () => {
     expect(onBack).toHaveBeenCalledTimes(2);
     expect(onClose).toHaveBeenCalledOnce();
   }, 15_000);
+
+  it('marks a deleted resource and hides its actions, keeping the last state', () => {
+    const sel = selection('Pod');
+    queries.current = objectFor(sel, { status: { phase: 'Running' } });
+    queries.resourceError = Object.assign(new Error('pods "pod-a" not found'), { status: 404 });
+    render(<ResourceDetailPanel sel={sel} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Deleted from the cluster — showing the last known state.')).toBeInTheDocument();
+    expect(screen.getByText('Deleted')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Quick actions pod-a' })).not.toBeInTheDocument();
+    expect(screen.getByText('Pod overview pod-a')).toBeInTheDocument();
+  });
 
   it('guards dirty ConfigMap data before changing tabs or closing', () => {
     const sel = selection('ConfigMap');

--- a/tests/unit/client/resource-detail-drawer.test.tsx
+++ b/tests/unit/client/resource-detail-drawer.test.tsx
@@ -204,6 +204,9 @@ describe('ResourceDetailDrawer', () => {
     expect(screen.getByRole('tab', { name: 'Metrics' })).toBeInTheDocument();
     expect(screen.queryByLabelText('Full screen')).not.toBeInTheDocument();
     expect(effects.yamlSchema).toHaveBeenCalledWith(expect.objectContaining({ kind: 'Pod' }));
+    const podCalls = () => queries.resourceCalls.filter(({ selection: call }) => call?.name === 'pod-a');
+    // Overview is live: watch-fed with the poll as fallback.
+    expect(podCalls().at(-1)?.options).toMatchObject({ liveMs: 5000, watch: true });
 
     fireEvent.click(screen.getByRole('tab', { name: 'Map' }));
     expect(screen.getByText('Topology pod-a')).toBeInTheDocument();
@@ -214,6 +217,8 @@ describe('ResourceDetailDrawer', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'YAML' }));
     expect(screen.getByTestId('yaml-editor')).toHaveTextContent('Replace');
     expect((screen.getByLabelText('YAML input') as HTMLTextAreaElement).value).toContain('name: pod-a');
+    // Off Overview the object freezes so live updates cannot clobber edits.
+    expect(podCalls().at(-1)?.options).toMatchObject({ liveMs: undefined, watch: false });
     fireEvent.click(screen.getByRole('button', { name: 'Dry run YAML mock' }));
     expect(queries.dryRunMutateAsync).toHaveBeenCalledWith(expect.objectContaining({ ctx: 'dev' }));
 


### PR DESCRIPTION
## Summary

- feed the open detail drawer from the shared watch subscription so the Overview keeps pace with the tables instead of lagging on a gated 5s poll (which the refresh-rate preference, an unfocused window or staleTime could defer indefinitely)
- reuse the cluster-wide wire subscription an open list page already holds, so the common row-click path adds no watch cost
- keep the poll as fallback; revealed Secret reads stay poll-only since the watch stream is redacted
- surface deletions: a DELETED event (or absence from a reconnect snapshot) keeps the terminal object for post-mortem but marks the drawer with a Deleted chip and banner, hides quick actions, and stops the poll; a recreate under the same name goes live again
- non-Overview tabs still freeze their snapshot so live updates cannot clobber YAML edits

## Testing

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- built-client browser verification against a kind cluster: with the refresh rate set to *off*, an open ConfigMap panel showed a `kubectl patch` 610ms later with zero resource GETs (watch-fed); an open Pod drawer showed Terminating 247ms after `kubectl delete` and flipped to the Deleted banner once the pod was removed, in step with the table

Fixes #152