### PR TITLE
Fix terminal tab cycling shortcuts and help

### DIFF
--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -85,6 +85,7 @@ export const SHORTCUT_SECTIONS: Array<{ title: string; shortcuts: ShortcutRowDef
       { combos: [['Alt', 'Shift', 'T']], description: 'Reopen the last closed tab' },
       { combos: [['Alt', '1–9']], description: 'Switch to tab 1–9 (9 = last tab)' },
       { combos: [['Alt', 'PgUp'], ['Alt', 'PgDn']], description: 'Previous / next tab' },
+      { combos: [['Ctrl', 'PgUp'], ['Ctrl', 'PgDn']], description: 'Previous / next tab', desktopOnly: true },
       { combos: [['Ctrl', 'Tab'], ['Ctrl', 'Shift', 'Tab']], description: 'Next / previous tab', desktopOnly: true },
       { combos: [['←'], ['→'], ['Home'], ['End']], description: 'Move focus on the tab strip' },
       { combos: [['Enter'], ['Delete']], description: 'Activate / close the focused tab' },
@@ -311,9 +312,19 @@ export function GlobalShortcuts() {
       }
 
       // Alt is the tab namespace. Never with Ctrl/Meta (AltGr reports
-      // ctrl+alt on Windows), and never while a terminal/editor owns Alt
-      // sequences (Alt+digit is an escape sequence in shells).
-      if (e.altKey && !e.ctrlKey && !e.metaKey && !isEditorOrTerminalTarget(e.target)) {
+      // ctrl+alt on Windows). Terminals allow the advertised tab-cycling
+      // chords but keep other Alt sequences; editors keep all of them.
+      if (e.altKey && !e.ctrlKey && !e.metaKey) {
+        const isTabCycle = !e.shiftKey && (e.code === 'PageUp' || e.code === 'PageDown');
+        const inTerminal = e.target instanceof HTMLElement && !!e.target.closest('.xterm');
+        if (isEditorOrTerminalTarget(e.target) && !(inTerminal && isTabCycle)) return;
+        if (isTabCycle) {
+          e.preventDefault();
+          // xterm must not also send the shortcut as input to the shell.
+          e.stopPropagation();
+          cycleTab(e.code === 'PageDown' ? 1 : -1);
+          return;
+        }
         if (!e.shiftKey && e.code === 'KeyJ') {
           if (e.repeat) return;
           const eventTarget = e.target instanceof HTMLElement ? e.target : null;
@@ -336,16 +347,6 @@ export function GlobalShortcuts() {
         if (digit) {
           e.preventDefault();
           activateTab(Number(digit));
-          return;
-        }
-        if (!e.shiftKey && e.code === 'PageDown') {
-          e.preventDefault();
-          cycleTab(1);
-          return;
-        }
-        if (!e.shiftKey && e.code === 'PageUp') {
-          e.preventDefault();
-          cycleTab(-1);
           return;
         }
         if (e.code === 'KeyT') {

--- a/client/src/shortcuts.ts
+++ b/client/src/shortcuts.ts
@@ -195,7 +195,9 @@ export function GlobalShortcuts() {
       const focusedDock = document.activeElement instanceof HTMLElement
         ? document.activeElement.closest<HTMLElement>('.kubus-bottom-dock')
         : null;
-      if (focusedDock && dock.open && dock.tabs.length > 1) {
+      if (focusedDock && dock.open) {
+        // A focused dock owns cycling even when there is no other dock tab.
+        if (dock.tabs.length < 2) return;
         const idx = Math.max(0, dock.tabs.findIndex((tab) => tab.id === dock.activeId));
         const next = dock.tabs[(idx + delta + dock.tabs.length) % dock.tabs.length]!;
         // Keep focus in the dock while the old pane is hidden and the next

--- a/client/src/text-entry.ts
+++ b/client/src/text-entry.ts
@@ -19,8 +19,8 @@ export function isTextEntryTarget(target: EventTarget | null): boolean {
 /**
  * True when the target sits inside a surface that owns the whole keyboard
  * (terminals, code editors). Stricter than isTextEntryTarget: plain filter
- * inputs still allow e.g. Alt tab-switching chords, but a shell or editor
- * must receive every Alt sequence unmodified.
+ * inputs still allow e.g. Alt tab-switching chords. Shortcuts must explicitly
+ * opt in to handling keys inside a shell or editor.
  */
 export function isEditorOrTerminalTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && !!target.closest('.xterm, .monaco-editor');

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -25,6 +25,10 @@ is the hub, and almost everything is reachable through it.
 | Shortcut | Action |
 | --- | --- |
 | ++ctrl+w++ / ++cmd+w++ | Close the focused log or terminal tab |
+| ++alt+page-up++ / ++alt+page-down++ | Previous / next tab in the focused dock |
+| ++ctrl+page-up++ / ++ctrl+page-down++ | Previous / next tab in the focused dock (desktop app) |
+
+Tab-cycling shortcuts switch page tabs when focus is outside the dock.
 
 When the dock is empty, ++ctrl+w++ / ++cmd+w++ closes the Kubus window as usual.
 

--- a/tests/electron/specs/terminal-tab-focus.spec.ts
+++ b/tests/electron/specs/terminal-tab-focus.spec.ts
@@ -101,6 +101,23 @@ for (const shortcut of ['Ctrl+Tab', 'Ctrl+PgUp/PgDn', 'Alt+PgUp/PgDn']) {
       await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
       expect(shellConnections).toBe(2);
 
+      // A focused dock still owns the shortcut when only one tab remains.
+      await dock.getByRole('button', { name: 'Close Node shell', exact: true }).click();
+      await dock.getByRole('button', { name: 'Close Pod logs', exact: true }).click();
+      await expect(dock.getByRole('tab')).toHaveCount(1);
+      await input.focus();
+      let expectedInput = 'pod input after cycling';
+      for (const backwards of [false, true]) {
+        await cycleTab(backwards);
+        const text = backwards ? ' backward' : ' forward';
+        await page.keyboard.type(text);
+        expectedInput += text;
+        await expect.poll(() => shellInput.get('web')).toBe(expectedInput);
+        await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+        await expect(podTab).toHaveAttribute('aria-selected', 'true');
+        await expect(input).toBeFocused();
+      }
+
       // Once focus leaves the dock, the same chord still cycles page tabs.
       const search = page.getByRole('button', { name: 'Search', exact: true });
       await search.focus();

--- a/tests/electron/specs/terminal-tab-focus.spec.ts
+++ b/tests/electron/specs/terminal-tab-focus.spec.ts
@@ -1,104 +1,115 @@
 import { expect, test } from '@playwright/test';
 import { launchElectron } from '../helpers/app.js';
 
-test('keeps keyboard focus and shell input in the dock while cycling tabs', async () => {
-  const launched = await launchElectron();
-  const { page } = launched;
-  const shellInput = new Map<string, string>();
-  let shellConnections = 0;
-  const cycleTab = async (backwards = false) => {
-    await launched.app.evaluate(({ BrowserWindow }, reverse) => {
-      const webContents = BrowserWindow.getAllWindows()[0]!.webContents;
-      const modifiers: Array<'control' | 'shift'> = reverse ? ['control', 'shift'] : ['control'];
-      webContents.sendInputEvent({ type: 'keyDown', keyCode: 'Tab', modifiers });
-      webContents.sendInputEvent({ type: 'keyUp', keyCode: 'Tab', modifiers });
-    }, backwards);
-  };
+for (const shortcut of ['Ctrl+Tab', 'Ctrl+PgUp/PgDn', 'Alt+PgUp/PgDn']) {
+  test(`${shortcut} keeps keyboard focus and shell input in the dock while cycling tabs`, async () => {
+    const launched = await launchElectron();
+    const { page } = launched;
+    const shellInput = new Map<string, string>();
+    let shellConnections = 0;
+    const cycleTab = async (backwards = false) => {
+      await launched.app.evaluate(({ BrowserWindow }, { shortcut, backwards }) => {
+        const webContents = BrowserWindow.getAllWindows()[0]!.webContents;
+        const modifiers: Array<'control' | 'alt' | 'shift'> = [shortcut.startsWith('Alt') ? 'alt' : 'control'];
+        const usesPageKeys = shortcut !== 'Ctrl+Tab';
+        if (!usesPageKeys && backwards) modifiers.push('shift');
+        const keyCode = usesPageKeys ? (backwards ? 'PageUp' : 'PageDown') : 'Tab';
+        webContents.sendInputEvent({ type: 'keyDown', keyCode, modifiers });
+        webContents.sendInputEvent({ type: 'keyUp', keyCode, modifiers });
+      }, { shortcut, backwards });
+    };
 
-  try {
-    // Keep the real renderer, xterm inputs, and native accelerators; only the
-    // remote sessions are stubbed so this runs without a Kubernetes cluster.
-    await page.routeWebSocket(/\/ws\/(exec|node-shell|logs)\?/, (socket) => {
-      const url = new URL(socket.url());
-      if (url.pathname === '/ws/logs') return;
-      const session = url.searchParams.get('pod') ?? url.searchParams.get('node')!;
-      shellConnections += 1;
-      socket.onMessage((message) => {
-        if (typeof message !== 'string') {
-          shellInput.set(session, (shellInput.get(session) ?? '') + message.toString());
-        }
+    try {
+      // Keep the real renderer, xterm inputs, and native accelerators; only the
+      // remote sessions are stubbed so this runs without a Kubernetes cluster.
+      await page.routeWebSocket(/\/ws\/(exec|node-shell|logs)\?/, (socket) => {
+        const url = new URL(socket.url());
+        if (url.pathname === '/ws/logs') return;
+        const session = url.searchParams.get('pod') ?? url.searchParams.get('node')!;
+        shellConnections += 1;
+        socket.onMessage((message) => {
+          if (typeof message !== 'string') {
+            shellInput.set(session, (shellInput.get(session) ?? '') + message.toString());
+          }
+        });
       });
-    });
-    await page.evaluate(() => {
-      sessionStorage.setItem('kubus-dock:main', JSON.stringify({
-        tabs: [
-          { kind: 'terminal', id: 'pod-shell', title: 'Pod shell', ctx: 'test', namespace: 'default', pod: 'web', container: 'web' },
-          { kind: 'node-shell', id: 'node-shell', title: 'Node shell', ctx: 'test', node: 'worker' },
-          { kind: 'logs', id: 'logs', title: 'Pod logs', ctx: 'test', namespace: 'default', pods: ['web'] },
-        ],
-        activeId: 'pod-shell',
-        open: true,
-        height: 320,
-        maximized: false,
-      }));
-    });
-    await page.reload();
+      await page.evaluate(() => {
+        sessionStorage.setItem('kubus-dock:main', JSON.stringify({
+          tabs: [
+            { kind: 'terminal', id: 'pod-shell', title: 'Pod shell', ctx: 'test', namespace: 'default', pod: 'web', container: 'web' },
+            { kind: 'node-shell', id: 'node-shell', title: 'Node shell', ctx: 'test', node: 'worker' },
+            { kind: 'logs', id: 'logs', title: 'Pod logs', ctx: 'test', namespace: 'default', pods: ['web'] },
+          ],
+          activeId: 'pod-shell',
+          open: true,
+          height: 320,
+          maximized: false,
+        }));
+      });
+      await page.reload();
 
-    // A second page tab makes accidental routing out of the dock observable.
-    await page.getByRole('button', { name: 'New tab' }).click();
-    const pageTabs = page.getByRole('tablist', { name: 'Open pages' }).getByRole('tab');
-    await expect(pageTabs).toHaveCount(2);
-    await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+      await page.getByRole('button', { name: 'Keyboard shortcuts' }).click();
+      const help = page.getByRole('dialog');
+      await help.getByPlaceholder('Search shortcuts…').fill(shortcut.split('/')[0]!.replace('+', ' '));
+      await expect(help.getByText(shortcut === 'Ctrl+Tab' ? 'Next / previous tab' : 'Previous / next tab', { exact: true })).toBeVisible();
+      await help.getByRole('button', { name: 'Close', exact: true }).click();
 
-    const dock = page.locator('.kubus-bottom-dock');
-    const input = dock.locator('.xterm:visible .xterm-helper-textarea');
-    const podTab = dock.getByRole('tab', { name: /Pod shell/ });
-    const nodeTab = dock.getByRole('tab', { name: /Node shell/ });
-    const logsTab = dock.getByRole('tab', { name: /Pod logs/ });
-    await expect(dock.locator('.xterm:visible')).toHaveCount(1);
-    await expect.poll(() => shellConnections).toBe(2);
-    await input.focus();
-    await expect(input).toBeFocused();
+      // A second page tab makes accidental routing out of the dock observable.
+      await page.getByRole('button', { name: 'New tab' }).click();
+      const pageTabs = page.getByRole('tablist', { name: 'Open pages' }).getByRole('tab');
+      await expect(pageTabs).toHaveCount(2);
+      await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
 
-    await cycleTab();
-    await expect(nodeTab).toHaveAttribute('aria-selected', 'true');
-    await expect(input).toBeFocused();
-    await page.keyboard.type('node input');
-    await expect.poll(() => shellInput.get('worker')).toBe('node input');
+      const dock = page.locator('.kubus-bottom-dock');
+      const input = dock.locator('.xterm:visible .xterm-helper-textarea');
+      const podTab = dock.getByRole('tab', { name: /Pod shell/ });
+      const nodeTab = dock.getByRole('tab', { name: /Node shell/ });
+      const logsTab = dock.getByRole('tab', { name: /Pod logs/ });
+      await expect(dock.locator('.xterm:visible')).toHaveCount(1);
+      await expect.poll(() => shellConnections).toBe(2);
+      await input.focus();
+      await expect(input).toBeFocused();
 
-    await cycleTab(true);
-    await expect(podTab).toHaveAttribute('aria-selected', 'true');
-    await expect(input).toBeFocused();
-    await page.keyboard.type('pod input');
-    await expect.poll(() => shellInput.get('web')).toBe('pod input');
-
-    // Crossing a log pane must retain dock ownership for the next shortcut.
-    await cycleTab(true);
-    await expect(logsTab).toHaveAttribute('aria-selected', 'true');
-    await expect(dock).toBeFocused();
-    await cycleTab();
-    await expect(podTab).toHaveAttribute('aria-selected', 'true');
-    await expect(input).toBeFocused();
-
-    for (const tab of [nodeTab, logsTab, podTab]) {
       await cycleTab();
-      await expect(tab).toHaveAttribute('aria-selected', 'true');
-      if (tab === logsTab) await expect(dock).toBeFocused();
-      else await expect(input).toBeFocused();
-    }
-    await page.keyboard.type(' after cycling');
-    await expect.poll(() => shellInput.get('web')).toBe('pod input after cycling');
-    await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
-    expect(shellConnections).toBe(2);
+      await expect(nodeTab).toHaveAttribute('aria-selected', 'true');
+      await expect(input).toBeFocused();
+      await page.keyboard.type('node input');
+      await expect.poll(() => shellInput.get('worker')).toBe('node input');
 
-    // Once focus leaves the dock, the same chord still cycles page tabs.
-    const search = page.getByRole('button', { name: 'Search', exact: true });
-    await search.focus();
-    await cycleTab();
-    await expect(pageTabs.nth(0)).toHaveAttribute('aria-selected', 'true');
-    await expect(search).toBeFocused();
-    await expect(podTab).toHaveAttribute('aria-selected', 'true');
-  } finally {
-    await launched.close();
-  }
-});
+      await cycleTab(true);
+      await expect(podTab).toHaveAttribute('aria-selected', 'true');
+      await expect(input).toBeFocused();
+      await page.keyboard.type('pod input');
+      await expect.poll(() => shellInput.get('web')).toBe('pod input');
+
+      // Crossing a log pane must retain dock ownership for the next shortcut.
+      await cycleTab(true);
+      await expect(logsTab).toHaveAttribute('aria-selected', 'true');
+      await expect(dock).toBeFocused();
+      await cycleTab();
+      await expect(podTab).toHaveAttribute('aria-selected', 'true');
+      await expect(input).toBeFocused();
+
+      for (const tab of [nodeTab, logsTab, podTab]) {
+        await cycleTab();
+        await expect(tab).toHaveAttribute('aria-selected', 'true');
+        if (tab === logsTab) await expect(dock).toBeFocused();
+        else await expect(input).toBeFocused();
+      }
+      await page.keyboard.type(' after cycling');
+      await expect.poll(() => shellInput.get('web')).toBe('pod input after cycling');
+      await expect(pageTabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+      expect(shellConnections).toBe(2);
+
+      // Once focus leaves the dock, the same chord still cycles page tabs.
+      const search = page.getByRole('button', { name: 'Search', exact: true });
+      await search.focus();
+      await cycleTab();
+      await expect(pageTabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+      await expect(search).toBeFocused();
+      await expect(podTab).toHaveAttribute('aria-selected', 'true');
+    } finally {
+      await launched.close();
+    }
+  });
+}


### PR DESCRIPTION
Alt+Page Up/Down was listed in the shortcut dialog but ignored while a terminal had focus. Allow those chords to cycle the focused dock's tabs and consume the key event so it does not reach the shell. A focused dock with only one tab consumes the shortcut without changing page tabs. Other terminal Alt sequences and editor shortcuts retain their existing behavior.

List the existing desktop Ctrl+Page Up/Down alternative in the help dialog and document both bindings. Extend the Electron regression test to cover Alt+Page Up/Down, Ctrl+Page Up/Down, and Ctrl+Tab, including the help entry, cycling in both directions, terminal focus, shell input, logs, a dock with only one tab, and page tabs.

Validation: reproduced both the ignored Alt+Page Down shortcut and the page switch from a focused dock with one tab before their fixes; all 3 desktop shortcut tests and all 1,263 unit tests pass. `pnpm build`, `pnpm lint`, `pnpm typecheck`, and `git diff --check` pass.

Fixes #173.

