### PR TITLE
fix: keep Edit menu copy working on macOS and release v0.8.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/client",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/release-notes/0.8.md
+++ b/docs/release-notes/0.8.md
@@ -125,4 +125,12 @@ that use the same server.
 
 Source builds now require **Node.js 24.20.0 or newer** and use **pnpm 11.24.0**.
 
+## Patches
+
+### 0.8.1
+
+:material-calendar: 3 September 2026 · [Changes](https://github.com/FloSch62/Kubus/compare/v0.8.0...v0.8.1)
+
+- Cmd+C copies selected text in the macOS desktop app even when the window's web content is not reported as focused.
+
 [View the v0.8.0 release on GitHub](https://github.com/FloSch62/Kubus/releases/tag/v0.8.0)

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/electron",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Kubus desktop app",
   "license": "MIT",

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -205,7 +205,12 @@ function saveClientState(state: Record<string, string>): void {
 interface EditCommand {
   label: string;
   accelerator?: string;
-  /** Mirrors the predefined role: shown, but not registered as a window-wide shortcut. */
+  /**
+   * Windows/Linux only, mirroring the predefined role: the chord is shown but
+   * not registered as a window-wide shortcut, so the renderer keeps handling
+   * it natively. macOS ignores the flag and always binds the accelerator as
+   * the menu item's key equivalent, which is how Cmd+C reaches `click`.
+   */
   registerAccelerator?: boolean;
   run: (target: WebContents) => void;
 }

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -12,6 +12,7 @@ import {
   nativeTheme,
   screen,
   shell,
+  webContents,
   type MenuItemConstructorOptions,
   type WebContents,
 } from 'electron';
@@ -34,6 +35,7 @@ mainLog('info', `Kubus ${app.getVersion()} starting on ${process.platform}/${pro
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const isMac = process.platform === 'darwin';
+const isWindows = process.platform === 'win32';
 const isLinux = process.platform === 'linux';
 
 // Must match the client TopBar height: its toolbar doubles as the titlebar.
@@ -200,23 +202,49 @@ function saveClientState(state: Record<string, string>): void {
   clientStateCache = state;
 }
 
-type EditRole = 'undo' | 'redo' | 'cut' | 'copy' | 'paste' | 'pasteAndMatchStyle' | 'delete' | 'selectAll';
+interface EditCommand {
+  label: string;
+  accelerator?: string;
+  /** Mirrors the predefined role: shown, but not registered as a window-wide shortcut. */
+  registerAccelerator?: boolean;
+  run: (target: WebContents) => void;
+}
 
 /**
- * An Edit item that keeps its native role but falls back to the key window's
- * web contents. Electron only runs a role's web-contents method on the web
- * contents it reports as focused, and on macOS that lookup can come back
- * empty while the page still shows a selection (the renderer view is not the
- * window's first responder). The stock editMenu role then dropped Cmd+C
- * silently — and macOS has no other copy path, unlike Linux/Windows where the
- * renderer handles Ctrl+C itself and never goes through the menu.
+ * The Edit commands, mirroring Electron's predefined roles item for item.
+ * They are plain items rather than roles because a role only ever acts on
+ * the web contents Electron reports as focused, and its click handler is
+ * documented as ignored. On macOS that lookup can come back empty while the
+ * page still shows a selection (the renderer view is not the window's first
+ * responder), so the stock editMenu dropped Cmd+C silently — and macOS has
+ * no other copy path, unlike Linux/Windows where the renderer handles Ctrl+C
+ * itself and never goes through the menu. These fall back to the key window.
  */
-function editItem(role: EditRole, method: (wc: WebContents) => void): MenuItemConstructorOptions {
+const EDIT_COMMANDS = {
+  undo: { label: 'Undo', accelerator: 'CommandOrControl+Z', run: (target) => target.undo() },
+  redo: { label: 'Redo', accelerator: isWindows ? 'Control+Y' : 'Shift+CommandOrControl+Z', run: (target) => target.redo() },
+  cut: { label: 'Cut', accelerator: 'CommandOrControl+X', registerAccelerator: false, run: (target) => target.cut() },
+  copy: { label: 'Copy', accelerator: 'CommandOrControl+C', registerAccelerator: false, run: (target) => target.copy() },
+  paste: { label: 'Paste', accelerator: 'CommandOrControl+V', registerAccelerator: false, run: (target) => target.paste() },
+  pasteAndMatchStyle: {
+    label: 'Paste and Match Style',
+    accelerator: isMac ? 'Cmd+Option+Shift+V' : 'Shift+CommandOrControl+V',
+    registerAccelerator: false,
+    run: (target) => target.pasteAndMatchStyle(),
+  },
+  delete: { label: 'Delete', run: (target) => target.delete() },
+  selectAll: { label: 'Select All', accelerator: 'CommandOrControl+A', run: (target) => target.selectAll() },
+} satisfies Record<string, EditCommand>;
+
+function editItem(command: EditCommand): MenuItemConstructorOptions {
+  const { label, accelerator, registerAccelerator, run } = command;
   return {
-    role,
+    label,
+    ...(accelerator ? { accelerator } : {}),
+    ...(registerAccelerator === undefined ? {} : { registerAccelerator }),
     click: () => {
-      const win = BrowserWindow.getFocusedWindow() ?? primaryWindow;
-      if (win && !win.isDestroyed()) method(win.webContents);
+      const target = webContents.getFocusedWebContents() ?? (BrowserWindow.getFocusedWindow() ?? primaryWindow)?.webContents;
+      if (target && !target.isDestroyed()) run(target);
     },
   };
 }
@@ -224,22 +252,22 @@ function editItem(role: EditRole, method: (wc: WebContents) => void): MenuItemCo
 function buildEditMenu(): MenuItemConstructorOptions {
   const platformItems: MenuItemConstructorOptions[] = isMac
     ? [
-        editItem('pasteAndMatchStyle', (wc) => wc.pasteAndMatchStyle()),
-        editItem('delete', (wc) => wc.delete()),
-        editItem('selectAll', (wc) => wc.selectAll()),
+        editItem(EDIT_COMMANDS.pasteAndMatchStyle),
+        editItem(EDIT_COMMANDS.delete),
+        editItem(EDIT_COMMANDS.selectAll),
         { type: 'separator' },
         { label: 'Speech', submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }] },
       ]
-    : [editItem('delete', (wc) => wc.delete()), { type: 'separator' }, editItem('selectAll', (wc) => wc.selectAll())];
+    : [editItem(EDIT_COMMANDS.delete), { type: 'separator' }, editItem(EDIT_COMMANDS.selectAll)];
   return {
     label: 'Edit',
     submenu: [
-      editItem('undo', (wc) => wc.undo()),
-      editItem('redo', (wc) => wc.redo()),
+      editItem(EDIT_COMMANDS.undo),
+      editItem(EDIT_COMMANDS.redo),
       { type: 'separator' },
-      editItem('cut', (wc) => wc.cut()),
-      editItem('copy', (wc) => wc.copy()),
-      editItem('paste', (wc) => wc.paste()),
+      editItem(EDIT_COMMANDS.cut),
+      editItem(EDIT_COMMANDS.copy),
+      editItem(EDIT_COMMANDS.paste),
       ...platformItems,
     ],
   };

--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -13,6 +13,7 @@ import {
   screen,
   shell,
   type MenuItemConstructorOptions,
+  type WebContents,
 } from 'electron';
 import fixPath from 'fix-path';
 import { startServer, type RunningServer } from '@kubus/server';
@@ -199,11 +200,56 @@ function saveClientState(state: Record<string, string>): void {
   clientStateCache = state;
 }
 
+type EditRole = 'undo' | 'redo' | 'cut' | 'copy' | 'paste' | 'pasteAndMatchStyle' | 'delete' | 'selectAll';
+
+/**
+ * An Edit item that keeps its native role but falls back to the key window's
+ * web contents. Electron only runs a role's web-contents method on the web
+ * contents it reports as focused, and on macOS that lookup can come back
+ * empty while the page still shows a selection (the renderer view is not the
+ * window's first responder). The stock editMenu role then dropped Cmd+C
+ * silently — and macOS has no other copy path, unlike Linux/Windows where the
+ * renderer handles Ctrl+C itself and never goes through the menu.
+ */
+function editItem(role: EditRole, method: (wc: WebContents) => void): MenuItemConstructorOptions {
+  return {
+    role,
+    click: () => {
+      const win = BrowserWindow.getFocusedWindow() ?? primaryWindow;
+      if (win && !win.isDestroyed()) method(win.webContents);
+    },
+  };
+}
+
+function buildEditMenu(): MenuItemConstructorOptions {
+  const platformItems: MenuItemConstructorOptions[] = isMac
+    ? [
+        editItem('pasteAndMatchStyle', (wc) => wc.pasteAndMatchStyle()),
+        editItem('delete', (wc) => wc.delete()),
+        editItem('selectAll', (wc) => wc.selectAll()),
+        { type: 'separator' },
+        { label: 'Speech', submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }] },
+      ]
+    : [editItem('delete', (wc) => wc.delete()), { type: 'separator' }, editItem('selectAll', (wc) => wc.selectAll())];
+  return {
+    label: 'Edit',
+    submenu: [
+      editItem('undo', (wc) => wc.undo()),
+      editItem('redo', (wc) => wc.redo()),
+      { type: 'separator' },
+      editItem('cut', (wc) => wc.cut()),
+      editItem('copy', (wc) => wc.copy()),
+      editItem('paste', (wc) => wc.paste()),
+      ...platformItems,
+    ],
+  };
+}
+
 function buildMenu(): void {
   const template: MenuItemConstructorOptions[] = [
     ...(isMac ? [{ role: 'appMenu' as const }] : []),
     { role: 'fileMenu' },
-    { role: 'editMenu' },
+    buildEditMenu(),
     { role: 'viewMenu' },
     { role: 'windowMenu' },
   ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kubus",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Free, open-source Kubernetes GUI — multi-cluster browsing, logs, exec, port-forward, metrics, Helm",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/shared",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubus/tests",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -22,6 +22,7 @@ const electron = vi.hoisted(() => {
     readonly pasteAndMatchStyle = vi.fn();
     readonly delete = vi.fn();
     readonly selectAll = vi.fn();
+    readonly isDestroyed = vi.fn(() => false);
     readonly on = vi.fn((name: string, handler: Handler) => {
       this.handlers.set(name, handler);
       return this;
@@ -103,6 +104,7 @@ const electron = vi.hoisted(() => {
     setApplicationMenu: vi.fn(),
   };
   const shell = { openExternal: vi.fn(async () => undefined) };
+  const webContentsApi = { getFocusedWebContents: vi.fn((): MockWebContents | undefined => undefined) };
 
   return {
     app,
@@ -124,6 +126,8 @@ const electron = vi.hoisted(() => {
     shell,
     startServer,
     state,
+    webContentsApi,
+    MockWebContents,
   };
 });
 
@@ -136,18 +140,32 @@ vi.mock('electron', () => ({
   nativeTheme: electron.nativeTheme,
   screen: electron.screen,
   shell: electron.shell,
+  webContents: electron.webContentsApi,
 }));
 vi.mock('fix-path', () => ({ default: electron.fixPath }));
 vi.mock('@kubus/server', () => ({ appendAppLog: electron.appendAppLog, startServer: electron.startServer }));
 
-type EditRole = 'undo' | 'redo' | 'cut' | 'copy' | 'paste' | 'pasteAndMatchStyle' | 'delete' | 'selectAll';
+type EditMethod = 'undo' | 'redo' | 'cut' | 'copy' | 'paste' | 'pasteAndMatchStyle' | 'delete' | 'selectAll';
 interface MenuTemplateItem {
   label?: string;
   role?: string;
   type?: string;
+  accelerator?: string;
+  registerAccelerator?: boolean;
   click?: () => void;
   submenu?: MenuTemplateItem[];
 }
+
+const EDIT_METHODS: Record<string, EditMethod> = {
+  Undo: 'undo',
+  Redo: 'redo',
+  Cut: 'cut',
+  Copy: 'copy',
+  Paste: 'paste',
+  'Paste and Match Style': 'pasteAndMatchStyle',
+  Delete: 'delete',
+  'Select All': 'selectAll',
+};
 
 let userDataPath: string;
 let previousHelmEngine: string | undefined;
@@ -196,6 +214,7 @@ beforeEach(() => {
   electron.ipcHandlers.clear();
   electron.BrowserWindow.instances.length = 0;
   electron.BrowserWindow.getFocusedWindow.mockReturnValue(undefined);
+  electron.webContentsApi.getFocusedWebContents.mockReturnValue(undefined);
   electron.app.isPackaged = false;
   electron.app.requestSingleInstanceLock.mockReturnValue(true);
   electron.app.whenReady.mockResolvedValue(undefined);
@@ -593,37 +612,50 @@ describe('Electron main process', () => {
     expect(electron.BrowserWindow.instances).toHaveLength(0);
   });
 
-  it('routes Edit menu commands to the focused window, falling back to the primary window', async () => {
+  it('routes Edit menu commands to the focused web contents, then the key window, then the primary window', async () => {
     const win = await loadMain();
     const items = editMenuItems();
-    const roles = items.map((item) => item.role ?? item.type ?? item.label);
+    const names = items.map((item) => item.label ?? item.type);
     if (process.platform === 'darwin') {
-      expect(roles).toEqual(['undo', 'redo', 'separator', 'cut', 'copy', 'paste', 'pasteAndMatchStyle', 'delete', 'selectAll', 'separator', 'Speech']);
+      expect(names).toEqual(['Undo', 'Redo', 'separator', 'Cut', 'Copy', 'Paste', 'Paste and Match Style', 'Delete', 'Select All', 'separator', 'Speech']);
     } else {
-      expect(roles).toEqual(['undo', 'redo', 'separator', 'cut', 'copy', 'paste', 'delete', 'separator', 'selectAll']);
+      expect(names).toEqual(['Undo', 'Redo', 'separator', 'Cut', 'Copy', 'Paste', 'Delete', 'separator', 'Select All']);
     }
-    // Every command keeps its native role and carries the fallback.
-    const commands = items.filter((item) => item.role);
-    expect(commands.every((item) => typeof item.click === 'function')).toBe(true);
+    // Plain items, never predefined roles: a role's click is ignored and a
+    // role only acts on the web contents Electron reports as focused.
+    const commands = items.filter((item) => item.label && item.label !== 'Speech');
+    expect(commands.every((item) => item.role === undefined && typeof item.click === 'function')).toBe(true);
+    expect(commands.find((item) => item.label === 'Copy')).toMatchObject({ accelerator: 'CommandOrControl+C', registerAccelerator: false });
+    expect(commands.find((item) => item.label === 'Redo')?.accelerator).toBe(process.platform === 'win32' ? 'Control+Y' : 'Shift+CommandOrControl+Z');
+    expect(commands.find((item) => item.label === 'Delete')).not.toHaveProperty('accelerator');
 
-    // Electron only calls click when it found no focused web contents; the
-    // key window then receives the command, never the primary one.
+    // The focused web contents wins, exactly like the predefined roles.
+    const focused = new electron.MockWebContents();
+    electron.webContentsApi.getFocusedWebContents.mockReturnValue(focused);
     const other = new electron.BrowserWindow({});
     electron.BrowserWindow.getFocusedWindow.mockReturnValue(other);
     for (const item of commands) {
       item.click!();
-      expect(other.webContents[item.role as EditRole], item.role).toHaveBeenCalledOnce();
-      expect(win.webContents[item.role as EditRole], item.role).not.toHaveBeenCalled();
+      expect(focused[EDIT_METHODS[item.label!]!], item.label).toHaveBeenCalledOnce();
+      expect(other.webContents[EDIT_METHODS[item.label!]!], item.label).not.toHaveBeenCalled();
+    }
+
+    // Without a focused web contents the key window receives the command.
+    electron.webContentsApi.getFocusedWebContents.mockReturnValue(undefined);
+    for (const item of commands) {
+      item.click!();
+      expect(other.webContents[EDIT_METHODS[item.label!]!], item.label).toHaveBeenCalledOnce();
+      expect(win.webContents[EDIT_METHODS[item.label!]!], item.label).not.toHaveBeenCalled();
     }
 
     // No key window at all: the primary window is the last resort.
     electron.BrowserWindow.getFocusedWindow.mockReturnValue(undefined);
-    const copy = commands.find((item) => item.role === 'copy')!;
+    const copy = commands.find((item) => item.label === 'Copy')!;
     copy.click!();
     expect(win.webContents.copy).toHaveBeenCalledOnce();
 
-    // A destroyed window is left alone.
-    win.isDestroyed.mockReturnValue(true);
+    // Destroyed web contents are left alone.
+    win.webContents.isDestroyed.mockReturnValue(true);
     copy.click!();
     expect(win.webContents.copy).toHaveBeenCalledOnce();
   });
@@ -633,13 +665,14 @@ describe('Electron main process', () => {
       const win = await loadMain();
       expect(win.setMenuBarVisibility).not.toHaveBeenCalled();
       const items = editMenuItems();
-      expect(items.map((item) => item.role ?? item.type ?? item.label)).toEqual([
-        'undo', 'redo', 'separator', 'cut', 'copy', 'paste', 'pasteAndMatchStyle', 'delete', 'selectAll', 'separator', 'Speech',
+      expect(items.map((item) => item.label ?? item.type)).toEqual([
+        'Undo', 'Redo', 'separator', 'Cut', 'Copy', 'Paste', 'Paste and Match Style', 'Delete', 'Select All', 'separator', 'Speech',
       ]);
+      expect(items.find((item) => item.label === 'Paste and Match Style')?.accelerator).toBe('Cmd+Option+Shift+V');
       expect(items.find((item) => item.label === 'Speech')?.submenu).toEqual([{ role: 'startSpeaking' }, { role: 'stopSpeaking' }]);
-      for (const item of items.filter((entry) => entry.role)) {
+      for (const item of items.filter((entry) => entry.label && entry.label !== 'Speech')) {
         item.click!();
-        expect(win.webContents[item.role as EditRole], item.role).toHaveBeenCalledOnce();
+        expect(win.webContents[EDIT_METHODS[item.label!]!], item.label).toHaveBeenCalledOnce();
       }
     });
   });

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -14,6 +14,14 @@ const electron = vi.hoisted(() => {
     readonly id = ++state.nextWebContentsId;
     readonly handlers = new Map<string, Handler>();
     readonly send = vi.fn();
+    readonly undo = vi.fn();
+    readonly redo = vi.fn();
+    readonly cut = vi.fn();
+    readonly copy = vi.fn();
+    readonly paste = vi.fn();
+    readonly pasteAndMatchStyle = vi.fn();
+    readonly delete = vi.fn();
+    readonly selectAll = vi.fn();
     readonly on = vi.fn((name: string, handler: Handler) => {
       this.handlers.set(name, handler);
       return this;
@@ -26,6 +34,7 @@ const electron = vi.hoisted(() => {
 
   class MockBrowserWindow {
     static readonly instances: MockBrowserWindow[] = [];
+    static readonly getFocusedWindow = vi.fn((): MockBrowserWindow | undefined => undefined);
 
     readonly handlers = new Map<string, Handler>();
     readonly webContents = new MockWebContents();
@@ -131,8 +140,34 @@ vi.mock('electron', () => ({
 vi.mock('fix-path', () => ({ default: electron.fixPath }));
 vi.mock('@kubus/server', () => ({ appendAppLog: electron.appendAppLog, startServer: electron.startServer }));
 
+type EditRole = 'undo' | 'redo' | 'cut' | 'copy' | 'paste' | 'pasteAndMatchStyle' | 'delete' | 'selectAll';
+interface MenuTemplateItem {
+  label?: string;
+  role?: string;
+  type?: string;
+  click?: () => void;
+  submenu?: MenuTemplateItem[];
+}
+
 let userDataPath: string;
 let previousHelmEngine: string | undefined;
+
+function editMenuItems(): MenuTemplateItem[] {
+  const template = (electron.menu.buildFromTemplate.mock.calls[0] as unknown[] | undefined)?.[0] as MenuTemplateItem[] | undefined;
+  const edit = template?.find((item) => item.label === 'Edit');
+  expect(edit?.submenu, 'Edit menu should be built').toBeDefined();
+  return edit!.submenu!;
+}
+
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
 
 function registered(map: Map<string, Handler>, name: string): Handler {
   const callback = map.get(name);
@@ -160,6 +195,7 @@ beforeEach(() => {
   electron.ipcListeners.clear();
   electron.ipcHandlers.clear();
   electron.BrowserWindow.instances.length = 0;
+  electron.BrowserWindow.getFocusedWindow.mockReturnValue(undefined);
   electron.app.isPackaged = false;
   electron.app.requestSingleInstanceLock.mockReturnValue(true);
   electron.app.whenReady.mockResolvedValue(undefined);
@@ -555,5 +591,56 @@ describe('Electron main process', () => {
       expect.stringContaining(logPath),
     );
     expect(electron.BrowserWindow.instances).toHaveLength(0);
+  });
+
+  it('routes Edit menu commands to the focused window, falling back to the primary window', async () => {
+    const win = await loadMain();
+    const items = editMenuItems();
+    const roles = items.map((item) => item.role ?? item.type ?? item.label);
+    if (process.platform === 'darwin') {
+      expect(roles).toEqual(['undo', 'redo', 'separator', 'cut', 'copy', 'paste', 'pasteAndMatchStyle', 'delete', 'selectAll', 'separator', 'Speech']);
+    } else {
+      expect(roles).toEqual(['undo', 'redo', 'separator', 'cut', 'copy', 'paste', 'delete', 'separator', 'selectAll']);
+    }
+    // Every command keeps its native role and carries the fallback.
+    const commands = items.filter((item) => item.role);
+    expect(commands.every((item) => typeof item.click === 'function')).toBe(true);
+
+    // Electron only calls click when it found no focused web contents; the
+    // key window then receives the command, never the primary one.
+    const other = new electron.BrowserWindow({});
+    electron.BrowserWindow.getFocusedWindow.mockReturnValue(other);
+    for (const item of commands) {
+      item.click!();
+      expect(other.webContents[item.role as EditRole], item.role).toHaveBeenCalledOnce();
+      expect(win.webContents[item.role as EditRole], item.role).not.toHaveBeenCalled();
+    }
+
+    // No key window at all: the primary window is the last resort.
+    electron.BrowserWindow.getFocusedWindow.mockReturnValue(undefined);
+    const copy = commands.find((item) => item.role === 'copy')!;
+    copy.click!();
+    expect(win.webContents.copy).toHaveBeenCalledOnce();
+
+    // A destroyed window is left alone.
+    win.isDestroyed.mockReturnValue(true);
+    copy.click!();
+    expect(win.webContents.copy).toHaveBeenCalledOnce();
+  });
+
+  it('builds the macOS Edit menu with its extra commands and the Speech submenu', async () => {
+    await withPlatform('darwin', async () => {
+      const win = await loadMain();
+      expect(win.setMenuBarVisibility).not.toHaveBeenCalled();
+      const items = editMenuItems();
+      expect(items.map((item) => item.role ?? item.type ?? item.label)).toEqual([
+        'undo', 'redo', 'separator', 'cut', 'copy', 'paste', 'pasteAndMatchStyle', 'delete', 'selectAll', 'separator', 'Speech',
+      ]);
+      expect(items.find((item) => item.label === 'Speech')?.submenu).toEqual([{ role: 'startSpeaking' }, { role: 'stopSpeaking' }]);
+      for (const item of items.filter((entry) => entry.role)) {
+        item.click!();
+        expect(win.webContents[item.role as EditRole], item.role).toHaveBeenCalledOnce();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Problem

A macOS user reported that selected text (for example in the "Why this pod isn't ready" banner) could not be copied with Cmd+C, while the same works on Linux.

On macOS, Cmd+C only reaches the page through the Edit menu's copy role. Electron runs a role's web-contents method solely against the web contents it reports as focused. When that lookup comes back empty while the page still shows a selection (the renderer view is not the window's first responder, which also renders the selection in the inactive gray), the stock `editMenu` role returns without doing anything and the shortcut silently fails. Linux and Windows never route Ctrl+C through the menu, so they were unaffected.

Nothing in 0.8.0 changed this path: the menu code and the client's key handlers are identical to 0.7.0.

## Fix

Build the Edit menu explicitly from plain items that mirror Electron's predefined roles item for item (labels, accelerators, `registerAccelerator`). Each command acts on the focused web contents when Electron reports one, exactly like the role did, and otherwise falls back to the key window's web contents, then the primary window. Predefined roles are not used for these commands because a role's click handler is documented as ignored. The Speech submenu keeps its native roles.

## Release

Bumps every workspace package to 0.8.1 and adds the 0.8.1 patch notes to the 0.8 release page.

## Verification

- Client (built, headless Chrome): triple-selecting the banner text and pressing Ctrl+C copies exactly that text, with and without a grid cell having had focus; no handler cancels a Cmd+C keydown.
- Desktop app on Linux, driven over CDP and the main-process inspector: a stock `role: 'copy'` item invoked with no focused web contents copies nothing, which is the failure mode; the app's Edit → Copy item under the same conditions copies the selection.
- Unit tests cover the Edit menu shape on Linux and macOS, the focused web contents taking precedence, the fallback to the key window and then the primary window, and the destroyed-web-contents no-op.
- Existing Electron specs pass (9/9), `tsc` and `oxlint` are clean.

Not verified on macOS hardware; this closes the only macOS-specific silent-failure path found.