### PR TITLE
Fix Microsoft Store icon background and sizing

### DIFF
--- a/docs/community/microsoft-store.md
+++ b/docs/community/microsoft-store.md
@@ -24,7 +24,11 @@ These values belong to the reserved Kubus product and must remain stable across 
 The package settings are in `electron/electron-builder.yml`. The application ID is
 `Kubus`, the architecture is x64, and the minimum Windows version is 10.0.19041.0.
 The existing `kubus://` protocol is included in the generated package manifest.
-Store tile assets are rendered from the Kubus SVG during the Electron build.
+Store tile assets are rendered from the Kubus SVG during the Electron build. The
+tile background is transparent, and `Square44x44Logo.targetsize-*` icons include
+both `altform-unplated` and `altform-lightunplated` variants so Windows does not add
+a background box in Start or the taskbar. Keep all variants even though they use
+the same artwork; see Microsoft's [app icon requirements](https://learn.microsoft.com/en-us/windows/apps/design/iconography/app-icon-construction#app-icon).
 
 ## Obtain the submission package
 
@@ -64,7 +68,9 @@ See Microsoft's [package signing guide](https://learn.microsoft.com/en-us/window
 
 Exercise the installed package before public release:
 
-1. Launch from Start, including on a profile with no kubeconfig.
+1. Launch from Start, including on a profile with no kubeconfig. Check the Start
+   and taskbar icons in both light and dark Windows themes: the Kubus glyph should
+   appear without a background box, matching the regular installer.
 2. Read and edit a test kubeconfig, including a custom `KUBECONFIG` location.
 3. Connect using any installed authentication helpers you support, such as `aws`,
    `gke-gcloud-auth-plugin` and `kubelogin`.

--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -33,6 +33,7 @@ appx:
   publisherDisplayName: FloSch.me
   applicationId: Kubus
   displayName: Kubus
+  backgroundColor: transparent
   languages: [en-US]
   minVersion: 10.0.19041.0
   # The Store reserves the fourth version component; it must remain zero.

--- a/electron/scripts/render-icon.mjs
+++ b/electron/scripts/render-icon.mjs
@@ -65,3 +65,14 @@ for (const [name, width, height] of [
   const file = path.resolve(root, '../build/appx', name);
   if (await outdated(file)) await render(width, file, height);
 }
+
+// Windows adds a backplate in Start and the taskbar unless both unplated
+// theme variants are present, even when the PNG and tile are transparent.
+// https://learn.microsoft.com/en-us/windows/apps/design/iconography/app-icon-construction#app-icon
+const appxTargetSizes = [16, 20, 24, 30, 32, 36, 40, 48, 60, 64, 72, 80, 96, 256];
+for (const size of appxTargetSizes) {
+  for (const variant of ['', '_altform-unplated', '_altform-lightunplated']) {
+    const file = path.resolve(root, `../build/appx/Square44x44Logo.targetsize-${size}${variant}.png`);
+    if (await outdated(file)) await render(size, file);
+  }
+}


### PR DESCRIPTION
Microsoft Store installations display a smaller Kubus icon inside a background box in Start and the taskbar. Set the AppX tile background to transparent and generate the default, dark-theme unplated, and light-theme unplated icons at all 14 Windows target sizes, preserving the regular installer's artwork proportions.

Document the required variants and add a Windows visual check to the Store release instructions.

Validation:

- Electron build and type checking passed.
- Repository lint and `git diff --check` passed.
- Verified all 42 new variants have correct dimensions, transparent borders, and visible artwork; electron-builder includes all 46 Store assets and preserves the transparent background setting.
- Compared artwork sizes with the regular Windows icon source at 24, 32, 48, 64, and 256 pixels; differences are at most one pixel from rasterization rounding.
- Visual verification of the installed package on Windows remains pending.
