### PR TITLE
Prepare v0.8.0 release

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/release-notes/0.8.md
+++ b/docs/release-notes/0.8.md
@@ -1,0 +1,70 @@
+---
+icon: lucide/scroll-text
+---
+
+# Release 0.8
+
+:material-calendar: 2 September 2026 · [Full changelog](https://github.com/FloSch62/Kubus/compare/v0.7.0...v0.8.0)
+
+Release 0.8 turns resource details and Helm releases into live, hands-on workspaces. The
+new manifest tree makes complete Kubernetes objects easier to understand and edit, while
+the redesigned detail views surface health, relationships and actions without losing
+context. Helm pages now follow changes from the cluster as they happen.
+
+## Browse and edit complete manifests
+
+The new **Manifest** tab presents every object as a structured tree with schema descriptions,
+natural names for list items, links to related resources and tools to filter or expand the
+object. Values can be edited in place, fields and list items can be added or removed, and a
+review step shows the resulting YAML diff before a server-side dry run and apply.
+
+Tree and YAML views share the same draft, and unapplied changes stay with their resource
+while you browse elsewhere. When the live object changes, Kubus can rebase the draft onto
+the latest version instead of discarding it. Protected fields stay locked, and Secret data
+remains masked until explicitly revealed.
+
+## Detail views that explain what is happening
+
+The resource drawer has been rebuilt around concise summaries, problem banners and
+collapsible sections. Pods expose container state, usage, probes, environment, mounts and
+quick actions in one place. Deployments make rollout progress and failing pods clearer,
+Services connect ports to live endpoints, and Nodes combine health, capacity and scheduled
+pods. Related resources are clickable, with a back stack for returning to the starting
+object.
+
+The drawer now stays synchronized with Kubernetes watch data, including deletion and full
+query changes, so an open detail view does not quietly fall behind the resource list.
+
+## Helm pages that stay live
+
+Kubus now watches Helm release records and updates both the release list and detail page
+within seconds when a release changes in Kubus, the Helm CLI or a GitOps controller. A
+visible status badge reports whether each cluster is using a live watch or the permission-
+aware polling fallback.
+
+Release details add a live resource overview with readiness at a glance and direct links to
+the underlying Kubernetes objects. Filters for releases that need attention or have chart
+updates make large installations easier to scan, and upgrade or uninstall actions are now
+available directly from a release's context menu.
+
+## Faster, bounded cluster watches
+
+Kubernetes watches can share HTTP/2 connections, reducing connection pressure while keeping
+resource lists and CRD search live. Search watches are bounded, API server base paths are
+honoured and aborted requests and log streams shut down cleanly, improving behaviour on
+large clusters and through proxies.
+
+## Debug with your own image catalog
+
+Settings now includes a configurable debug-container catalog. Add internal toolbox images,
+replace built-in presets and associate each entry with a preferred security profile, then
+choose those presets when starting a pod debug session.
+
+## Navigation and desktop polish
+
+Favourite categories reveal themselves when a matching tab becomes active, topology lock
+controls behave consistently, and the namespace picker remains clickable with the macOS
+title-bar overlay. The new About page puts version, project and support information inside
+Kubus and on the documentation site.
+
+[View the v0.8.0 release on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.8.0)

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,8 +5,8 @@ hide:
   - toc
 ---
 
-<meta http-equiv="refresh" content="0; url=0.7/">
+<meta http-equiv="refresh" content="0; url=0.8/">
 
 # Latest release
 
-[Continue to release 0.7](0.7.md)
+[Continue to release 0.8](0.8.md)

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/tests",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/zensical.toml
+++ b/zensical.toml
@@ -61,6 +61,7 @@ nav = [
     { "Security model" = "reference/security.md" },
   ] },
   { "Release notes" = [
+    { "0.8" = "release-notes/0.8.md" },
     { "0.7" = "release-notes/0.7.md" },
     { "0.6" = "release-notes/0.6.md" },
     { "0.5" = "release-notes/0.5.md" },


### PR DESCRIPTION
## Summary

- bump every workspace package from 0.7.1 to 0.8.0
- add release 0.8 notes covering the manifest editor, redesigned detail views, live Helm pages, cluster watch improvements, configurable debug images and desktop polish
- make 0.8 the latest release in the documentation navigation and redirect

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build-docs`

The local Node.js version is 24.18.0 while the project requests at least 24.20.0; all checks completed successfully despite that engine warning.