### PR TITLE
Add an About page to Settings and the docs

### DIFF
--- a/client/src/components/settings/AboutSection.tsx
+++ b/client/src/components/settings/AboutSection.tsx
@@ -1,0 +1,226 @@
+import { Fragment, useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
+import CoffeeOutlinedIcon from '@mui/icons-material/CoffeeOutlined';
+import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
+import StarBorderOutlinedIcon from '@mui/icons-material/StarBorderOutlined';
+import type { AppInfo, UpdateCheckResult } from '@kubus/shared';
+import { checkForUpdate, getAppInfo } from '../../api/app.js';
+
+const LINKS = {
+  docs: 'https://kubus-app.dev/',
+  source: 'https://github.com/FloSch62/Kubus',
+  releases: 'https://github.com/FloSch62/Kubus/releases',
+  author: 'https://flosch.me/',
+  authorGithub: 'https://github.com/FloSch62',
+  authorLinkedIn: 'https://www.linkedin.com/in/florian-schwarz-812a34145/',
+  coffee: 'https://www.buymeacoffee.com/FloSch62',
+} as const;
+
+/**
+ * The About page of Settings: what this build is, who makes it, how to support
+ * the work, and whether a newer build exists. Every link opens in the system
+ * browser (the desktop shell denies new windows and hands the URL to the OS).
+ */
+export function AboutSection() {
+  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getAppInfo()
+      .then((info) => {
+        if (!cancelled) setAppInfo(info ?? null);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <Stack spacing={3}>
+      <Box>
+        <SectionTitle>About</SectionTitle>
+        <Stack spacing={1.25}>
+          <Typography variant="body2">
+            {[`Kubus ${appInfo?.version ?? ''}`.trim(), platformLabel(window.kubusDesktop?.platform), 'MIT license']
+              .filter(Boolean)
+              .join(' · ')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            A free, open-source Kubernetes GUI. Browse every cluster and resource, stream logs, open shells,
+            forward ports, watch metrics and manage Helm from one local app.
+          </Typography>
+          <LinkRow
+            links={[
+              ['Documentation', LINKS.docs],
+              ['Source', LINKS.source],
+              ['Releases', LINKS.releases],
+            ]}
+          />
+        </Stack>
+      </Box>
+
+      <Box>
+        <SectionTitle>Made by</SectionTitle>
+        <Stack spacing={1.25}>
+          <Typography variant="body2" color="text.secondary">
+            Kubus is built by me (FloSch), in the open and in my spare time. Bug reports, ideas and pull
+            requests are always welcome.
+          </Typography>
+          <LinkRow
+            links={[
+              ['flosch.me', LINKS.author],
+              ['GitHub', LINKS.authorGithub],
+              ['LinkedIn', LINKS.authorLinkedIn],
+            ]}
+          />
+        </Stack>
+      </Box>
+
+      <Box>
+        <SectionTitle>Support</SectionTitle>
+        <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+          <Typography variant="body2" color="text.secondary">
+            Kubus is free and stays free. If it saves you time, a coffee keeps the releases coming.
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+            <Button
+              variant="outlined"
+              startIcon={<CoffeeOutlinedIcon />}
+              href={LINKS.coffee}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Buy me a coffee
+            </Button>
+            <Button startIcon={<StarBorderOutlinedIcon />} href={LINKS.source} target="_blank" rel="noreferrer">
+              Star on GitHub
+            </Button>
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Box>
+        <SectionTitle>Updates</SectionTitle>
+        <UpdateControls currentVersion={appInfo?.version} />
+      </Box>
+    </Stack>
+  );
+}
+
+function UpdateControls({ currentVersion }: { currentVersion?: string }) {
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<UpdateCheckResult | null>(null);
+
+  const checkForUpdates = () => {
+    setChecking(true);
+    setResult(null);
+    void checkForUpdate({ force: true })
+      .then(setResult)
+      .catch(() => setResult({ available: false, currentVersion: currentVersion ?? '', reason: 'network' }))
+      .finally(() => setChecking(false));
+  };
+
+  const updatesAvailable = result?.available === true;
+
+  return (
+    <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
+      <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+        <Button
+          variant="contained"
+          startIcon={checking ? <CircularProgress color="inherit" size={16} /> : <CachedOutlinedIcon />}
+          disabled={checking}
+          onClick={checkForUpdates}
+        >
+          Check for updates
+        </Button>
+        {updatesAvailable && (
+          <Button startIcon={<DownloadOutlinedIcon />} href={result.releaseUrl} target="_blank" rel="noreferrer">
+            Download
+          </Button>
+        )}
+      </Stack>
+      {result?.available === false && result.latestVersion && (
+        <Alert severity="success" variant="outlined">
+          Kubus is up to date. Latest release: {result.latestVersion}.
+        </Alert>
+      )}
+      {result?.available === false && !result.latestVersion && (
+        <Alert severity="warning" variant="outlined">
+          {updateReasonLabel(result.reason)}
+        </Alert>
+      )}
+      {updatesAvailable && (
+        <Alert severity="info" variant="outlined">
+          Kubus {result.latestVersion} is available. You are running {result.currentVersion}.
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+function SectionTitle({ children }: { children: string }) {
+  return (
+    <Typography variant="subtitle2" gutterBottom>
+      {children}
+    </Typography>
+  );
+}
+
+/** A row of plain links, the way the rest of the dialog points elsewhere. */
+function LinkRow({ links }: { links: ReadonlyArray<readonly [label: string, href: string]> }) {
+  return (
+    <Typography variant="body2" sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1 }}>
+      {links.map(([label, href], index) => (
+        <Fragment key={href}>
+          {index > 0 && (
+            <Box component="span" aria-hidden sx={{ color: 'text.disabled' }}>
+              ·
+            </Box>
+          )}
+          <Link href={href} target="_blank" rel="noreferrer">
+            {label}
+          </Link>
+        </Fragment>
+      ))}
+    </Typography>
+  );
+}
+
+function platformLabel(platform?: string): string {
+  switch (platform) {
+    case 'darwin':
+      return 'macOS';
+    case 'win32':
+      return 'Windows';
+    case 'linux':
+      return 'Linux';
+    default:
+      return platform ?? '';
+  }
+}
+
+function updateReasonLabel(reason?: string): string {
+  switch (reason) {
+    case 'timeout':
+      return 'The update check timed out.';
+    case 'network':
+      return 'The update check could not reach GitHub.';
+    case 'no-release':
+      return 'No published release was found.';
+    case 'missing-version':
+    case 'missing-release-url':
+      return 'The latest release metadata is incomplete.';
+    default:
+      return reason?.startsWith('manifest-')
+        ? `The update manifest returned ${reason.replace('manifest-', '')}.`
+        : 'The update check could not be completed.';
+  }
+}

--- a/client/src/components/settings/SettingsDialog.tsx
+++ b/client/src/components/settings/SettingsDialog.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
-import CircularProgress from '@mui/material/CircularProgress';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -28,7 +27,6 @@ import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import ShieldIcon from '@mui/icons-material/Shield';
@@ -36,15 +34,15 @@ import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteOutlinedIcon from '@mui/icons-material/DeleteOutlined';
 import AddIcon from '@mui/icons-material/Add';
-import type { AppInfo, ContextInfo, DebugProfile, UpdateCheckResult } from '@kubus/shared';
+import type { ContextInfo, DebugProfile } from '@kubus/shared';
 import { useAddDebugImage, useContexts, useDebugImages, useDeleteCluster, useKubeconfigSettings, useRemoveDebugImage } from '../../api/queries.js';
 import { ConfirmDialog } from '../ConfirmDialog.js';
-import { checkForUpdate, getAppInfo } from '../../api/app.js';
 import { AddClusterDialog } from './AddClusterDialog.js';
 import { EditClusterDialog } from './EditClusterDialog.js';
 import { useClustersStore } from '../../state/clusters.js';
 import { useLogPrefsStore, type TsMode } from '../../state/log-prefs.js';
 import { TAIL_LINE_OPTIONS, useUiPrefsStore, type RefreshRate, type RightClickAction, type TableDensity } from '../../state/prefs.js';
+import { AboutSection } from './AboutSection.js';
 import { KubeconfigSection } from './KubeconfigSection.js';
 import { isBuiltInDebugImage, mergeDebugPresets } from '../../debug-presets.js';
 import { fetchAppLogs, formatLogEntry } from '../../api/logs.js';
@@ -604,115 +602,6 @@ function DebugSection() {
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
           Covers app startup and operations since launch. Logs are held in memory on this machine only and never leave it unless you export them. If the desktop app fails to launch entirely, its shell also writes logs/main.log in the app data directory.
         </Typography>
-      </Section>
-    </Stack>
-  );
-}
-
-function updateReasonLabel(reason?: string): string {
-  switch (reason) {
-    case 'timeout':
-      return 'The update check timed out.';
-    case 'network':
-      return 'The update check could not reach GitHub.';
-    case 'no-release':
-      return 'No published release was found.';
-    case 'missing-version':
-    case 'missing-release-url':
-      return 'The latest release metadata is incomplete.';
-    default:
-      return reason?.startsWith('manifest-')
-        ? `The update manifest returned ${reason.replace('manifest-', '')}.`
-        : 'The update check could not be completed.';
-  }
-}
-
-function AboutSection() {
-  const [appInfo, setAppInfo] = useState<AppInfo | null>(null);
-  const [loaded, setLoaded] = useState(false);
-  const [checking, setChecking] = useState(false);
-  const [result, setResult] = useState<UpdateCheckResult | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    void getAppInfo()
-      .then((info) => {
-        if (!cancelled) setAppInfo(info ?? null);
-      })
-      .catch(() => undefined)
-      .finally(() => {
-        if (!cancelled) setLoaded(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const checkForUpdates = () => {
-    setChecking(true);
-    setResult(null);
-    void checkForUpdate({ force: true })
-      .then(setResult)
-      .catch(() => setResult({ available: false, currentVersion: appInfo?.version ?? '', reason: 'network' }))
-      .finally(() => setChecking(false));
-  };
-
-  const version = appInfo?.version ?? (loaded ? 'Unavailable' : 'Loading…');
-  const updatesAvailable = result?.available === true;
-
-  return (
-    <Stack spacing={3}>
-      <Section title="Application">
-        <Stack spacing={1.25}>
-          <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-              Version
-            </Typography>
-            <Typography variant="body2">{version}</Typography>
-          </Box>
-          <Box>
-            <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
-              Repository
-            </Typography>
-            <Link href="https://github.com/FloSch62/Kubus" target="_blank" rel="noreferrer">
-              github.com/FloSch62/Kubus
-            </Link>
-          </Box>
-        </Stack>
-      </Section>
-      <Section title="Updates">
-        <Stack spacing={1.5} sx={{ alignItems: 'flex-start' }}>
-          <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
-            <Button
-              variant="contained"
-              startIcon={checking ? <CircularProgress color="inherit" size={16} /> : <CachedOutlinedIcon />}
-              disabled={checking}
-              onClick={checkForUpdates}
-            >
-              Check for updates
-            </Button>
-            {updatesAvailable && (
-              <Button startIcon={<DownloadOutlinedIcon />} href={result.releaseUrl} target="_blank" rel="noreferrer">
-                Download
-              </Button>
-            )}
-          </Stack>
-          {result?.available === false && result.latestVersion && (
-            <Alert severity="success" variant="outlined">
-              Kubus is up to date. Latest release: {result.latestVersion}.
-            </Alert>
-          )}
-          {result?.available === false && !result.latestVersion && (
-            <Alert severity="warning" variant="outlined">
-              {updateReasonLabel(result.reason)}
-            </Alert>
-          )}
-          {updatesAvailable && (
-            <Alert severity="info" variant="outlined">
-              Kubus {result.latestVersion} is available. You are running {result.currentVersion}.
-            </Alert>
-          )}
-        </Stack>
       </Section>
     </Stack>
   );

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,51 @@
+---
+icon: lucide/user-round
+hide:
+  - navigation
+---
+
+# About
+
+Kubus is built by me (FloSch), in the open and in my spare time. I build open-source tooling
+for network automation and the desktop apps that go with it, and Kubus is the Kubernetes client
+I wanted for that work: every cluster from my kubeconfig in one window, with the logs, shells,
+port forwards, metrics and Helm releases next to the resources they belong to, and nothing
+leaving my machine.
+
+- :material-web: [flosch.me](https://flosch.me/), who I am and what I work on
+- :simple-github: [FloSch62 on GitHub](https://github.com/FloSch62), everything I build, Kubus included
+- :fontawesome-brands-linkedin: [LinkedIn](https://www.linkedin.com/in/florian-schwarz-812a34145/), say hello
+
+## Support Kubus
+
+Kubus is free and stays free. If it saves you time, a coffee keeps the releases coming, and a
+star helps others find it.
+
+[:simple-buymeacoffee: Buy me a coffee](https://www.buymeacoffee.com/FloSch62){ .md-button .md-button--primary }
+[:material-star-outline: Star on GitHub](https://github.com/FloSch62/Kubus){ .md-button }
+
+## Other things I build
+
+<div class="grid cards" markdown>
+
+-   :material-console: **[Muxus](https://github.com/FloSch62/muxus)**
+
+    ---
+
+    A free, open-source SSH, Telnet and serial client. Split panes, saved workspaces, SFTP,
+    a remote editor, saved tunnels and images in the terminal.
+
+-   :material-lan: **[containerlab tooling](https://github.com/srl-labs/vscode-containerlab)**
+
+    ---
+
+    The VS Code extension and the desktop app for containerlab, which spins up container-based
+    networking labs from topology files.
+
+</div>
+
+## Get in touch
+
+Bug reports, ideas and pull requests are always welcome on the
+[issue tracker](https://github.com/FloSch62/Kubus/issues). For anything else, the links above
+reach me.

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -59,6 +59,17 @@
   font-size: 0.78rem;
 }
 
+/* An icon shortcode inside a button sits on the text baseline with a small gap. */
+.md-typeset .md-button .twemoji {
+  margin-right: 0.35em;
+  vertical-align: -0.2em;
+}
+
+.md-typeset .md-button .twemoji svg {
+  width: 1.1em;
+  height: 1.1em;
+}
+
 /* ---------------------------------------------------------------------------
    Landing page hero. Rendered by overrides/partials/kubus-hero.html for pages
    with `hero: true`; the cube field comes from hack/docs-hero.mjs.

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -45,3 +45,12 @@ whether that's code, docs, a bug report or a feature idea.
 
 - :simple-github: **Source & issues**: [github.com/FloSch62/Kubus](https://github.com/FloSch62/Kubus)
 - :material-download: **Releases**: [github.com/FloSch62/Kubus/releases](https://github.com/FloSch62/Kubus/releases)
+- :material-account-outline: **The author**: [About](../about.md), or [flosch.me](https://flosch.me/)
+
+## Support the project
+
+Kubus is built by me (FloSch) in my spare time, and it is free and stays free. If it saves you
+time, a coffee keeps the releases coming, and a star helps others find it.
+
+[:simple-buymeacoffee: Buy me a coffee](https://www.buymeacoffee.com/FloSch62){ .md-button .md-button--primary }
+[:material-star-outline: Star on GitHub](https://github.com/FloSch62/Kubus){ .md-button }

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,3 +132,11 @@ machine.
     Kubus runs on your machine against clusters you already have credentials for. It is
     not a hosted, multi-tenant dashboard. The [security model](reference/security.md)
     spells out exactly what that means.
+
+## Made by
+
+Kubus is built by me (FloSch), in the open and in my spare time. It is free and stays free.
+If it saves you time, a coffee keeps the releases coming. [More about me](about.md).
+
+[:simple-buymeacoffee: Buy me a coffee](https://www.buymeacoffee.com/FloSch62){ .md-button .md-button--primary }
+[:material-star-outline: Star on GitHub](https://github.com/FloSch62/Kubus){ .md-button }

--- a/zensical.toml
+++ b/zensical.toml
@@ -77,6 +77,7 @@ nav = [
     { "Test clusters" = "community/test-clusters.md" },
     { "FAQ" = "community/faq.md" },
   ] },
+  { "About" = "about.md" },
 ]
 
 # ----------------------------------------------------------------------------
@@ -134,6 +135,16 @@ code = "JetBrains Mono"
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/FloSch62/Kubus"
+
+[[project.extra.social]]
+icon = "simple/buymeacoffee"
+link = "https://www.buymeacoffee.com/FloSch62"
+name = "Buy me a coffee"
+
+[[project.extra.social]]
+icon = "material/web"
+link = "https://flosch.me/"
+name = "flosch.me"
 
 # ----------------------------------------------------------------------------
 # Markdown extensions, the same stack containerlab.dev / Material sites use.


### PR DESCRIPTION
## Summary

Kubus gets a proper About page in two places.

**Settings → About** moves into its own component, `client/src/components/settings/AboutSection.tsx`, and keeps the dialog's plain style: section titles, body text, links and buttons, no cards.

- **About.** Build line with version, platform and licence, the one-line description, and Documentation · Source · Releases links. The platform comes from the desktop bridge, so the browser build shows just version and licence.
- **Made by.** "Kubus is built by me (FloSch), in the open and in my spare time…" with flosch.me · GitHub · LinkedIn links.
- **Support.** A short line, an outlined Buy Me a Coffee button and a text "Star on GitHub" button.
- **Updates.** Unchanged.

Every link opens with `target="_blank"`, which the desktop shell already routes to the system browser.

**Docs** get an About tab after Community, with the same content in prose: who makes Kubus, the personal links as an icon list, the support buttons, the other projects, and how to get in touch. The landing page's "Made by" section and the Community page's "Support the project" section use the same icon buttons and link through to it. The footer carries the Buy Me a Coffee and website icons next to GitHub, and a small style rule aligns icon glyphs inside docs buttons.

## Verification

- Lint, typecheck and the client build pass.
- `zensical build --clean --strict` passes.
- Drove Settings → About against the built client in both themes: all eight links carry the expected hrefs and open in a new tab, and the update check still returns a result.
- Captured the docs About page, the landing "Made by" section and the Community page in both themes.
