### PR TITLE
Fix browser login storms from expired exec credentials

### DIFF
--- a/server/src/kube/auth-diagnostics.ts
+++ b/server/src/kube/auth-diagnostics.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { User } from '@kubernetes/client-node';
 import type { ClusterAuthType } from '@kubus/shared';
 import type { RawClient } from './raw-client.js';
+import { ExecCredentialError } from './exec-credentials.js';
 
 /**
  * Turns raw connection/auth failures into messages that say what to do next,
@@ -231,6 +232,7 @@ function clip(text: string): string {
  * descriptive fallback instead of a blank alert.
  */
 export async function describeProbeFailure(err: unknown, user: User | null | undefined, raw?: RawClient): Promise<string> {
+  if (err instanceof ExecCredentialError) return err.message;
   const status = statusCodeOf(err);
   if (status === 401) return describe401(user, authTypeOf(user));
   if (status === 403) {

--- a/server/src/kube/cluster-manager.ts
+++ b/server/src/kube/cluster-manager.ts
@@ -29,6 +29,7 @@ import { HelmRecordWatcher } from '../helm/record-watcher.js';
 import { applyEnvProxy, applyProxyRuntimeCompatibility, overrideClusterProxyUrl } from './connection.js';
 import { clearCurrentContext, patchClusterEntry, patchUserEntry, removeKubeconfigEntry, writeKubeconfig, type ClusterEditPatch } from './kubeconfig-file.js';
 import { authTypeOf, authWarningForUser, describeProbeFailure } from './auth-diagnostics.js';
+import { ExecCredentialManager } from './exec-credentials.js';
 import { HttpProblem } from '../util/errors.js';
 import type { SshTunnelManager } from '../ssh/tunnel-manager.js';
 import { isValidSshDestination } from '../ssh/tunnel-manager.js';
@@ -68,16 +69,23 @@ export class ClusterHandle {
     public readonly contextName: string,
     log: FastifyBaseLogger,
     sshProxyUrl?: string,
+    sharedCredentials?: ExecCredentialManager,
   ) {
     // Each handle owns its own KubeConfig: setCurrentContext mutates state
-    // and exec-auth caches per-instance — never share across contexts.
+    // so never share it across contexts. Exec credentials are coordinated
+    // separately across handles and background probes.
     this.kc = new KubeConfig();
     this.kc.loadFromString(baseConfig.exportConfig());
     applyProxyRuntimeCompatibility(this.kc);
     this.kc.setCurrentContext(contextName);
     const clusterName = this.kc.getContexts().find((c) => c.name === contextName)?.cluster;
     if (sshProxyUrl && clusterName) overrideClusterProxyUrl(this.kc, clusterName, sshProxyUrl);
-    this.raw = new RawClient(this.kc);
+    const credentials = sharedCredentials ?? new ExecCredentialManager();
+    const releaseAuth = credentials.attach(this.kc);
+    this.raw = new RawClient(this.kc, undefined, () => {
+      releaseAuth();
+      if (!sharedCredentials) credentials.dispose();
+    });
     this.discovery = new DiscoveryCache(this.raw);
     this.watchers = new WatcherRegistry(this.raw, log);
     this.metricsPoller = new MetricsPoller(new Metrics(this.kc), log);
@@ -175,6 +183,7 @@ export class ClusterHandle {
 
 export class ClusterManager extends EventEmitter {
   private kc = new KubeConfig();
+  private execCredentials = new ExecCredentialManager();
   /** File that supplied each context at the last load; retained until the next load completes. */
   private contextFiles = new Map<string, string>();
   private handles = new Map<string, ClusterHandle>();
@@ -321,8 +330,10 @@ export class ClusterManager extends EventEmitter {
     this.kc = new KubeConfig();
     this.loadKubeconfig();
     this.restoreMovedSshAssociations(sshAssociations);
+    for (const client of this.probeClients.values()) client.raw.dispose();
     this.probeClients.clear();
     const after = this.contextFingerprints();
+    this.execCredentials.retainContexts(new Set([...after.keys()].filter((name) => after.get(name) === before.get(name))));
     for (const [name, handle] of this.handles) {
       // Drop sessions whose backing entries were removed or edited so clients
       // reconnect against the new definition instead of a stale clone.
@@ -395,6 +406,7 @@ export class ClusterManager extends EventEmitter {
     if (!this.kc.getContexts().some((c) => c.name === contextName)) {
       throw new HttpProblem(404, `context "${contextName}" not found in kubeconfig`, 'NotFound');
     }
+    this.execCredentials.retry(contextName);
     const result = await this.probeContext(contextName, BACKGROUND_HEALTH_TIMEOUT_MS);
     if (this.setCachedHealth(contextName, result)) this.emit('contexts-changed');
     return result;
@@ -416,13 +428,14 @@ export class ClusterManager extends EventEmitter {
     const sshProxyUrl = await this.sshProxyFor(contextName);
     const cached = this.probeClients.get(contextName);
     if (cached && cached.proxyUrl === sshProxyUrl) return cached.raw;
+    cached?.raw.dispose();
     const kc = new KubeConfig();
     kc.loadFromString(this.kc.exportConfig());
     applyProxyRuntimeCompatibility(kc);
     kc.setCurrentContext(contextName);
     const clusterName = kc.getContexts().find((c) => c.name === contextName)?.cluster;
     if (sshProxyUrl && clusterName) overrideClusterProxyUrl(kc, clusterName, sshProxyUrl);
-    const raw = new RawClient(kc);
+    const raw = new RawClient(kc, undefined, this.execCredentials.attach(kc));
     this.probeClients.set(contextName, { raw, proxyUrl: sshProxyUrl });
     return raw;
   }
@@ -734,7 +747,7 @@ export class ClusterManager extends EventEmitter {
     } catch (err) {
       throw new HttpProblem(502, err instanceof Error ? err.message : String(err), 'SshTunnelFailed');
     }
-    const handle = new ClusterHandle(this.kc, contextName, this.log, sshProxyUrl);
+    const handle = new ClusterHandle(this.kc, contextName, this.log, sshProxyUrl, this.execCredentials);
     handle.onDiscoveryChanged = () => this.emit('discovery-changed', contextName);
     handle.onHelmRecordsChanged = (changes) => this.emit('helm-records-changed', contextName, changes);
     handle.onHelmWatchStatus = (status) => this.emit('helm-watch-status', contextName, status);
@@ -778,7 +791,9 @@ export class ClusterManager extends EventEmitter {
    * session is stuck / my credentials rotated" escape hatch.
    */
   async reconnect(contextName: string): Promise<ClusterHandle> {
+    this.execCredentials.retry(contextName);
     this.disconnect(contextName);
+    this.probeClients.get(contextName)?.raw.dispose();
     this.probeClients.delete(contextName);
     return this.connect(contextName);
   }
@@ -789,6 +804,9 @@ export class ClusterManager extends EventEmitter {
     this.closeFileWatchers();
     for (const handle of this.handles.values()) handle.dispose();
     this.handles.clear();
+    for (const client of this.probeClients.values()) client.raw.dispose();
+    this.probeClients.clear();
+    this.execCredentials.dispose();
   }
 }
 

--- a/server/src/kube/exec-credentials.ts
+++ b/server/src/kube/exec-credentials.ts
@@ -1,0 +1,246 @@
+import childProcess from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import type { RequestOptions } from 'node:https';
+import type { KubeConfig, User } from '@kubernetes/client-node';
+import type { Authenticator } from '@kubernetes/client-node/dist/auth.js';
+import { HttpProblem } from '../util/errors.js';
+
+export const EXEC_AUTH_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+
+interface ExecConfig {
+  command: string;
+  args?: string[];
+  env?: Array<{ name: string; value: string }>;
+  apiVersion?: string;
+  interactiveMode?: string;
+  provideClusterInfo?: boolean;
+}
+
+interface Credential {
+  token?: string;
+  clientCertificateData?: string;
+  clientKeyData?: string;
+  expirationTimestamp?: string;
+}
+
+interface Session {
+  exec: ExecConfig;
+  env: NodeJS.ProcessEnv;
+  credential?: Credential;
+  pending?: Promise<Credential>;
+  error?: ExecCredentialError;
+  cancel?: () => void;
+  retired?: boolean;
+}
+
+export class ExecCredentialError extends HttpProblem {
+  constructor(command: string | undefined, detail: string) {
+    const name = command?.split(/[\\/]/).pop() || 'unknown';
+    super(401, `Credential plugin "${name}" failed: ${detail.trim().slice(0, 400) || 'no error message'}. Automatic authentication is paused. Sign in with your cloud CLI, then use Reconnect or Test connection to retry.`, 'AuthenticationRequired');
+    this.name = 'ExecCredentialError';
+  }
+}
+
+function execConfig(user: User | null): ExecConfig | undefined {
+  return (user?.exec ?? (user?.authProvider as { config?: { exec?: ExecConfig } } | undefined)?.config?.exec) as ExecConfig | undefined;
+}
+
+function parseCredential(stdout: string, apiVersion: string): Credential {
+  let result: { apiVersion?: string; kind?: string; status?: Credential };
+  try {
+    result = JSON.parse(stdout) as typeof result;
+  } catch {
+    // JSON parser errors can quote stdout, which may contain a credential.
+    throw new Error('the plugin returned invalid JSON');
+  }
+  if (result?.apiVersion !== apiVersion || result.kind !== 'ExecCredential' || !result.status) {
+    throw new Error('the plugin did not return a matching ExecCredential');
+  }
+  const status = result.status;
+  for (const key of ['token', 'clientCertificateData', 'clientKeyData', 'expirationTimestamp'] as const) {
+    if (status[key] !== undefined && typeof status[key] !== 'string') throw new Error(`invalid credential ${key}`);
+  }
+  if (!!status.clientCertificateData !== !!status.clientKeyData) throw new Error('the plugin must return both a client certificate and key');
+  if (!status.token && !status.clientCertificateData) throw new Error('the plugin returned no token or client certificate');
+  if (status.expirationTimestamp && !(Date.parse(status.expirationTimestamp) > Date.now())) {
+    throw new Error('the plugin returned an expired or invalid expiration timestamp');
+  }
+  return status;
+}
+
+/**
+ * One credential refresh per effective exec configuration across cluster handles
+ * and health probes. Failures stay paused across background retries and config
+ * reloads; only an explicit retry clears them. Resource deadlines do not own the
+ * shared child process: it has its own deadline and is terminated on shutdown.
+ */
+export class ExecCredentialManager {
+  private sessions = new Map<string, Session>();
+  private contexts = new Map<string, Session>();
+  private disposed = false;
+
+  constructor(private timeoutMs = EXEC_AUTH_TIMEOUT_MS) {}
+
+  attach(kc: KubeConfig): () => void {
+    if (this.disposed) throw new HttpProblem(409, 'The cluster session is closed', 'NotConnected');
+    const user = kc.getCurrentUser();
+    const config = execConfig(user);
+    if (!config || !user) return () => {};
+    const exec = structuredClone(config);
+    const apiVersion = exec.apiVersion ?? 'client.authentication.k8s.io/v1beta1';
+    const cluster = kc.getCurrentCluster();
+    const clusterInfo = exec.provideClusterInfo && cluster ? {
+      server: cluster.server,
+      'tls-server-name': cluster.tlsServerName,
+      'insecure-skip-tls-verify': cluster.skipTLSVerify,
+      'certificate-authority-data': cluster.caData ?? (cluster.caFile ? fs.readFileSync(cluster.caFile).toString('base64') : undefined),
+      'proxy-url': cluster.proxyUrl,
+    } : undefined;
+    const env = { ...process.env };
+    for (const entry of exec.env ?? []) env[entry.name] = entry.value;
+    env.KUBERNETES_EXEC_INFO = JSON.stringify({ apiVersion, kind: 'ExecCredential', spec: { interactive: false, cluster: clusterInfo } });
+    // Never key by username or executable alone: profiles, environment and
+    // cluster input can all change which identity the plugin returns.
+    const key = createHash('sha256').update(JSON.stringify([
+      exec.command, exec.args ?? [], exec.interactiveMode ?? 'IfAvailable', process.cwd(),
+      Object.entries(env).sort(([a], [b]) => a.localeCompare(b)),
+    ])).digest('hex');
+    let session = this.sessions.get(key);
+    if (!session) {
+      session = { exec: { ...exec, apiVersion }, env };
+      this.sessions.set(key, session);
+    }
+    this.contexts.set(kc.getCurrentContext(), session);
+    const bound = session;
+    let active = true;
+    const assertActive = () => {
+      if (!active || this.disposed) throw new HttpProblem(409, 'The cluster session is closed', 'NotConnected');
+    };
+    const authenticator: Authenticator = {
+      isAuthProvider: (candidate) => candidate === user,
+      applyAuthentication: async (_user, options) => {
+        assertActive();
+        const credential = await this.getCredential(bound);
+        assertActive();
+        const opts = options as RequestOptions;
+        if (credential.token) {
+          opts.headers ??= {};
+          (opts.headers as Record<string, string>).Authorization = `Bearer ${credential.token}`;
+        }
+        if (credential.clientCertificateData) opts.cert = credential.clientCertificateData;
+        if (credential.clientKeyData) opts.key = credential.clientKeyData;
+      },
+    };
+    // client-node's public addAuthenticator() only appends fallbacks, so its
+    // built-in ExecAuth would still win. Keep the private integration in this
+    // one adapter and exercise both public authentication APIs in tests.
+    const { authenticators } = kc as unknown as { authenticators: Authenticator[] };
+    const index = authenticators.findIndex((entry) => entry.isAuthProvider(user));
+    if (index < 0) throw new Error('Kubernetes exec authenticator is unavailable');
+    authenticators[index] = authenticator;
+    return () => { active = false; };
+  }
+
+  /** Reconnect/Test connection may retry a failure, but never overlap a running login. */
+  retry(contextName: string): void {
+    const session = this.contexts.get(contextName);
+    if (!session || session.pending) return;
+    session.error = undefined;
+    session.credential = undefined;
+  }
+
+  retainContexts(names: Set<string>): void {
+    for (const name of this.contexts.keys()) if (!names.has(name)) this.contexts.delete(name);
+    const retained = new Set(this.contexts.values());
+    for (const [key, session] of this.sessions) {
+      if (retained.has(session)) continue;
+      session.retired = true;
+      session.cancel?.();
+      this.sessions.delete(key);
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    for (const session of this.sessions.values()) {
+      session.retired = true;
+      session.cancel?.();
+    }
+    this.sessions.clear();
+    this.contexts.clear();
+  }
+
+  private getCredential(session: Session): Promise<Credential> {
+    if (session.retired) return Promise.reject(new HttpProblem(409, 'The cluster session is closed', 'NotConnected'));
+    if (session.pending) return session.pending;
+    if (session.error) return Promise.reject(session.error);
+    const credential = session.credential;
+    if (credential && (!credential.expirationTimestamp || Date.parse(credential.expirationTimestamp) > Date.now())) {
+      return Promise.resolve(credential);
+    }
+    session.credential = undefined;
+    // Publish the promise before spawning so every caller shares successes
+    // and failures, including synchronous spawn/configuration errors.
+    session.pending = Promise.resolve().then(() => this.run(session)).then((next) => {
+      session.credential = next;
+      return next;
+    }).catch((err: unknown) => {
+      session.error = new ExecCredentialError(session.exec.command, err instanceof Error ? err.message : String(err));
+      throw session.error;
+    }).finally(() => {
+      session.pending = undefined;
+    });
+    return session.pending;
+  }
+
+  private run(session: Session): Promise<Credential> {
+    if (this.disposed || session.retired) throw new Error('authentication was cancelled');
+    const { exec, env } = session;
+    if (!exec.command) throw new Error('no credential command was configured');
+    if (exec.interactiveMode === 'Always') throw new Error('the plugin requires a terminal; authenticate with your cloud CLI first');
+    return new Promise((resolve, reject) => {
+      const child = childProcess.spawn(exec.command, exec.args ?? [], {
+        env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true, detached: process.platform !== 'win32',
+      });
+      let stdout = '';
+      let stderr = '';
+      let bytes = 0;
+      let failure: Error | undefined;
+      const stop = (message: string) => {
+        if (failure) return;
+        failure = new Error(message);
+        // Own a process group on POSIX so wrappers cannot leave a CLI child
+        // behind. On Windows taskkill /T terminates the equivalent tree.
+        if (child.pid && process.platform === 'win32') {
+          const killer = childProcess.spawn('taskkill', ['/PID', String(child.pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore' });
+          killer.on('error', () => { child.kill('SIGKILL'); });
+          killer.on('close', (code) => { if (code !== 0) child.kill('SIGKILL'); });
+        } else if (child.pid) {
+          try { process.kill(-child.pid, 'SIGKILL'); } catch { child.kill('SIGKILL'); }
+        }
+      };
+      session.cancel = () => stop('authentication was cancelled');
+      const timer = setTimeout(() => stop(`authentication timed out after ${this.timeoutMs / 1000}s`), this.timeoutMs);
+      timer.unref();
+      const collect = (chunk: string, output: 'stdout' | 'stderr') => {
+        bytes += Buffer.byteLength(chunk);
+        if (bytes > MAX_OUTPUT_BYTES) { stop('credential plugin output exceeded 1 MiB'); return; }
+        if (output === 'stdout') stdout += chunk;
+        else stderr += chunk;
+      };
+      child.stdout.setEncoding('utf8').on('data', (chunk: string) => collect(chunk, 'stdout'));
+      child.stderr.setEncoding('utf8').on('data', (chunk: string) => collect(chunk, 'stderr'));
+      child.on('error', (err) => { failure ??= err; });
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        session.cancel = undefined;
+        // Keep the shared attempt locked until the process has actually closed.
+        if (failure) { reject(failure); return; }
+        if (code !== 0) { reject(new Error(stderr.trim() || `exited with code ${code}`)); return; }
+        try { resolve(parseCredential(stdout, exec.apiVersion!)); } catch (err) { reject(err); }
+      });
+    });
+  }
+}

--- a/server/src/kube/raw-client.ts
+++ b/server/src/kube/raw-client.ts
@@ -76,12 +76,14 @@ export class RawClient {
   constructor(
     private kc: KubeConfig,
     h2Transport?: H2WatchTransport,
+    private releaseAuth?: () => void,
   ) {
     this.h2 = h2Transport ?? new H2WatchTransport();
   }
 
   /** Close pooled HTTP/2 watch sessions. Call when the cluster handle is torn down. */
   dispose(): void {
+    this.releaseAuth?.();
     this.h2.close();
   }
 

--- a/tests/unit/server/exec-credentials.test.ts
+++ b/tests/unit/server/exec-credentials.test.ts
@@ -40,6 +40,7 @@ class Helper extends EventEmitter {
 }
 
 const children: Helper[] = [];
+const terminationProcesses: Helper[] = [];
 const managers: ExecCredentialManager[] = [];
 const clusters: ClusterManager[] = [];
 const dirs: string[] = [];
@@ -72,12 +73,24 @@ async function authenticate(kc: KubeConfig): Promise<RequestOptions> {
 const flush = () => vi.advanceTimersByTimeAsync(0);
 const expires = () => ({ token: 'short-lived', expirationTimestamp: new Date(Date.now() + 1000).toISOString() });
 
+async function withPlatform(platform: NodeJS.Platform, run: () => Promise<void>): Promise<void> {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    await run();
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.spyOn(process, 'kill').mockReturnValue(true);
-  vi.spyOn(childProcess, 'spawn').mockImplementation(() => {
+  vi.spyOn(childProcess, 'spawn').mockImplementation((command) => {
     const child = new Helper();
-    children.push(child);
+    // Windows launches taskkill to terminate a process tree. It is not a
+    // credential attempt and must not affect helper counts or completion.
+    (command === 'taskkill' ? terminationProcesses : children).push(child);
     return child as unknown as ReturnType<typeof childProcess.spawn>;
   });
 });
@@ -86,6 +99,7 @@ afterEach(async () => {
   for (const cluster of clusters.splice(0)) cluster.dispose();
   for (const value of managers.splice(0)) value.dispose();
   for (const child of children.splice(0)) child.close();
+  for (const child of terminationProcesses.splice(0)) child.close();
   await flush();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
@@ -189,18 +203,24 @@ describe('shared exec credentials', () => {
     raw.dispose();
   });
 
-  it('terminates a timed-out helper and holds the attempt until process close before allowing an explicit retry', async () => {
+  it.each(['linux', 'win32'] as const)('terminates a timed-out helper and holds the attempt until process close before allowing an explicit retry (%s)', async (platform) => withPlatform(platform, async () => {
     const credentials = manager();
     const kc = config();
     credentials.attach(kc);
     const first = Promise.allSettled([authenticate(kc)]);
     await flush();
     await vi.advanceTimersByTimeAsync(EXEC_AUTH_TIMEOUT_MS);
-    if (process.platform !== 'win32') expect(process.kill).toHaveBeenCalledWith(-children[0]!.pid, 'SIGKILL');
+    if (platform === 'win32') {
+      expect(childProcess.spawn).toHaveBeenCalledWith('taskkill', ['/PID', String(children[0]!.pid), '/T', '/F'], { windowsHide: true, stdio: 'ignore' });
+      expect(process.kill).not.toHaveBeenCalled();
+    } else {
+      expect(process.kill).toHaveBeenCalledWith(-children[0]!.pid, 'SIGKILL');
+    }
+    expect(terminationProcesses).toHaveLength(platform === 'win32' ? 1 : 0);
     credentials.retry('ctx');
     const second = Promise.allSettled([authenticate(kc)]);
     await flush();
-    expect(vi.mocked(childProcess.spawn).mock.calls.filter(([command]) => command === '/fake/cloud-cli')).toHaveLength(1);
+    expect(children).toHaveLength(1);
     children[0]!.close();
     expect((await first)[0]).toMatchObject({ status: 'rejected', reason: { message: expect.stringContaining('timed out') } });
     await second;
@@ -210,7 +230,7 @@ describe('shared exec credentials', () => {
     await flush();
     children.at(-1)!.finish();
     await expect(retry).resolves.toBeDefined();
-  });
+  }));
 
   it.each([
     ['malformed JSON', 'not json'],
@@ -297,19 +317,20 @@ describe('shared exec credentials', () => {
     expect(children).toHaveLength(0);
   });
 
-  it('retires removed sessions and prevents disposed clients from launching helpers', async () => {
+  it.each(['linux', 'win32'] as const)('retires removed sessions and prevents disposed clients from launching helpers (%s)', async (platform) => withPlatform(platform, async () => {
     const credentials = manager();
     const kc = config();
     const release = credentials.attach(kc);
     const pending = Promise.allSettled([authenticate(kc)]);
     await flush();
     credentials.retainContexts(new Set());
+    expect(terminationProcesses).toHaveLength(platform === 'win32' ? 1 : 0);
     children[0]!.close();
     await pending;
     release();
     await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'NotConnected' });
     expect(children).toHaveLength(1);
-  });
+  }));
 });
 
 it('shares background probes with live handles, preserves failure on reload, and recovers through Test connection and Reconnect', async () => {

--- a/tests/unit/server/exec-credentials.test.ts
+++ b/tests/unit/server/exec-credentials.test.ts
@@ -1,0 +1,353 @@
+/* oxlint-disable typescript/unbound-method -- process methods are asserted as mocks. */
+import childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import type { RequestOptions } from 'node:https';
+import type { FastifyBaseLogger } from 'fastify';
+import { KubeConfig, type User } from '@kubernetes/client-node';
+import { HttpMethod, RequestContext } from '@kubernetes/client-node/dist/gen/http/http.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExecCredentialManager, EXEC_AUTH_TIMEOUT_MS } from '../../../server/src/kube/exec-credentials.js';
+import { ClusterHandle, ClusterManager } from '../../../server/src/kube/cluster-manager.js';
+import { describeProbeFailure } from '../../../server/src/kube/auth-diagnostics.js';
+import { RawClient } from '../../../server/src/kube/raw-client.js';
+
+vi.mock('../../../server/node_modules/node-fetch/src/index.js', () => ({
+  default: vi.fn(async () => new Response(JSON.stringify({ gitVersion: 'v1.test', items: [] }))),
+}));
+
+class Helper extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 99_999_999;
+  readonly kill = vi.fn();
+  closed = false;
+
+  finish(status: Record<string, unknown> = { token: 'fresh' }, code = 0, apiVersion = 'client.authentication.k8s.io/v1beta1'): void {
+    this.close(JSON.stringify({ apiVersion, kind: 'ExecCredential', status }), code);
+  }
+
+  close(stdout = '', code = 1): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.stdout.end(stdout);
+    this.stderr.end();
+    this.emit('close', code);
+  }
+}
+
+const children: Helper[] = [];
+const managers: ExecCredentialManager[] = [];
+const clusters: ClusterManager[] = [];
+const dirs: string[] = [];
+
+function config(options: { context?: string; server?: string; exec?: Record<string, unknown>; user?: User } = {}): KubeConfig {
+  const kc = new KubeConfig();
+  kc.loadFromOptions({
+    clusters: [{ name: 'cluster', server: options.server ?? 'https://cluster.test', skipTLSVerify: true }],
+    users: [options.user ?? { name: 'user', exec: {
+      command: '/fake/cloud-cli', args: ['get-token', '--profile', 'a'],
+      apiVersion: 'client.authentication.k8s.io/v1beta1', interactiveMode: 'IfAvailable', ...options.exec,
+    } }],
+    contexts: [{ name: options.context ?? 'ctx', user: 'user', cluster: 'cluster' }], currentContext: options.context ?? 'ctx',
+  });
+  return kc;
+}
+
+function manager(): ExecCredentialManager {
+  const value = new ExecCredentialManager();
+  managers.push(value);
+  return value;
+}
+
+async function authenticate(kc: KubeConfig): Promise<RequestOptions> {
+  const options: RequestOptions = {};
+  await kc.applyToHTTPSOptions(options);
+  return options;
+}
+
+const flush = () => vi.advanceTimersByTimeAsync(0);
+const expires = () => ({ token: 'short-lived', expirationTimestamp: new Date(Date.now() + 1000).toISOString() });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(process, 'kill').mockReturnValue(true);
+  vi.spyOn(childProcess, 'spawn').mockImplementation(() => {
+    const child = new Helper();
+    children.push(child);
+    return child as unknown as ReturnType<typeof childProcess.spawn>;
+  });
+});
+
+afterEach(async () => {
+  for (const cluster of clusters.splice(0)) cluster.dispose();
+  for (const value of managers.splice(0)) value.dispose();
+  for (const child of children.splice(0)) child.close();
+  await flush();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+  for (const dir of dirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('shared exec credentials', () => {
+  it('runs one helper for 100 concurrent requests across HTTPS and typed-client authentication, including expiry', async () => {
+    const credentials = manager();
+    const kc = config();
+    const probe = config();
+    credentials.attach(kc);
+    credentials.attach(probe);
+    const typed = new RequestContext('https://cluster.test/api/v1/pods', HttpMethod.GET);
+    const first = Promise.all([kc.applySecurityAuthentication(typed), ...Array.from({ length: 99 }, () => authenticate(probe))]);
+    await flush();
+    expect(children).toHaveLength(1);
+    children[0]!.finish(expires());
+    await first;
+    expect(typed.getHeaders().Authorization).toBe('Bearer short-lived');
+    expect((await authenticate(kc)).headers).toMatchObject({ Authorization: 'Bearer short-lived' });
+    expect(children).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1001);
+    const refreshed = Promise.all(Array.from({ length: 100 }, (_, i) => authenticate(i % 2 ? kc : probe)));
+    await flush();
+    expect(children).toHaveLength(2);
+    children[1]!.finish({ token: 'renewed' });
+    expect((await refreshed).every((o) => (o.headers as Record<string, string>).Authorization === 'Bearer renewed')).toBe(true);
+  });
+
+  it('keeps failed refreshes paused across retries and new config clones until explicitly retried', async () => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    const first = Promise.allSettled(Array.from({ length: 100 }, () => authenticate(kc)));
+    await flush();
+    children[0]!.stderr.write('cloud session expired');
+    children[0]!.close();
+    const results = await first;
+    expect(results.every((r) => r.status === 'rejected' && r.reason.reason === 'AuthenticationRequired')).toBe(true);
+    const error = (results[0] as PromiseRejectedResult).reason;
+    expect(await describeProbeFailure(error, kc.getCurrentUser())).toContain('Reconnect or Test connection');
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    const clone = config();
+    credentials.attach(clone);
+    await expect(authenticate(clone)).rejects.toBe(error);
+    expect(children).toHaveLength(1);
+
+    credentials.retry('ctx');
+    const retried = authenticate(clone);
+    await flush();
+    children[1]!.finish();
+    await expect(retried).resolves.toMatchObject({ headers: { Authorization: 'Bearer fresh' } });
+  });
+
+  it('shares aliases but separates profiles, effective environments and cluster-specific plugin input', async () => {
+    const credentials = manager();
+    const configs = [
+      config(), config({ context: 'alias' }),
+      config({ exec: { args: ['get-token', '--profile', 'b'] } }),
+      config({ exec: { env: [{ name: 'CLOUD_PROFILE', value: 'another' }] } }),
+      config({ exec: { provideClusterInfo: true } }),
+      config({ exec: { provideClusterInfo: true }, server: 'https://other.test' }),
+    ];
+    configs.forEach((kc) => credentials.attach(kc));
+    const pending = Promise.all(configs.map(authenticate));
+    await flush();
+    expect(children).toHaveLength(5);
+    children.forEach((child, i) => child.finish({ token: `identity-${i}` }));
+    const results = await pending;
+    expect(results.map((r) => (r.headers as Record<string, string>).Authorization)).toEqual([
+      'Bearer identity-0', 'Bearer identity-0', 'Bearer identity-1', 'Bearer identity-2', 'Bearer identity-3', 'Bearer identity-4',
+    ]);
+    const calls = vi.mocked(childProcess.spawn).mock.calls;
+    const env = (calls[4]![2] as { env: NodeJS.ProcessEnv }).env;
+    expect(JSON.parse(env.KUBERNETES_EXEC_INFO!)).toMatchObject({ spec: { interactive: false, cluster: { server: 'https://other.test' } } });
+  });
+
+  it('leaves a refresh shared when a resource deadline expires or a caller cancels', async () => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    const raw = new RawClient(kc);
+    const aborted = new AbortController();
+    const first = raw.json('/version', { deadlineMs: 10 });
+    const cancelled = raw.json('/version', { signal: aborted.signal });
+    const settled = Promise.allSettled([first, cancelled]);
+    await flush();
+    aborted.abort();
+    await vi.advanceTimersByTimeAsync(11);
+    expect((await settled).every((r) => r.status === 'rejected')).toBe(true);
+    credentials.retry('ctx');
+    const next = raw.json('/version');
+    await flush();
+    expect(children).toHaveLength(1);
+    expect(process.kill).not.toHaveBeenCalled();
+    children[0]!.finish();
+    await expect(next).resolves.toMatchObject({ gitVersion: 'v1.test' });
+    raw.dispose();
+  });
+
+  it('terminates a timed-out helper and holds the attempt until process close before allowing an explicit retry', async () => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    const first = Promise.allSettled([authenticate(kc)]);
+    await flush();
+    await vi.advanceTimersByTimeAsync(EXEC_AUTH_TIMEOUT_MS);
+    if (process.platform !== 'win32') expect(process.kill).toHaveBeenCalledWith(-children[0]!.pid, 'SIGKILL');
+    credentials.retry('ctx');
+    const second = Promise.allSettled([authenticate(kc)]);
+    await flush();
+    expect(vi.mocked(childProcess.spawn).mock.calls.filter(([command]) => command === '/fake/cloud-cli')).toHaveLength(1);
+    children[0]!.close();
+    expect((await first)[0]).toMatchObject({ status: 'rejected', reason: { message: expect.stringContaining('timed out') } });
+    await second;
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'AuthenticationRequired' });
+    credentials.retry('ctx');
+    const retry = authenticate(kc);
+    await flush();
+    children.at(-1)!.finish();
+    await expect(retry).resolves.toBeDefined();
+  });
+
+  it.each([
+    ['malformed JSON', 'not json'],
+    ['missing credentials', JSON.stringify({ kind: 'ExecCredential', apiVersion: 'client.authentication.k8s.io/v1beta1', status: {} })],
+    ['expired credentials', JSON.stringify({ kind: 'ExecCredential', apiVersion: 'client.authentication.k8s.io/v1beta1', status: { token: 'old', expirationTimestamp: '2000-01-01T00:00:00Z' } })],
+  ])('pauses after %s instead of repeatedly executing the helper', async (_name, output) => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    const pending = Promise.allSettled([authenticate(kc)]);
+    await flush();
+    children[0]!.close(output, 0);
+    expect((await pending)[0]).toMatchObject({ status: 'rejected', reason: { reason: 'AuthenticationRequired' } });
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'AuthenticationRequired' });
+    expect(children).toHaveLength(1);
+  });
+
+  it('caches certificate credentials and handles legacy nested exec entries', async () => {
+    const credentials = manager();
+    const kc = config({ user: { name: 'user', authProvider: { name: 'exec', config: { exec: { command: '/fake/cloud-cli', apiVersion: 'client.authentication.k8s.io/v1' } } } } });
+    credentials.attach(kc);
+    const pending = authenticate(kc);
+    await flush();
+    children[0]!.finish({ clientCertificateData: 'certificate', clientKeyData: 'key' }, 0, 'client.authentication.k8s.io/v1');
+    expect(await pending).toMatchObject({ cert: 'certificate', key: 'key' });
+    await authenticate(kc);
+    expect(children).toHaveLength(1);
+  });
+
+  it('pauses synchronous spawn errors and invalid helper configurations', async () => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    vi.mocked(childProcess.spawn).mockImplementationOnce(() => { throw new Error('spawn failed'); });
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'AuthenticationRequired' });
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'AuthenticationRequired' });
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1);
+    const missingCommand = config({ exec: { command: undefined } });
+    credentials.attach(missingCommand);
+    await expect(authenticate(missingCommand)).rejects.toThrow('no credential command');
+    const needsTerminal = config({ exec: { interactiveMode: 'Always' } });
+    credentials.attach(needsTerminal);
+    await expect(authenticate(needsTerminal)).rejects.toThrow('requires a terminal');
+    expect(childProcess.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds helper output and keeps failures paused after terminating it', async () => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    const pending = Promise.allSettled([authenticate(kc)]);
+    await flush();
+    children[0]!.stdout.write('x'.repeat(1024 * 1024 + 1));
+    if (process.platform !== 'win32') expect(process.kill).toHaveBeenCalled();
+    children[0]!.close();
+    expect((await pending)[0]).toMatchObject({ status: 'rejected', reason: { message: expect.stringContaining('output exceeded') } });
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'AuthenticationRequired' });
+  });
+
+  it('cancels outstanding authentication on shutdown and refuses later attachments', async () => {
+    const credentials = manager();
+    const kc = config();
+    credentials.attach(kc);
+    const pending = Promise.allSettled([authenticate(kc)]);
+    await flush();
+    credentials.dispose();
+    children[0]!.close();
+    expect((await pending)[0]).toMatchObject({ status: 'rejected', reason: { message: expect.stringContaining('cancelled') } });
+    expect(() => credentials.attach(config())).toThrow('session is closed');
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'NotConnected' });
+  });
+
+  it('does not change static authentication or kubeconfig exports', async () => {
+    const credentials = manager();
+    const kc = config({ user: { name: 'user', token: 'static' } });
+    const original = kc.exportConfig();
+    credentials.attach(kc);
+    expect(await authenticate(kc)).toMatchObject({ headers: { Authorization: 'Bearer static' } });
+    const exec = config();
+    const originalExec = exec.exportConfig();
+    credentials.attach(exec);
+    expect(exec.exportConfig()).toBe(originalExec);
+    expect(kc.exportConfig()).toBe(original);
+    expect(children).toHaveLength(0);
+  });
+
+  it('retires removed sessions and prevents disposed clients from launching helpers', async () => {
+    const credentials = manager();
+    const kc = config();
+    const release = credentials.attach(kc);
+    const pending = Promise.allSettled([authenticate(kc)]);
+    await flush();
+    credentials.retainContexts(new Set());
+    children[0]!.close();
+    await pending;
+    release();
+    await expect(authenticate(kc)).rejects.toMatchObject({ reason: 'NotConnected' });
+    expect(children).toHaveLength(1);
+  });
+});
+
+it('shares background probes with live handles, preserves failure on reload, and recovers through Test connection and Reconnect', async () => {
+  vi.spyOn(ClusterHandle.prototype, 'activate').mockImplementation(() => {});
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kubus-exec-test-'));
+  dirs.push(dir);
+  const file = path.join(dir, 'config');
+  fs.writeFileSync(file, config().exportConfig());
+  const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } as unknown as FastifyBaseLogger;
+  const cluster = new ClusterManager(log, file);
+  clusters.push(cluster);
+  const connected = cluster.connect('ctx');
+  await flush();
+  expect(children).toHaveLength(1);
+  children[0]!.finish(expires());
+  const handle = await connected;
+  await vi.advanceTimersByTimeAsync(1001);
+  const failed = Promise.allSettled(Array.from({ length: 100 }, () => handle.raw.json('/version')));
+  await flush();
+  children[1]!.close();
+  await failed;
+  cluster.reload();
+  await flush();
+  expect(children).toHaveLength(2);
+  const test = cluster.test('ctx');
+  await flush();
+  children[2]!.finish(expires());
+  expect(await test).toMatchObject({ health: 'connected' });
+  await expect(handle.raw.json('/version')).resolves.toMatchObject({ gitVersion: 'v1.test' });
+  await vi.advanceTimersByTimeAsync(1001);
+  const failedAgain = Promise.allSettled([handle.raw.json('/version')]);
+  await flush();
+  children[3]!.close();
+  await failedAgain;
+  const reconnect = cluster.reconnect('ctx');
+  await flush();
+  children[4]!.finish();
+  expect((await reconnect).health).toBe('connected');
+  expect(children).toHaveLength(5);
+  await expect(handle.raw.json('/version')).rejects.toMatchObject({ reason: 'NotConnected' });
+});


### PR DESCRIPTION
When kubeconfig exec credentials expire, concurrent resource requests and background health probes can each launch the credential helper. Helpers that open a browser for login can consequently create a tab storm, and request timeouts previously left those helpers running.

Share one credential refresh across cluster handles, health probes, typed API clients, and watch streams. Cache failures until the user selects Reconnect or Test connection, and give the shared helper a two-minute deadline with process termination on timeout or shutdown. Individual request cancellation does not cancel another caller's login or start a replacement helper.

Credential sharing accounts for the command, arguments, effective environment, and supplied cluster information. The adapter replaces client-node's built-in exec authenticator because its public registration API only appends fallbacks; regression tests exercise both public authentication APIs. Kubeconfig entries remain unchanged.

Validation:

- All 533 server tests passed, including 17 new regression tests for concurrency, expiry, failure pause, cancellation, isolation, and recovery. Timeout and session-removal tests exercise both Windows and Linux termination paths on every platform.
- Lint, workspace type checking, and server build passed.
- Read-only smoke tests against a kind cluster passed with a synthetic exec helper: 100 concurrent requests launched one process, expired credentials refreshed once, failures stayed paused, and explicit recovery succeeded.
- Typed API calls and watch streams worked against kind. A real timed-out helper was confirmed terminated.

