### PR TITLE
fix: prevent desktop quit from hanging on server shutdown

### DIFF
--- a/electron/src/main.ts
+++ b/electron/src/main.ts
@@ -42,6 +42,7 @@ const isLinux = process.platform === 'linux';
 const TITLEBAR_HEIGHT = 52;
 const UPDATE_MANIFEST_URL = 'https://kubus-app.dev/latest.json';
 const UPDATE_CHECK_TIMEOUT_MS = 10_000;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
 
 let primaryWindow: BrowserWindow | undefined;
 let appUrl: string | undefined;
@@ -735,13 +736,34 @@ if (!app.requestSingleInstanceLock()) {
   app.on('before-quit', (event) => {
     flushClientState();
     if (!server) return;
+    event.preventDefault();
     if (!closing) {
-      closing = server.close().catch(() => undefined);
-      void closing.then(() => {
+      // Quit can arrive with a window still open (Cmd+Q), or after the last
+      // window disappears. Persist bounds before the fallback can bypass close.
+      if (primaryWindow && !primaryWindow.isDestroyed()) saveWindowState(primaryWindow);
+      mainLog('info', 'closing the embedded server');
+      let timedOut = false;
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        flushClientState();
+        mainLog('warn', `server shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms; forcing application exit`);
+        // app.quit() would re-enter this handler and wait on the same stalled
+        // promise. Exit directly if cleanup cannot finish, e.g. after sleep.
+        app.exit(0);
+      }, SHUTDOWN_TIMEOUT_MS);
+      closing = (async () => {
+        try {
+          await server.close();
+          if (!timedOut) mainLog('info', 'embedded server closed');
+        } catch (err) {
+          mainLog('error', 'embedded server shutdown failed', err);
+        } finally {
+          clearTimeout(timeout);
+        }
+        if (timedOut) return;
         server = undefined;
         app.quit();
-      });
+      })();
     }
-    event.preventDefault();
   });
 }

--- a/tests/electron/helpers/app.ts
+++ b/tests/electron/helpers/app.ts
@@ -73,6 +73,7 @@ export async function launchElectron(options: LaunchOptions = {}): Promise<Launc
       },
       timeout: 20_000,
     });
+    const child = app.process();
     const page = await app.firstWindow();
     let closed = false;
     return {
@@ -84,7 +85,7 @@ export async function launchElectron(options: LaunchOptions = {}): Promise<Launc
         if (closed) return;
         closed = true;
         try {
-          if (app && app.process().exitCode === null) await app.close();
+          if (app && child.exitCode === null && child.signalCode === null) await app.close();
         } finally {
           rmSync(stateDir, { recursive: true, force: true });
         }

--- a/tests/electron/specs/shutdown.spec.ts
+++ b/tests/electron/specs/shutdown.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import { launchElectron } from '../helpers/app.js';
+
+for (const scenario of ['close-window', 'stalled-close-window', 'stalled-quit'] as const) {
+  test(`exits the desktop process on ${scenario}`, async () => {
+    const launched = await launchElectron();
+    const child = launched.app.process();
+    const stalled = scenario.startsWith('stalled');
+    try {
+      await expect(launched.page).toHaveURL((url) => !url.searchParams.has('token'));
+      await launched.page.evaluate(() => window.kubusDesktop?.stateStorage.setItem('shutdown-test', 'saved'));
+
+      if (stalled) {
+        const port = Number(new URL(launched.page.url()).port);
+        // Simulate a server close that never completes, without exposing a
+        // fault-injection API in the production app or touching real clusters.
+        await launched.app.evaluate((_electron, serverPort) => {
+          const { Server } = process.getBuiltinModule('node:http');
+          // Preserve the receiver explicitly with call/apply below.
+          // oxlint-disable-next-line typescript/unbound-method
+          const originalClose = Server.prototype.close;
+          Server.prototype.close = function (...args) {
+            const address = this.address();
+            if (address && typeof address === 'object' && address.port === serverPort) {
+              return originalClose.call(this); // Deliberately omit the completion callback.
+            }
+            return originalClose.apply(this, args);
+          };
+        }, port);
+      }
+
+      await launched.app.evaluate(({ app, BrowserWindow }, quit) => {
+        // Let evaluate return before the application tears down Playwright's connection.
+        setTimeout(() => {
+          if (quit) app.quit();
+          else BrowserWindow.getAllWindows()[0]?.close();
+        }, 50);
+      }, scenario === 'stalled-quit');
+
+      await expect.poll(() => child.exitCode, { timeout: 8_000 }).toBe(0);
+      const log = readFileSync(path.join(launched.userDataDir, 'logs', 'main.log'), 'utf8');
+      expect(log).toContain(stalled ? 'server shutdown timed out after 5000ms' : 'embedded server closed');
+      const state = JSON.parse(readFileSync(path.join(launched.userDataDir, 'client-state.json'), 'utf8'));
+      expect(state['shutdown-test']).toBe('saved');
+      const bounds = JSON.parse(readFileSync(path.join(launched.userDataDir, 'window-state.json'), 'utf8'));
+      expect(bounds.width).toBeGreaterThan(0);
+    } finally {
+      // A regression must fail the test without leaving the test app hung.
+      if (child.exitCode === null && child.signalCode === null) {
+        await new Promise<void>((resolve) => {
+          child.once('exit', () => resolve());
+          child.kill('SIGKILL');
+        });
+      }
+      await launched.close();
+    }
+  });
+}

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -87,6 +87,7 @@ const electron = vi.hoisted(() => {
     requestSingleInstanceLock: vi.fn(() => true),
     whenReady: vi.fn(async () => undefined),
     quit: vi.fn(),
+    exit: vi.fn(),
     on: vi.fn((name: string, handler: Handler) => {
       const handlers = appHandlers.get(name) ?? [];
       handlers.push(handler);
@@ -95,7 +96,7 @@ const electron = vi.hoisted(() => {
     }),
   };
   const state = { userDataPath: '', nextWebContentsId: 0 };
-  const serverClose = vi.fn(async () => undefined);
+  const serverClose = vi.fn(async (): Promise<void> => undefined);
   const startServer = vi.fn(async () => ({ url: 'http://127.0.0.1:41234/?token=secret-test-token', close: serverClose }));
   const appendAppLog = vi.fn();
   const fixPath = vi.fn();
@@ -580,6 +581,55 @@ describe('Electron main process', () => {
     expect(quitEvent.preventDefault).toHaveBeenCalledOnce();
     expect(electron.serverClose).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(electron.app.quit).toHaveBeenCalledOnce());
+  });
+
+  it('forces macOS to exit when server shutdown stalls, without restarting the deadline on repeated quits', async () => {
+    await withPlatform('darwin', async () => {
+      const win = await loadMain();
+      vi.useFakeTimers();
+      let finishClose!: () => void;
+      electron.serverClose.mockImplementationOnce(() => new Promise<void>((resolve) => { finishClose = resolve; }));
+      registered(electron.ipcListeners, 'kubus:state:set-item')({ sender: win.webContents }, 'quit-state', 'saved');
+
+      const quitEvent = { preventDefault: vi.fn() };
+      appHandler('before-quit')(quitEvent);
+      expect(quitEvent.preventDefault).toHaveBeenCalledOnce();
+      expect(JSON.parse(readFileSync(path.join(userDataPath, 'client-state.json'), 'utf8'))['quit-state']).toBe('saved');
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(electron.app.exit).not.toHaveBeenCalled();
+      appHandler('before-quit')({ preventDefault: vi.fn() });
+      expect(electron.serverClose).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(electron.app.exit).toHaveBeenCalledExactlyOnceWith(0);
+      expect(readFileSync(path.join(userDataPath, 'logs', 'main.log'), 'utf8')).toContain('shutdown timed out');
+      expect(readFileSync(path.join(userDataPath, 'window-state.json'), 'utf8')).toContain('1280');
+
+      // A late completion must not request another quit after forced exit.
+      finishClose();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(electron.app.quit).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(['resolve', 'reject', 'throw'] as const)('cancels the shutdown deadline when close completes via %s', async (outcome) => {
+    await loadMain();
+    vi.useFakeTimers();
+    const error = new Error('shutdown failure');
+    if (outcome === 'reject') electron.serverClose.mockRejectedValueOnce(error);
+    if (outcome === 'throw') electron.serverClose.mockImplementationOnce(() => { throw error; });
+
+    appHandler('before-quit')({ preventDefault: vi.fn() });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(electron.app.quit).toHaveBeenCalledOnce();
+    const resumedQuit = { preventDefault: vi.fn() };
+    appHandler('before-quit')(resumedQuit);
+    expect(resumedQuit.preventDefault).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(electron.app.exit).not.toHaveBeenCalled();
+    if (outcome !== 'resolve') {
+      expect(readFileSync(path.join(userDataPath, 'logs', 'main.log'), 'utf8')).toContain('shutdown failure');
+    }
   });
 
   it('quits immediately when another instance owns the lock', async () => {


### PR DESCRIPTION
Quitting could leave Kubus running after its window disappeared because the desktop shell waited indefinitely for the embedded server to close. This matches the reported macOS symptoms; the suspected sleep/wake trigger has not been reproduced directly.

Allow five seconds for server cleanup, then exit if shutdown is still stuck. Preserve UI state and window bounds before the fallback, log shutdown completion/errors/timeouts to the persistent main log, and keep repeated quit requests from restarting cleanup or its deadline. The fix applies on macOS, Linux, and Windows.

Validation: `pnpm build`, test typecheck, and repository lint passed. All 22 relevant unit tests and 11 desktop tests passed, including real process exit with deliberately stalled server shutdown through both window close and application quit. Desktop tests ran on Linux; native macOS and Windows validation remains outstanding.
