### PR TITLE
Fix terminal focus when cycling dock tabs

### DIFF
--- a/client/src/layout/BottomDock.tsx
+++ b/client/src/layout/BottomDock.tsx
@@ -88,6 +88,7 @@ export const BottomDock = memo(function BottomDock({
   return (
     <Box
       className="kubus-bottom-dock"
+      tabIndex={-1}
       sx={{
         height: '100%',
         display: 'flex',

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -191,10 +191,17 @@ export function GlobalShortcuts() {
 
     const cycleTab = (delta: number) => {
       const dock = useDockStore.getState();
-      const focusedInDock = document.activeElement instanceof HTMLElement && !!document.activeElement.closest('.kubus-bottom-dock');
-      if (focusedInDock && dock.open && dock.tabs.length > 1) {
+      const focusedDock = document.activeElement instanceof HTMLElement
+        ? document.activeElement.closest<HTMLElement>('.kubus-bottom-dock')
+        : null;
+      if (focusedDock && dock.open && dock.tabs.length > 1) {
         const idx = Math.max(0, dock.tabs.findIndex((tab) => tab.id === dock.activeId));
-        dock.setActive(dock.tabs[(idx + delta + dock.tabs.length) % dock.tabs.length]!.id);
+        const next = dock.tabs[(idx + delta + dock.tabs.length) % dock.tabs.length]!;
+        // Keep focus in the dock while the old pane is hidden and the next
+        // terminal waits for its focus request, or when landing on logs.
+        focusedDock.focus({ preventScroll: true });
+        if (isTerminalTab(next)) dock.requestTerminalFocus(next.id);
+        else dock.setActive(next.id);
         return;
       }
       const s = useTabsStore.getState();

--- a/tests/electron/specs/terminal-tab-focus.spec.ts
+++ b/tests/electron/specs/terminal-tab-focus.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+import { launchElectron } from '../helpers/app.js';
+
+test('keeps keyboard focus and shell input in the dock while cycling tabs', async () => {
+  const launched = await launchElectron();
+  const { page } = launched;
+  const shellInput = new Map<string, string>();
+  let shellConnections = 0;
+  const cycleTab = async (backwards = false) => {
+    await launched.app.evaluate(({ BrowserWindow }, reverse) => {
+      const webContents = BrowserWindow.getAllWindows()[0]!.webContents;
+      const modifiers: Array<'control' | 'shift'> = reverse ? ['control', 'shift'] : ['control'];
+      webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Tab', modifiers });
+      webContents.sendInputEvent({ type: 'keyUp', keyCode: 'Tab', modifiers });
+    }, backwards);
+  };
+
+  try {
+    // Keep the real renderer, xterm inputs, and native accelerators; only the
+    // remote sessions are stubbed so this runs without a Kubernetes cluster.
+    await page.routeWebSocket(/\/ws\/(exec|node-shell|logs)\?/, (socket) => {
+      const url = new URL(socket.url());
+      if (url.pathname === '/ws/logs') return;
+      const session = url.searchParams.get('pod') ?? url.searchParams.get('node')!;
+      shellConnections += 1;
+      socket.onMessage((message) => {
+        if (typeof message !== 'string') {
+          shellInput.set(session, (shellInput.get(session) ?? '') + message.toString());
+        }
+      });
+    });
+    await page.evaluate(() => {
+      sessionStorage.setItem('kubus-dock:main', JSON.stringify({
+        tabs: [
+          { kind: 'terminal', id: 'pod-shell', title: 'Pod shell', ctx: 'test', namespace: 'default', pod: 'web', container: 'web' },
+          { kind: 'node-shell', id: 'node-shell', title: 'Node shell', ctx: 'test', node: 'worker' },
+          { kind: 'logs', id: 'logs', title: 'Pod logs', ctx: 'test', namespace: 'default', pods: ['web'] },
+        ],
+        activeId: 'pod-shell',
+        open: true,
+        height: 320,
+        maximized: false,
+      }));
+    });
+    await page.reload();
+
+    // A second page tab makes accidental routing out of the dock observable.
+    await page.getByRole('button', { name: 'New tab' }).click();
+    const pageTabs = page.getByRole('tablist', { name: 'Open pages' }).getByRole('tab');
+    await expect(pageTabs).toHaveCount(2);
+    await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+
+    const dock = page.locator('.kubus-bottom-dock');
+    const input = dock.locator('.xterm:visible .xterm-helper-textarea');
+    const podTab = dock.getByRole('tab', { name: /Pod shell/ });
+    const nodeTab = dock.getByRole('tab', { name: /Node shell/ });
+    const logsTab = dock.getByRole('tab', { name: /Pod logs/ });
+    await expect(dock.locator('.xterm:visible')).toHaveCount(1);
+    await expect.poll(() => shellConnections).toBe(2);
+    await input.focus();
+    await expect(input).toBeFocused();
+
+    await cycleTab();
+    await expect(nodeTab).toHaveAttribute('aria-selected', 'true');
+    await expect(input).toBeFocused();
+    await page.keyboard.type('node input');
+    await expect.poll(() => shellInput.get('worker')).toBe('node input');
+
+    await cycleTab(true);
+    await expect(podTab).toHaveAttribute('aria-selected', 'true');
+    await expect(input).toBeFocused();
+    await page.keyboard.type('pod input');
+    await expect.poll(() => shellInput.get('web')).toBe('pod input');
+
+    // Crossing a log pane must retain dock ownership for the next shortcut.
+    await cycleTab(true);
+    await expect(logsTab).toHaveAttribute('aria-selected', 'true');
+    await expect(dock).toBeFocused();
+    await cycleTab();
+    await expect(podTab).toHaveAttribute('aria-selected', 'true');
+    await expect(input).toBeFocused();
+
+    for (const tab of [nodeTab, logsTab, podTab]) {
+      await cycleTab();
+      await expect(tab).toHaveAttribute('aria-selected', 'true');
+      if (tab === logsTab) await expect(dock).toBeFocused();
+      else await expect(input).toBeFocused();
+    }
+    await page.keyboard.type(' after cycling');
+    await expect.poll(() => shellInput.get('web')).toBe('pod input after cycling');
+    await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+    expect(shellConnections).toBe(2);
+
+    // Once focus leaves the dock, the same chord still cycles page tabs.
+    const search = page.getByRole('button', { name: 'Search', exact: true });
+    await search.focus();
+    await cycleTab();
+    await expect(pageTabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+    await expect(search).toBeFocused();
+    await expect(podTab).toHaveAttribute('aria-selected', 'true');
+  } finally {
+    await launched.close();
+  }
+});


### PR DESCRIPTION
Cycling dock tabs with Ctrl+Tab or Ctrl+Shift+Tab hid the focused terminal without focusing its replacement, leaving typing inactive and allowing the next shortcut to switch page tabs.

Keep focus in the dock during the transition and request focus for the selected terminal. Log tabs retain dock focus so cycling can continue back to a shell.

Fixes #172.

Validation:
- Added an Electron regression test using native accelerators and real xterm inputs, with stubbed remote sessions. Covers forward/backward cycling, wraparound, pod and node shells, typing, transitions through logs, and page-tab cycling outside the dock.
- Confirmed the regression test fails before the fix and passes after it.
- Build, all 1,263 unit tests, lint, and type checks pass.
- The full Electron suite passes 12 of 13 tests, including the new regression. The existing window-restoration test fails locally, including under Xvfb; the same test also fails with the unchanged production code from base revision `9860b26`.
