### PR TITLE
fix: stop mistaking cluster 401s for a dead session and let the banner clear

### DIFF
--- a/client/src/api/http.ts
+++ b/client/src/api/http.ts
@@ -1,5 +1,5 @@
-import type { ApiErrorBody } from '@kubus/shared';
-import { reportAuthInvalid, reportBackendDown, reportBackendUp } from '../state/backend.js';
+import { SESSION_AUTH_CHALLENGE, type ApiErrorBody } from '@kubus/shared';
+import { reportAuthInvalid, reportAuthValid, reportBackendDown, reportBackendUp } from '../state/backend.js';
 
 let token = '';
 
@@ -20,6 +20,13 @@ export function authToken(): string {
 }
 
 export class ApiError extends Error {
+  /**
+   * The Kubus server rejected the session token. The global status banner
+   * owns that state; a cluster's own 401 relayed by a route stays a per-call
+   * error and leaves this false.
+   */
+  sessionRejected = false;
+
   constructor(
     public status: number,
     message: string,
@@ -27,6 +34,17 @@ export class ApiError extends Error {
   ) {
     super(message);
   }
+}
+
+/** Only the server's own auth guard sends the challenge; relayed cluster 401s do not. */
+function isSessionRejection(res: Response): boolean {
+  return res.status === 401 && res.headers.get('www-authenticate') === SESSION_AUTH_CHALLENGE;
+}
+
+function responseError(res: Response, message: string, body?: ApiError['body']): ApiError {
+  const err = new ApiError(res.status, message, body);
+  err.sessionRejected = isSessionRejection(res);
+  return err;
 }
 
 function authHeaders(init?: HeadersInit): Headers {
@@ -37,8 +55,10 @@ function authHeaders(init?: HeadersInit): Headers {
 
 /**
  * Fetch that feeds the global backend-status store: connection failures and
- * 401s are cross-cutting states (server gone / token stale), not per-call
- * errors, so every call site reports them here instead of handling them.
+ * session rejections are cross-cutting states (server gone / token stale),
+ * not per-call errors, so every call site reports them here instead of
+ * handling them. Every other response, including an error, proves the token
+ * was accepted and clears a stale session flag.
  */
 async function statusFetch(path: string, init?: RequestInit): Promise<Response> {
   let res: Response;
@@ -53,7 +73,8 @@ async function statusFetch(path: string, init?: RequestInit): Promise<Response> 
     throw new ApiError(0, 'Cannot reach the Kubus backend');
   }
   reportBackendUp();
-  if (res.status === 401) reportAuthInvalid();
+  if (isSessionRejection(res)) reportAuthInvalid();
+  else reportAuthValid();
   return res;
 }
 
@@ -68,7 +89,7 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   }
   if (!res.ok) {
     const err = body as ApiErrorBody | undefined;
-    throw new ApiError(res.status, err?.message ?? `${res.status} ${res.statusText}`, body as ApiError['body']);
+    throw responseError(res, err?.message ?? `${res.status} ${res.statusText}`, body as ApiError['body']);
   }
   return body as T;
 }
@@ -84,7 +105,7 @@ export async function apiFetchRaw(path: string, init?: RequestInit): Promise<Res
     } catch {
       /* non-JSON error body */
     }
-    throw new ApiError(res.status, message);
+    throw responseError(res, message);
   }
   return res;
 }

--- a/client/src/components/BackendStatusBanner.tsx
+++ b/client/src/components/BackendStatusBanner.tsx
@@ -1,30 +1,36 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import Snackbar from '@mui/material/Snackbar';
 import { useQueryClient } from '@tanstack/react-query';
 import { apiFetch } from '../api/http.js';
 import { watchClient } from '../api/ws/watch-client.js';
-import { useBackendStore } from '../state/backend.js';
+import { dismissAuthInvalid, useBackendStore } from '../state/backend.js';
 
 const RETRY_MS = 3000;
+
+type Notice = 'outage' | 'session';
 
 /**
  * Global banner for the two cross-cutting backend failure states: the server
  * not answering at all, and the session token no longer being accepted.
- * While unreachable it pings until the server answers, then refetches
- * everything so the app snaps back without a manual reload.
+ * While either holds it pings until the server accepts a request, then
+ * refetches everything so the app snaps back without a manual reload. The
+ * session banner can also be closed by hand; the dismissal lasts until the
+ * server accepts the token again, so a fresh rejection shows it anew.
  */
 export function BackendStatusBanner() {
   const unreachable = useBackendStore((s) => s.unreachable);
   const authInvalid = useBackendStore((s) => s.authInvalid);
+  const authDismissed = useBackendStore((s) => s.authInvalidDismissed);
   const queryClient = useQueryClient();
+  const degraded = unreachable || authInvalid;
 
   useEffect(() => {
-    if (!unreachable) return;
+    if (!degraded) return;
     let cancelled = false;
     const timer = setInterval(() => {
-      // A successful response flips the store back via statusFetch.
+      // An accepted response flips the store back via statusFetch.
       apiFetch('/api/app/info')
         .then(() => {
           if (cancelled) return;
@@ -37,20 +43,29 @@ export function BackendStatusBanner() {
       cancelled = true;
       clearInterval(timer);
     };
-  }, [unreachable, queryClient]);
+  }, [degraded, queryClient]);
 
-  const open = unreachable || authInvalid;
+  // An outage is the more current observation: while the server is silent
+  // the session state is unknown, so the retry notice wins over the session
+  // notice until a response settles it.
+  const notice: Notice | undefined = unreachable ? 'outage' : authInvalid ? 'session' : undefined;
+  const open = notice === 'outage' || (notice === 'session' && !authDismissed);
+  // The Snackbar keeps its child mounted through the exit fade, so remember
+  // the last notice rather than letting the text flip while it fades out.
+  const [shown, setShown] = useState(notice);
+  if (notice && notice !== shown) setShown(notice);
+  const session = shown === 'session';
+
   // Bottom-left keeps clear of ToastHost, which owns bottom-center.
   return (
     <Snackbar open={open} anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}>
       <Alert
-        severity={authInvalid ? 'error' : 'warning'}
+        severity={session ? 'error' : 'warning'}
         variant="filled"
-        icon={authInvalid ? undefined : <CircularProgress color="inherit" size={18} />}
+        icon={session ? undefined : <CircularProgress color="inherit" size={18} />}
+        onClose={session ? dismissAuthInvalid : undefined}
       >
-        {authInvalid
-          ? 'Session is no longer valid — restart Kubus to reconnect.'
-          : 'Backend connection lost — retrying…'}
+        {session ? 'Session is no longer valid — restart Kubus to reconnect.' : 'Backend connection lost — retrying…'}
       </Alert>
     </Snackbar>
   );

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -44,12 +44,13 @@ if (launch && sessionStorage.getItem(launchAppliedKey) !== launch.windowId) {
 const queryClient = new QueryClient({
   mutationCache: new MutationCache({
     // Safety net so a failed action is never silent: mutations that handle
-    // their own errors keep doing so. Unreachable-backend and stale-token
-    // failures are excluded — the global status banner owns those.
+    // their own errors keep doing so. Unreachable-backend and stale-session
+    // failures are excluded — the global status banner owns those. A 401 the
+    // cluster itself returned is a real per-call failure and still toasts.
     onError: (error, _variables, _context, mutation) => {
       if (mutation.options.onError) return;
       if (isMutationErrorHandledLocally(mutation.meta)) return;
-      if (error instanceof ApiError && (error.status === 0 || error.status === 401)) return;
+      if (error instanceof ApiError && (error.status === 0 || error.sessionRejected)) return;
       showErrorToast(error);
     },
   }),

--- a/client/src/state/backend.ts
+++ b/client/src/state/backend.ts
@@ -5,11 +5,17 @@ interface BackendState {
   unreachable: boolean;
   /** The server answered 401 — the session token is no longer valid. */
   authInvalid: boolean;
+  /**
+   * The user closed the invalid-session banner. Cleared as soon as the server
+   * accepts the token again, so a later rejection surfaces the banner anew.
+   */
+  authInvalidDismissed: boolean;
 }
 
 export const useBackendStore = create<BackendState>()(() => ({
   unreachable: false,
   authInvalid: false,
+  authInvalidDismissed: false,
 }));
 
 export function reportBackendDown(): void {
@@ -22,4 +28,14 @@ export function reportBackendUp(): void {
 
 export function reportAuthInvalid(): void {
   if (!useBackendStore.getState().authInvalid) useBackendStore.setState({ authInvalid: true });
+}
+
+/** Any response the server did not reject as a session failure proves the token still works. */
+export function reportAuthValid(): void {
+  const { authInvalid, authInvalidDismissed } = useBackendStore.getState();
+  if (authInvalid || authInvalidDismissed) useBackendStore.setState({ authInvalid: false, authInvalidDismissed: false });
+}
+
+export function dismissAuthInvalid(): void {
+  if (!useBackendStore.getState().authInvalidDismissed) useBackendStore.setState({ authInvalidDismissed: true });
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import Fastify, { type FastifyBaseLogger, type FastifyInstance } from 'fastify';
 import pino from 'pino';
 import fastifyWebsocket from '@fastify/websocket';
 import fastifyStatic from '@fastify/static';
+import { SESSION_AUTH_CHALLENGE } from '@kubus/shared';
 import type { ServerConfig } from './config.js';
 import { ClusterManager } from './kube/cluster-manager.js';
 import { PortForwardManager } from './kube/portforward-manager.js';
@@ -122,7 +123,10 @@ export async function buildApp(config: ServerConfig): Promise<{ app: FastifyInst
     const header = req.headers.authorization;
     const ok = header === `Bearer ${config.token}`;
     if (!ok) {
-      await reply.code(401).send({ message: 'unauthorized' });
+      // The challenge header marks this as a session rejection so the client
+      // does not mistake a cluster's own 401 (relayed by resource routes) for
+      // a dead Kubus session.
+      await reply.code(401).header('www-authenticate', SESSION_AUTH_CHALLENGE).send({ message: 'unauthorized' });
     }
   });
 

--- a/shared/src/api-types.ts
+++ b/shared/src/api-types.ts
@@ -432,6 +432,14 @@ export interface ApiErrorBody {
   details?: unknown;
 }
 
+/**
+ * `WWW-Authenticate` challenge the Kubus server attaches when it rejects the
+ * session bearer token itself. A 401 relayed from a cluster through a
+ * passthrough route never carries it, which is how the client tells a dead
+ * session apart from expired cluster credentials.
+ */
+export const SESSION_AUTH_CHALLENGE = 'Bearer realm="kubus", error="invalid_token"';
+
 // ---- Actions ----
 
 export interface ScaleRequest {

--- a/tests/unit/client/backend-status-banner.test.tsx
+++ b/tests/unit/client/backend-status-banner.test.tsx
@@ -1,0 +1,129 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => {
+  const value = {
+    apiFetch: vi.fn(),
+    reconnectNow: vi.fn(),
+    queryClient: { invalidateQueries: vi.fn(() => Promise.resolve()) },
+  };
+  Reflect.set(globalThis, Symbol.for('kubus.test.query-harness'), value);
+  return value;
+});
+
+vi.mock('../../../client/src/api/http.js', () => ({ apiFetch: harness.apiFetch }));
+vi.mock('../../../client/src/api/ws/watch-client.js', () => ({
+  watchClient: { reconnectNow: harness.reconnectNow },
+}));
+
+import { BackendStatusBanner } from '../../../client/src/components/BackendStatusBanner';
+import {
+  dismissAuthInvalid,
+  reportAuthInvalid,
+  reportAuthValid,
+  reportBackendDown,
+  useBackendStore,
+} from '../../../client/src/state/backend';
+
+const SESSION_TEXT = 'Session is no longer valid';
+const RETRY_TEXT = 'Backend connection lost';
+
+beforeEach(() => {
+  useBackendStore.setState({ unreachable: false, authInvalid: false, authInvalidDismissed: false });
+  harness.apiFetch.mockReset().mockResolvedValue({});
+  harness.reconnectNow.mockClear();
+  harness.queryClient.invalidateQueries.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('BackendStatusBanner', () => {
+  it('renders nothing while the backend is healthy', () => {
+    render(<BackendStatusBanner />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('shows the session notice with a close button that hides it', async () => {
+    render(<BackendStatusBanner />);
+    act(() => reportAuthInvalid());
+    expect(screen.getByRole('alert')).toHaveTextContent(SESSION_TEXT);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(useBackendStore.getState().authInvalidDismissed).toBe(true);
+    // The notice keeps its text while the snackbar fades out.
+    expect(screen.getByRole('alert')).toHaveTextContent(SESSION_TEXT);
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
+  it('keeps a dismissed notice hidden while the same session keeps failing', async () => {
+    render(<BackendStatusBanner />);
+    act(() => reportAuthInvalid());
+    act(() => dismissAuthInvalid());
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+
+    // Repeated rejections from the ongoing polling must not resurface it.
+    act(() => reportAuthInvalid());
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('hides the session notice once the server accepts the token again and shows it anew on a fresh rejection', async () => {
+    render(<BackendStatusBanner />);
+    act(() => reportAuthInvalid());
+    expect(screen.getByRole('alert')).toHaveTextContent(SESSION_TEXT);
+
+    act(() => reportAuthValid());
+    // Still the session text while fading, never the retry notice.
+    expect(screen.getByRole('alert')).toHaveTextContent(SESSION_TEXT);
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+
+    act(() => reportAuthInvalid());
+    act(() => dismissAuthInvalid());
+    act(() => reportAuthValid());
+    act(() => reportAuthInvalid());
+    expect(screen.getByRole('alert')).toHaveTextContent(SESSION_TEXT);
+  });
+
+  it('shows the retry notice without a close button while the server is unreachable', () => {
+    render(<BackendStatusBanner />);
+    act(() => reportBackendDown());
+    expect(screen.getByRole('alert')).toHaveTextContent(RETRY_TEXT);
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull();
+  });
+
+  it('prefers the retry notice when the server drops while the session was already flagged', () => {
+    render(<BackendStatusBanner />);
+    act(() => {
+      reportAuthInvalid();
+      reportBackendDown();
+    });
+    expect(screen.getByRole('alert')).toHaveTextContent(RETRY_TEXT);
+  });
+
+  it('probes the server while the session is flagged and snaps the app back once it answers', async () => {
+    vi.useFakeTimers();
+    render(<BackendStatusBanner />);
+    act(() => reportAuthInvalid());
+    expect(harness.apiFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+    expect(harness.apiFetch).toHaveBeenCalledWith('/api/app/info');
+    expect(harness.reconnectNow).toHaveBeenCalledTimes(1);
+    expect(harness.queryClient.invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops probing once the session is accepted again', async () => {
+    vi.useFakeTimers();
+    render(<BackendStatusBanner />);
+    act(() => reportAuthInvalid());
+    act(() => reportAuthValid());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(harness.apiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/client/http.test.ts
+++ b/tests/unit/client/http.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, apiFetch, authToken, initAuthToken, wsUrl } from '../../../client/src/api/http';
+import { SESSION_AUTH_CHALLENGE } from '@kubus/shared';
+import { ApiError, apiFetch, apiFetchRaw, authToken, initAuthToken, wsUrl } from '../../../client/src/api/http';
 import { useBackendStore } from '../../../client/src/state/backend';
 
 function resetUrl(path = '/'): void {
@@ -9,7 +10,7 @@ function resetUrl(path = '/'): void {
 beforeEach(() => {
   sessionStorage.clear();
   resetUrl();
-  useBackendStore.setState({ unreachable: false, authInvalid: false });
+  useBackendStore.setState({ unreachable: false, authInvalid: false, authInvalidDismissed: false });
 });
 
 afterEach(() => {
@@ -97,13 +98,48 @@ describe('apiFetch', () => {
     expect(useBackendStore.getState().unreachable).toBe(false);
   });
 
-  it('reports an invalid session on 401 and throws with the server message', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ message: 'token expired' }, 401)));
+  function sessionRejection(): Response {
+    return new Response(JSON.stringify({ message: 'unauthorized' }), {
+      status: 401,
+      headers: { 'content-type': 'application/json', 'www-authenticate': SESSION_AUTH_CHALLENGE },
+    });
+  }
+
+  it('reports an invalid session on a 401 carrying the server challenge', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sessionRejection()));
 
     const err = await apiFetch('/api/x').catch((e: unknown) => e);
-    expect(err).toMatchObject({ status: 401, message: 'token expired' });
+    expect(err).toMatchObject({ status: 401, message: 'unauthorized', sessionRejected: true });
     expect(useBackendStore.getState().authInvalid).toBe(true);
     expect(useBackendStore.getState().unreachable).toBe(false);
+  });
+
+  it('treats a 401 relayed from the cluster as a per-call error, not a dead session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(jsonResponse({ message: 'Unauthorized', k8sStatus: { code: 401 } }, 401)),
+    );
+
+    const err = await apiFetch('/api/x').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err).toMatchObject({ status: 401, message: 'Unauthorized', sessionRejected: false });
+    expect(useBackendStore.getState().authInvalid).toBe(false);
+  });
+
+  it('clears the invalid-session flag and its dismissal once the server accepts a request', async () => {
+    useBackendStore.setState({ authInvalid: true, authInvalidDismissed: true });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ message: 'nope' }, 403)));
+
+    await apiFetch('/api/x').catch(() => {});
+    expect(useBackendStore.getState()).toMatchObject({ authInvalid: false, authInvalidDismissed: false });
+  });
+
+  it('flags session rejections on raw fetches too', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(sessionRejection()));
+
+    const err = await apiFetchRaw('/api/x').catch((e: unknown) => e);
+    expect(err).toMatchObject({ status: 401, sessionRejected: true });
+    expect(useBackendStore.getState().authInvalid).toBe(true);
   });
 
   it('throws ApiError with the body message and attaches the body on non-401 errors', async () => {

--- a/tests/unit/server/logs-routes.test.ts
+++ b/tests/unit/server/logs-routes.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SESSION_AUTH_CHALLENGE } from '@kubus/shared';
 import { buildApp } from '../../../server/src/app.js';
 import { resolveConfig } from '../../../server/src/config.js';
 import { clearAppLog } from '../../../server/src/logging/log-buffer.js';
@@ -103,5 +104,22 @@ describe('log routes', () => {
 
     const unauthorized = await app.inject({ method: 'GET', url: '/api/logs' });
     expect(unauthorized.statusCode).toBe(401);
+  });
+});
+
+describe('session auth guard', () => {
+  it('marks its own 401 with the session challenge so the client can tell it from a cluster 401', async () => {
+    const missing = await app.inject({ method: 'GET', url: '/api/logs' });
+    expect(missing.statusCode).toBe(401);
+    expect(missing.headers['www-authenticate']).toBe(SESSION_AUTH_CHALLENGE);
+    expect(missing.json()).toEqual({ message: 'unauthorized' });
+
+    const wrong = await app.inject({ method: 'GET', url: '/api/logs', headers: { authorization: 'Bearer nope' } });
+    expect(wrong.statusCode).toBe(401);
+    expect(wrong.headers['www-authenticate']).toBe(SESSION_AUTH_CHALLENGE);
+
+    const accepted = await app.inject({ method: 'GET', url: '/api/logs', headers: auth });
+    expect(accepted.statusCode).toBe(200);
+    expect(accepted.headers['www-authenticate']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

The "Session is no longer valid — restart Kubus to reconnect." banner could appear and never go away. The server relays a cluster's own 401 as an HTTP 401, and the client treated every 401 as an invalid Kubus session via a flag that nothing ever cleared. Expired cluster credentials (for example on an exec session) therefore raised the wrong banner permanently, and there was no way to close it.

## Changes

- **Server**: the session auth guard attaches a standard `WWW-Authenticate` challenge to its own 401. Relayed cluster 401s never carry it, so the client can tell the two apart. The challenge value lives in `@kubus/shared`.
- **Fetch wrapper**: only a challenged 401 flags the session. Any other response, including an error, proves the token was accepted and clears the flag. `ApiError` carries a `sessionRejected` marker so the mutation error safety net keeps suppressing session failures but toasts real cluster 401s instead of swallowing them.
- **Banner**:
  - close button on the session notice; the dismissal lasts until the server accepts the token again, so ongoing polling does not resurface it, while a fresh rejection later will
  - probes the server while flagged and snaps watches and queries back once accepted, matching the existing outage behavior
  - the outage notice takes precedence while the server is silent
  - the text no longer flips to the retry message during the fade-out

## Tests

- fetch wrapper: challenged vs relayed 401, flag clearing on an accepted response, raw fetches
- new banner component test: dismissal, auto-recovery, precedence, probe wiring
- server: the auth guard's 401 carries the challenge and accepted requests do not

Unit suite, typecheck, and lint pass.
